### PR TITLE
feat: add Base layout, global styles, and dark theme

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,152 @@
+---
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description = "Lightweight Fuji lens and camera explorer with genre-based scoring." } = Astro.props;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+
+const navLinks = [
+  { href: "/lenses", label: "Lenses" },
+  { href: "/cameras", label: "Cameras" },
+  { href: "/genre", label: "Genre Guide" },
+  { href: "/accessories", label: "Accessories" },
+  { href: "/trade-deals", label: "Trade Deals" },
+  { href: "/wiki", label: "Wiki" },
+];
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav" aria-label="Main navigation">
+        <a href="/" class="nav-brand">Fuji.me!</a>
+        <ul class="nav-links" role="list">
+          {navLinks.map((link) => (
+            <li>
+              <a
+                href={link.href}
+                class:list={["nav-link", { active: Astro.url.pathname.startsWith(link.href) }]}
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+
+    <main class="main">
+      <slot />
+    </main>
+
+    <footer class="site-footer">
+      <p class="footer-text">
+        Fuji.me! — part of the <a href="https://braboj.me">me! series</a> by braboj.me
+      </p>
+    </footer>
+  </body>
+</html>
+
+<style>
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: var(--color-bg-surface);
+    border-bottom: 1px solid var(--color-border);
+    height: var(--nav-height);
+  }
+
+  .nav {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 var(--space-md);
+    height: 100%;
+  }
+
+  .nav-brand {
+    font-weight: 700;
+    font-size: var(--font-size-lg);
+    color: var(--color-text);
+    white-space: nowrap;
+  }
+
+  .nav-brand:hover {
+    color: var(--color-accent);
+  }
+
+  .nav-links {
+    display: flex;
+    gap: var(--space-sm);
+    list-style: none;
+    overflow-x: auto;
+  }
+
+  .nav-link {
+    display: block;
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    border-radius: var(--radius);
+    white-space: nowrap;
+  }
+
+  .nav-link:hover {
+    color: var(--color-text);
+    background-color: var(--color-bg-hover);
+  }
+
+  .nav-link.active {
+    color: var(--color-accent);
+  }
+
+  .main {
+    flex: 1;
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: var(--space-xl) var(--space-md);
+    width: 100%;
+  }
+
+  .site-footer {
+    border-top: 1px solid var(--color-border);
+    padding: var(--space-lg) var(--space-md);
+    text-align: center;
+  }
+
+  .footer-text {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+  }
+
+  /* Mobile: hide nav links, show brand only */
+  @media (max-width: 640px) {
+    .nav-links {
+      gap: var(--space-xs);
+    }
+
+    .nav-link {
+      font-size: 0.75rem;
+      padding: var(--space-xs);
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,19 +1,8 @@
 ---
+import Base from "../layouts/Base.astro";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Fuji.me! — Fujifilm Lens and Camera Explorer</title>
-    <meta
-      name="description"
-      content="Lightweight Fuji lens and camera explorer with genre-based scoring."
-    />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  </head>
-  <body>
-    <h1>Fuji.me!</h1>
-    <p>Lightweight Fuji lens and camera explorer with genre-based scoring.</p>
-  </body>
-</html>
+<Base title="Fuji.me! — Fujifilm Lens and Camera Explorer">
+  <h1>Fuji.me!</h1>
+  <p>Lightweight Fuji lens and camera explorer with genre-based scoring.</p>
+</Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,107 @@
+/* ==========================================================================
+   CSS Custom Properties
+   ========================================================================== */
+
+:root {
+  /* Colors — dark theme */
+  --color-bg: #0f1117;
+  --color-bg-surface: #1a1d27;
+  --color-bg-hover: #242836;
+  --color-border: #2e3345;
+  --color-text: #e1e4ed;
+  --color-text-muted: #8a8fa8;
+  --color-accent: #6c9bff;
+  --color-accent-hover: #8db3ff;
+  --color-link: #6c9bff;
+  --color-link-hover: #8db3ff;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  /* Typography */
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "Cascadia Code", monospace;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.5rem;
+  --font-size-2xl: 2rem;
+  --line-height: 1.6;
+
+  /* Layout */
+  --max-width: 72rem;
+  --nav-height: 3.5rem;
+  --radius: 0.375rem;
+}
+
+/* ==========================================================================
+   Reset
+   ========================================================================== */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ==========================================================================
+   Base
+   ========================================================================== */
+
+html {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+/* ==========================================================================
+   Utilities
+   ========================================================================== */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- Create `src/layouts/Base.astro` — HTML shell with sticky nav, footer, canonical URLs, Open Graph meta, active link highlighting
- Create `src/styles/global.css` — CSS custom properties, dark theme, reset, base typography
- Update `index.astro` to use Base layout
- Part of #57

## Test plan
- [x] `npm run build` passes
- [x] `npm run dev` — dark theme, nav, footer visible at localhost:4321
- [x] Verify contrast ratio meets WCAG AA (4.5:1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)