### PR TITLE
feat: add Lens Explorer with filters, sorting, and mobile cards

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -1,0 +1,363 @@
+/* ==========================================================================
+   Hero
+   ========================================================================== */
+
+.hero {
+  margin-bottom: var(--space-lg);
+}
+
+.heroTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
+.heroSub {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* ==========================================================================
+   Filters
+   ========================================================================== */
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.filterTop {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.filterRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.searchInput {
+  flex: 1;
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+}
+
+.searchInput::placeholder {
+  color: var(--color-text-muted);
+}
+
+.searchInput:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterSelect {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+
+.filterSelect:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterActive {
+  border-color: var(--color-accent);
+  background-color: var(--color-bg-hover);
+}
+
+.clearButton {
+  background: none;
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius);
+  color: var(--color-accent);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  padding: var(--space-sm);
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.clearButton:hover {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Chips
+   ========================================================================== */
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.chipGroup {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chipLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  font-weight: 600;
+  margin-right: var(--space-xs);
+  white-space: nowrap;
+}
+
+.chip {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  padding: 2px var(--space-sm);
+  cursor: pointer;
+}
+
+.chip:first-of-type {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+.chip:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.chip:not(:first-of-type) {
+  border-left: none;
+}
+
+.chip:hover {
+  color: var(--color-text);
+}
+
+.chipOn {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+.chipOn:hover {
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Empty state
+   ========================================================================== */
+
+.emptyState {
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+/* ==========================================================================
+   Table (desktop)
+   ========================================================================== */
+
+.tableWrap {
+  overflow-x: auto;
+  display: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.table th,
+.table td {
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.table th {
+  text-align: left;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-bg-surface);
+}
+
+.table th:hover {
+  color: var(--color-text);
+}
+
+.table th.cellRight,
+.table td.cellRight {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.table th.cellCenter,
+.table td.cellCenter {
+  text-align: center;
+}
+
+/* Dot indicators (OIS, WR) */
+.dotOn,
+.dotOff {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.dotOn {
+  background-color: #5a9060;
+}
+
+.dotOff {
+  background-color: var(--color-bg-hover);
+  border: 1px solid var(--color-border);
+}
+
+.table tbody tr:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.sortIndicator {
+  margin-left: var(--space-xs);
+  font-size: 0.7em;
+  opacity: 0.4;
+}
+
+.lensLink {
+  color: var(--color-link);
+}
+
+.lensLink:hover {
+  color: var(--color-link-hover);
+}
+
+.typeBadge {
+  display: inline-block;
+  margin-right: var(--space-xs);
+  font-size: 0.65rem;
+  padding: 0 3px;
+  border-radius: 2px;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+  vertical-align: middle;
+  letter-spacing: 0.03em;
+}
+
+.rowDiscontinued {
+  opacity: 0.5;
+}
+
+.cardDiscontinued {
+  opacity: 0.5;
+}
+
+/* ==========================================================================
+   Cards (mobile — default)
+   ========================================================================== */
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardHeader .lensLink {
+  font-weight: 600;
+}
+
+.cardPrice {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardSpecs {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardBadges {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.badge {
+  font-size: 0.7rem;
+  padding: 1px var(--space-xs);
+  border-radius: 2px;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+}
+
+/* ==========================================================================
+   Desktop
+   ========================================================================== */
+
+@media (min-width: 640px) {
+  .tableWrap {
+    display: block;
+  }
+
+  .cards {
+    display: none;
+  }
+}
+
+/* ==========================================================================
+   Footnote
+   ========================================================================== */
+
+.footnote {
+  margin-top: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -1,0 +1,306 @@
+import { useState, useMemo } from "react";
+import type { Lens } from "../../../types/lens";
+import { useSort } from "../../../hooks/useSort";
+import { toSlug } from "../../../utils/slug";
+import styles from "./LensExplorer.module.css";
+
+interface LensExplorerProps {
+  lenses: Lens[];
+}
+
+type LensSortKey =
+  | "brand"
+  | "model"
+  | "focalLengthMin"
+  | "maxAperture"
+  | "hasOis"
+  | "isWeatherSealed"
+  | "afMotor"
+  | "weight"
+  | "price";
+
+type ColumnAlign = "left" | "right" | "center";
+
+const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
+  { key: "brand", label: "Brand", align: "left" },
+  { key: "model", label: "Model", align: "left" },
+  { key: "focalLengthMin", label: "FL", align: "right" },
+  { key: "maxAperture", label: "f/", align: "right" },
+  { key: "hasOis", label: "OIS", align: "center" },
+  { key: "isWeatherSealed", label: "WR", align: "center" },
+  { key: "afMotor", label: "AF", align: "center" },
+  { key: "weight", label: "Weight", align: "right" },
+  { key: "price", label: "~USD", align: "right" },
+];
+
+function formatFL(lens: Lens): string {
+  if (lens.focalLengthMin === lens.focalLengthMax) {
+    return `${lens.focalLengthMin}mm`;
+  }
+  return `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
+}
+
+function LensExplorer({ lenses }: LensExplorerProps) {
+  const [search, setSearch] = useState("");
+  const [mount, setMount] = useState("");
+  const [type, setType] = useState("");
+  const [brand, setBrand] = useState("");
+  const [ois, setOis] = useState("");
+  const [wr, setWr] = useState("");
+  const [af, setAf] = useState("");
+  const [discontinued, setDiscontinued] = useState("");
+  const [fl, setFl] = useState("");
+
+  const brands = useMemo(() => {
+    const pool = mount ? lenses.filter((l) => l.mount === mount) : lenses;
+    return [...new Set(pool.map((l) => l.brand))].sort();
+  }, [lenses, mount]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return lenses.filter((lens) => {
+      if (mount && lens.mount !== mount) return false;
+      if (type && lens.type !== type) return false;
+      if (brand && lens.brand !== brand) return false;
+      if (ois === "yes" && !lens.hasOis) return false;
+      if (ois === "no" && lens.hasOis) return false;
+      if (wr === "yes" && !lens.isWeatherSealed) return false;
+      if (wr === "no" && lens.isWeatherSealed) return false;
+      if (af === "yes" && !lens.hasAutofocus) return false;
+      if (af === "no" && lens.hasAutofocus) return false;
+      if (discontinued === "available" && lens.isDiscontinued) return false;
+      if (discontinued === "discontinued" && !lens.isDiscontinued) return false;
+      if (fl) {
+        const ranges: Record<string, [number, number]> = {
+          "0-14": [0, 14],
+          "15-23": [15, 23],
+          "24-35": [24, 35],
+          "36-100": [36, 100],
+          "101-300": [101, 300],
+          "300+": [300, Infinity],
+        };
+        const [min, max] = ranges[fl];
+        if (lens.focalLengthMax < min || lens.focalLengthMin > max) return false;
+      }
+      if (q && !`${lens.brand} ${lens.model}`.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [lenses, search, mount, type, brand, ois, wr, af, discontinued, fl]);
+
+  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Lens, LensSortKey>(filtered, "focalLengthMin");
+
+  function resetValue(value: string): string {
+    return value === "__all__" ? "" : value;
+  }
+
+  function handleMountChange(value: string): void {
+    setMount(value);
+    if (brand) {
+      const brandExistsInMount = lenses.some(
+        (l) => l.brand === brand && (!value || l.mount === value),
+      );
+      if (!brandExistsInMount) setBrand("");
+    }
+  }
+
+  const hasFilters = search || mount || type || brand || ois || wr || af || discontinued || fl;
+
+  function clearFilters(): void {
+    setSearch("");
+    setMount("");
+    setType("");
+    setBrand("");
+    setOis("");
+    setWr("");
+    setAf("");
+    setDiscontinued("");
+    setFl("");
+  }
+
+  return (
+    <div>
+      <div className={styles.hero}>
+        <h1 className={styles.heroTitle}>Lens Explorer</h1>
+        <p className={styles.heroSub}>{sorted.length} / {lenses.length} Fujifilm-compatible lenses</p>
+      </div>
+      <div className={styles.filters}>
+        <div className={styles.filterTop}>
+          <input
+            className={styles.searchInput}
+            type="text"
+            placeholder="Search model..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search by model name"
+          />
+          {hasFilters && (
+            <button
+              className={styles.clearButton}
+              onClick={clearFilters}
+              type="button"
+              aria-label="Clear all filters"
+            >
+              &#x2715; Clear
+            </button>
+          )}
+        </div>
+
+        <div className={styles.filterRow}>
+          <select className={`${styles.filterSelect} ${brand ? styles.filterActive : ""}`} value={brand} onChange={(e) => setBrand(resetValue(e.target.value))} aria-label="Filter by brand">
+            <option value="" hidden>Brand</option>
+            <option value="__all__">All brands</option>
+            {brands.includes("Fujifilm") && <option value="Fujifilm">Fujifilm</option>}
+            {brands.includes("Fujifilm") && <option disabled>───</option>}
+            {brands.filter((b) => b !== "Fujifilm").map((b) => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${fl ? styles.filterActive : ""}`} value={fl} onChange={(e) => setFl(resetValue(e.target.value))} aria-label="Filter by focal length">
+            <option value="" hidden>Focal Length</option>
+            <option value="__all__">All</option>
+            <option value="0-14">&le; 14mm</option>
+            <option value="15-23">15-23mm</option>
+            <option value="24-35">24-35mm</option>
+            <option value="36-100">36-100mm</option>
+            <option value="101-300">101-300mm</option>
+            <option value="300+">300mm+</option>
+          </select>
+
+          <select className={`${styles.filterSelect} ${discontinued ? styles.filterActive : ""}`} value={discontinued} onChange={(e) => setDiscontinued(resetValue(e.target.value))} aria-label="Filter by status">
+            <option value="" hidden>Status</option>
+            <option value="__all__">All</option>
+            <option value="available">Available</option>
+            <option value="discontinued">Discontinued</option>
+          </select>
+        </div>
+
+        <div className={styles.chipRow}>
+          <div className={styles.chipGroup}>
+            <span className={styles.chipLabel}>Mount</span>
+            <button type="button" className={`${styles.chip} ${mount === "" ? styles.chipOn : ""}`} onClick={() => handleMountChange("")}>All</button>
+            <button type="button" className={`${styles.chip} ${mount === "X" ? styles.chipOn : ""}`} onClick={() => handleMountChange("X")}>X</button>
+            <button type="button" className={`${styles.chip} ${mount === "GFX" ? styles.chipOn : ""}`} onClick={() => handleMountChange("GFX")}>GFX</button>
+          </div>
+
+          <div className={styles.chipGroup}>
+            <span className={styles.chipLabel}>Type</span>
+            <button type="button" className={`${styles.chip} ${type === "" ? styles.chipOn : ""}`} onClick={() => setType("")}>All</button>
+            <button type="button" className={`${styles.chip} ${type === "prime" ? styles.chipOn : ""}`} onClick={() => setType("prime")}>Prime</button>
+            <button type="button" className={`${styles.chip} ${type === "zoom" ? styles.chipOn : ""}`} onClick={() => setType("zoom")}>Zoom</button>
+          </div>
+
+          <div className={styles.chipGroup}>
+            <span className={styles.chipLabel}>AF</span>
+            <button type="button" className={`${styles.chip} ${af === "" ? styles.chipOn : ""}`} onClick={() => setAf("")}>All</button>
+            <button type="button" className={`${styles.chip} ${af === "yes" ? styles.chipOn : ""}`} onClick={() => setAf("yes")}>AF</button>
+            <button type="button" className={`${styles.chip} ${af === "no" ? styles.chipOn : ""}`} onClick={() => setAf("no")}>MF</button>
+          </div>
+
+          <div className={styles.chipGroup}>
+            <span className={styles.chipLabel}>OIS</span>
+            <button type="button" className={`${styles.chip} ${ois === "" ? styles.chipOn : ""}`} onClick={() => setOis("")}>All</button>
+            <button type="button" className={`${styles.chip} ${ois === "yes" ? styles.chipOn : ""}`} onClick={() => setOis("yes")}>Yes</button>
+            <button type="button" className={`${styles.chip} ${ois === "no" ? styles.chipOn : ""}`} onClick={() => setOis("no")}>No</button>
+          </div>
+
+          <div className={styles.chipGroup}>
+            <span className={styles.chipLabel}>WR</span>
+            <button type="button" className={`${styles.chip} ${wr === "" ? styles.chipOn : ""}`} onClick={() => setWr("")}>All</button>
+            <button type="button" className={`${styles.chip} ${wr === "yes" ? styles.chipOn : ""}`} onClick={() => setWr("yes")}>Yes</button>
+            <button type="button" className={`${styles.chip} ${wr === "no" ? styles.chipOn : ""}`} onClick={() => setWr("no")}>No</button>
+          </div>
+        </div>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className={styles.emptyState}>No lenses match the current filters.</p>
+      ) : (
+        <>
+          {/* Table — desktop */}
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  {COLUMNS.map((col) => (
+                    <th
+                      key={col.key}
+                      className={col.align === "right" ? styles.cellRight : col.align === "center" ? styles.cellCenter : undefined}
+                      onClick={() => toggleSort(col.key)}
+                      aria-sort={
+                        sortKey === col.key
+                          ? sortDirection === "asc" ? "ascending" : "descending"
+                          : "none"
+                      }
+                    >
+                      {col.label}
+                      <span className={styles.sortIndicator}>
+                        {sortKey === col.key
+                          ? (sortDirection === "asc" ? "\u2191" : "\u2193")
+                          : "\u2195"}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((lens) => (
+                  <tr key={`${lens.brand}-${lens.model}`} className={lens.isDiscontinued ? styles.rowDiscontinued : undefined}>
+                    <td>{lens.brand}</td>
+                    <td>
+                      <span className={styles.typeBadge}>{lens.type === "prime" ? "P" : "Z"}</span>
+                      <a className={styles.lensLink} href={`/lenses/${toSlug(`${lens.brand} ${lens.model}`)}`}>
+                        {lens.model}
+                      </a>
+                    </td>
+                    <td className={styles.cellRight}>{formatFL(lens)}</td>
+                    <td className={styles.cellRight}>{lens.maxAperture}</td>
+                    <td className={styles.cellCenter}><span className={lens.hasOis ? styles.dotOn : styles.dotOff} /></td>
+                    <td className={styles.cellCenter}><span className={lens.isWeatherSealed ? styles.dotOn : styles.dotOff} /></td>
+                    <td className={styles.cellCenter}>{lens.afMotor ?? "MF"}</td>
+                    <td className={styles.cellRight}>{lens.weight}g</td>
+                    <td className={styles.cellRight}>~${lens.price}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards — mobile */}
+          <div className={styles.cards}>
+            {sorted.map((lens) => (
+              <div key={`${lens.brand}-${lens.model}`} className={`${styles.card} ${lens.isDiscontinued ? styles.cardDiscontinued : ""}`}>
+                <div className={styles.cardHeader}>
+                  <a className={styles.lensLink} href={`/lenses/${toSlug(`${lens.brand} ${lens.model}`)}`}>
+                    {lens.brand} {lens.model}
+                  </a>
+                  <span className={styles.cardPrice}>~${lens.price}</span>
+                </div>
+                <div className={styles.cardSpecs}>
+                  <span>{formatFL(lens)}</span>
+                  <span>f/{lens.maxAperture}</span>
+                  <span>{lens.weight}g</span>
+                  <span>{lens.type === "prime" ? "Prime" : "Zoom"}</span>
+                </div>
+                <div className={styles.cardBadges}>
+                  {lens.hasOis && <span className={styles.badge}>OIS</span>}
+                  {lens.isWeatherSealed && <span className={styles.badge}>WR</span>}
+                  {lens.afMotor && <span className={styles.badge}>{lens.afMotor}</span>}
+                  {!lens.afMotor && <span className={styles.badge}>MF</span>}
+                  {lens.isDiscontinued && <span className={styles.badge}>Discontinued</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <p className={styles.footnote}>
+        All prices are approximate USD estimates.
+        See <a href="/trade-deals">Trade Deals</a> for current market rates.
+      </p>
+    </div>
+  );
+}
+
+export default LensExplorer;

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,0 +1,52 @@
+import { useState, useMemo } from "react";
+
+type FilterValues<K extends string> = Partial<Record<K, string>>;
+
+interface UseFilterResult<T, K extends string> {
+  filtered: T[];
+  filters: FilterValues<K>;
+  setFilter: (key: K, value: string) => void;
+  clearFilters: () => void;
+}
+
+function useFilter<T, K extends string & keyof T>(
+  items: T[],
+  filterKeys: K[],
+): UseFilterResult<T, K> {
+  const [filters, setFilters] = useState<FilterValues<K>>({});
+
+  const filtered = useMemo(() => {
+    return items.filter((item) =>
+      filterKeys.every((key) => {
+        const filterValue = filters[key];
+        if (!filterValue) return true;
+
+        const itemValue = item[key as keyof T];
+        if (itemValue == null) return false;
+
+        return String(itemValue) === filterValue;
+      }),
+    );
+  }, [items, filters, filterKeys]);
+
+  function setFilter(key: K, value: string): void {
+    setFilters((prev) => {
+      const next = { ...prev };
+      if (value === "") {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      return next;
+    });
+  }
+
+  function clearFilters(): void {
+    setFilters({});
+  }
+
+  return { filtered, filters, setFilter, clearFilters };
+}
+
+export { useFilter };
+export type { FilterValues };

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,0 +1,62 @@
+import { useState, useMemo } from "react";
+
+type SortDirection = "asc" | "desc";
+
+interface SortState<K extends string> {
+  key: K;
+  direction: SortDirection;
+}
+
+interface UseSortResult<T, K extends string> {
+  sorted: T[];
+  sortKey: K;
+  sortDirection: SortDirection;
+  toggleSort: (key: K) => void;
+}
+
+function useSort<T, K extends string & keyof T>(
+  items: T[],
+  defaultKey: K,
+  defaultDirection: SortDirection = "asc",
+): UseSortResult<T, K> {
+  const [sort, setSort] = useState<SortState<K>>({
+    key: defaultKey,
+    direction: defaultDirection,
+  });
+
+  const sorted = useMemo(() => {
+    const copy = [...items];
+    copy.sort((a, b) => {
+      const aVal = a[sort.key as keyof T];
+      const bVal = b[sort.key as keyof T];
+
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        const cmp = aVal.localeCompare(bVal);
+        return sort.direction === "asc" ? cmp : -cmp;
+      }
+
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sort.direction === "asc" ? aVal - bVal : bVal - aVal;
+      }
+
+      return 0;
+    });
+    return copy;
+  }, [items, sort.key, sort.direction]);
+
+  function toggleSort(key: K): void {
+    setSort((prev) => ({
+      key,
+      direction: prev.key === key && prev.direction === "asc" ? "desc" : "asc",
+    }));
+  }
+
+  return { sorted, sortKey: sort.key, sortDirection: sort.direction, toggleSort };
+}
+
+export { useSort };
+export type { SortDirection };

--- a/src/pages/lenses/index.astro
+++ b/src/pages/lenses/index.astro
@@ -1,9 +1,10 @@
 ---
 import Base from "../../layouts/Base.astro";
 import { lenses } from "../../data/lenses";
+import LensExplorer from "../../components/interactive/LensExplorer/LensExplorer";
 ---
 
 <Base title="Lenses — Fuji.me!" description="Browse all Fujifilm-compatible lenses with specs and genre scores.">
-  <h1>Lenses</h1>
-  <p>{lenses.length} lenses in the database.</p>
+  <LensExplorer client:load lenses={lenses} />
 </Base>
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,8 +10,8 @@
   --color-border: #2e3345;
   --color-text: #e1e4ed;
   --color-text-muted: #8a8fa8;
-  --color-accent: #6c9bff;
-  --color-accent-hover: #8db3ff;
+  --color-accent: #e8a045;
+  --color-accent-hover: #f0b560;
   --color-link: #6c9bff;
   --color-link-hover: #8db3ff;
 
@@ -61,6 +61,7 @@ html {
   line-height: var(--line-height);
   color: var(--color-text);
   background-color: var(--color-bg);
+  color-scheme: dark;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -69,6 +70,30 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+/* Scrollbar */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-text-muted) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--color-text-muted);
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-button {
+  display: none;
 }
 
 a {


### PR DESCRIPTION
## Summary
- Lens Explorer React island at `/lenses` with 9 sortable columns
- Chip filters (Mount, Type, AF, OIS, WR) + dropdown filters (Brand, Focal Length, Status)
- Text search, brand promotion (Fujifilm first), focal length ranges
- Mobile card layout below 640px with badges
- Hero with dynamic count, filter panel, warm golden accent
- Reusable `useSort` and `useFilter` hooks

## Related
- Part of #57 (Astro migration)
- Data audit needed: #98 (suffix fields), #100 (ghost lenses)
- Refactor planned: #95 (remove hasAutofocus)
- Feature planned: #99 (coating field)

## Test plan
- [x] `npm run check:all` — 0 errors, 258 pages
- [x] Filters, sorting, search work
- [x] Mobile card layout renders
- [ ] Cross-browser check

🤖 Generated with [Claude Code](https://claude.com/claude-code)