### PR TITLE
feat: add Camera Explorer with shared components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ src/
       WikiEntry.astro
       PriceTag.astro
     interactive/                  // React — hydrated as islands
+      shared/
+        ChipGroup.tsx             // Reusable chip filter group
+        constants.ts              // Shared filter constants (RESET_VALUE)
       LensExplorer/
         LensExplorer.tsx          // Sort/filter table (client:load)
         LensExplorer.test.tsx

--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -1,0 +1,343 @@
+/* ==========================================================================
+   Hero
+   ========================================================================== */
+
+.hero {
+  margin-bottom: var(--space-lg);
+}
+
+.heroTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
+.heroSub {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* ==========================================================================
+   Filters
+   ========================================================================== */
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.filterTop {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.filterRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.searchInput {
+  flex: 1;
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+}
+
+.searchInput::placeholder {
+  color: var(--color-text-muted);
+}
+
+.searchInput:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterSelect {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+
+.filterSelect:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterActive {
+  border-color: var(--color-accent);
+  background-color: var(--color-bg-hover);
+}
+
+.clearButton {
+  background: none;
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius);
+  color: var(--color-accent);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  padding: var(--space-sm);
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.clearButton:hover {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Chips
+   ========================================================================== */
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.chipGroup {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chipLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  font-weight: 600;
+  margin-right: var(--space-xs);
+  white-space: nowrap;
+}
+
+.chip {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  padding: 2px var(--space-sm);
+  cursor: pointer;
+}
+
+.chip:first-of-type {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+.chip:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.chip:not(:first-of-type) {
+  border-left: none;
+}
+
+.chip:hover {
+  color: var(--color-text);
+}
+
+.chipOn {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+.chipOn:hover {
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Empty state
+   ========================================================================== */
+
+.emptyState {
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+/* ==========================================================================
+   Table (desktop)
+   ========================================================================== */
+
+.tableWrap {
+  overflow-x: auto;
+  display: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.table th,
+.table td {
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.table th {
+  text-align: left;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-bg-surface);
+}
+
+.table th:hover {
+  color: var(--color-text);
+}
+
+.table th.cellRight,
+.table td.cellRight {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.table th.cellCenter,
+.table td.cellCenter {
+  text-align: center;
+}
+
+/* Dot indicators (OIS, WR) */
+.dotOn,
+.dotOff {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.dotOn {
+  background-color: #5a9060;
+}
+
+.dotOff {
+  background-color: var(--color-bg-hover);
+  border: 1px solid var(--color-border);
+}
+
+.table tbody tr:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.sortIndicator {
+  margin-left: var(--space-xs);
+  font-size: 0.7em;
+  opacity: 0.4;
+}
+
+.rowDiscontinued {
+  opacity: 0.5;
+}
+
+.cardDiscontinued {
+  opacity: 0.5;
+}
+
+/* ==========================================================================
+   Cards (mobile — default)
+   ========================================================================== */
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardHeader .lensLink {
+  font-weight: 600;
+}
+
+.cardPrice {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardSpecs {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardBadges {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.badge {
+  font-size: 0.7rem;
+  padding: 1px var(--space-xs);
+  border-radius: 2px;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+}
+
+/* ==========================================================================
+   Desktop
+   ========================================================================== */
+
+@media (min-width: 640px) {
+  .tableWrap {
+    display: block;
+  }
+
+  .cards {
+    display: none;
+  }
+}
+
+/* ==========================================================================
+   Footnote
+   ========================================================================== */
+
+.footnote {
+  margin-top: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -1,0 +1,325 @@
+import { useState, useMemo } from "react";
+import type { Camera } from "../../../types/camera";
+import { useSort } from "../../../hooks/useSort";
+import { ChipGroup } from "../shared/ChipGroup";
+import { RESET_VALUE, resetValue } from "../shared/constants";
+import styles from "./CameraExplorer.module.css";
+
+interface CameraExplorerProps {
+  cameras: Camera[];
+}
+
+type CameraSortKey =
+  | "model"
+  | "year"
+  | "megapixels"
+  | "sensor"
+  | "hasIbis"
+  | "isWeatherSealed"
+  | "burstFps"
+  | "videoSpec"
+  | "batteryLife"
+  | "weight"
+  | "price";
+
+type ColumnAlign = "left" | "right" | "center";
+
+const COLUMNS: { key: CameraSortKey; label: string; align: ColumnAlign }[] = [
+  { key: "model", label: "Model", align: "left" },
+  { key: "year", label: "Year", align: "right" },
+  { key: "megapixels", label: "MP", align: "right" },
+  { key: "sensor", label: "Sensor", align: "left" },
+  { key: "hasIbis", label: "IBIS", align: "center" },
+  { key: "isWeatherSealed", label: "WR", align: "center" },
+  { key: "burstFps", label: "FPS", align: "right" },
+  { key: "videoSpec", label: "Video", align: "center" },
+  { key: "batteryLife", label: "Battery", align: "right" },
+  { key: "weight", label: "Weight", align: "right" },
+  { key: "price", label: "Price", align: "right" },
+];
+
+const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
+  left: undefined,
+  right: styles.cellRight,
+  center: styles.cellCenter,
+};
+
+const YEAR_RANGES: Record<string, [number, number]> = {
+  "2022+": [2022, Infinity],
+  "2019-2021": [2019, 2021],
+  "2016-2018": [2016, 2018],
+  "2012-2015": [2012, 2015],
+};
+
+const VIDEO_OPTIONS = ["8K", "6.2K", "4K", "1080p"];
+
+const PRICE_RANGES: Record<string, [number, number]> = {
+  "0-500": [0, 500],
+  "500-1000": [500, 1000],
+  "1000-2000": [1000, 2000],
+  "2000-4000": [2000, 4000],
+  "4000+": [4000, Infinity],
+};
+
+function CameraExplorer({ cameras }: CameraExplorerProps) {
+  const [search, setSearch] = useState("");
+  const [mount, setMount] = useState("");
+  const [series, setSeries] = useState("");
+  const [yearRange, setYearRange] = useState("");
+  const [sensorType, setSensorType] = useState("");
+  const [ibis, setIbis] = useState("");
+  const [wr, setWr] = useState("");
+  const [formFactor, setFormFactor] = useState("");
+  const [discontinued, setDiscontinued] = useState("");
+  const [videoSpec, setVideoSpec] = useState("");
+  const [priceRange, setPriceRange] = useState("");
+
+  const seriesOptions = useMemo(() => {
+    const pool = mount ? cameras.filter((c) => c.mount === mount) : cameras;
+    return [...new Set(pool.map((c) => c.series))].sort();
+  }, [cameras, mount]);
+
+  const sensorOptions = useMemo(() => {
+    const pool = mount ? cameras.filter((c) => c.mount === mount) : cameras;
+    return [...new Set(pool.map((c) => c.sensor))].sort();
+  }, [cameras, mount]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return cameras.filter((cam) => {
+      if (mount && cam.mount !== mount) return false;
+      if (series && cam.series !== series) return false;
+      if (yearRange) {
+        const [min, max] = YEAR_RANGES[yearRange];
+        if (cam.year < min || cam.year > max) return false;
+      }
+      if (sensorType && cam.sensor !== sensorType) return false;
+      if (formFactor && cam.formFactor !== formFactor) return false;
+      if (ibis === "yes" && !cam.hasIbis) return false;
+      if (ibis === "no" && cam.hasIbis) return false;
+      if (wr === "yes" && !cam.isWeatherSealed) return false;
+      if (wr === "no" && cam.isWeatherSealed) return false;
+      if (discontinued === "available" && cam.isDiscontinued) return false;
+      if (discontinued === "discontinued" && !cam.isDiscontinued) return false;
+      if (videoSpec && cam.videoSpec !== videoSpec) return false;
+      if (priceRange) {
+        const [min, max] = PRICE_RANGES[priceRange];
+        if (cam.price < min || cam.price > max) return false;
+      }
+      if (q && !cam.model.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [cameras, search, mount, series, yearRange, sensorType, formFactor, discontinued, ibis, wr, videoSpec, priceRange]);
+
+  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Camera, CameraSortKey>(filtered, "year");
+
+  function handleMountChange(value: string): void {
+    setMount(value);
+    if (series) {
+      const seriesExistsInMount = cameras.some(
+        (c) => c.series === series && (!value || c.mount === value),
+      );
+      if (!seriesExistsInMount) setSeries("");
+    }
+  }
+
+  const hasFilters = search || mount || series || yearRange || sensorType || formFactor || discontinued || ibis || wr || videoSpec || priceRange;
+
+  function clearFilters(): void {
+    setSearch("");
+    setMount("");
+    setSeries("");
+    setYearRange("");
+    setSensorType("");
+    setFormFactor("");
+    setDiscontinued("");
+    setIbis("");
+    setWr("");
+    setVideoSpec("");
+    setPriceRange("");
+  }
+
+  return (
+    <div>
+      <div className={styles.hero}>
+        <h1 className={styles.heroTitle}>Camera Explorer</h1>
+        <p className={styles.heroSub}>{sorted.length} / {cameras.length} Fujifilm cameras</p>
+      </div>
+      <div className={styles.filters}>
+        <div className={styles.filterTop}>
+          <input
+            className={styles.searchInput}
+            type="text"
+            placeholder="Search model..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search by model name"
+          />
+          {hasFilters && (
+            <button
+              className={styles.clearButton}
+              onClick={clearFilters}
+              type="button"
+              aria-label="Clear all filters"
+            >
+              &#x2715; Clear
+            </button>
+          )}
+        </div>
+
+        <div className={styles.filterRow}>
+          <select className={`${styles.filterSelect} ${formFactor ? styles.filterActive : ""}`} value={formFactor} onChange={(e) => setFormFactor(resetValue(e.target.value))} aria-label="Filter by body style">
+            <option value="" hidden>Body</option>
+            <option value={RESET_VALUE}>All</option>
+            <option value="slr">Standard</option>
+            <option value="dslr-grip">Pro grip</option>
+            <option value="rangefinder">Rangefinder</option>
+            <option value="compact">Compact</option>
+          </select>
+
+          <select className={`${styles.filterSelect} ${series ? styles.filterActive : ""}`} value={series} onChange={(e) => setSeries(resetValue(e.target.value))} aria-label="Filter by series">
+            <option value="" hidden>Series</option>
+            <option value={RESET_VALUE}>All series</option>
+            {seriesOptions.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${yearRange ? styles.filterActive : ""}`} value={yearRange} onChange={(e) => setYearRange(resetValue(e.target.value))} aria-label="Filter by year">
+            <option value="" hidden>Year</option>
+            <option value={RESET_VALUE}>All</option>
+            {Object.keys(YEAR_RANGES).map((key) => (
+              <option key={key} value={key}>{key}</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${sensorType ? styles.filterActive : ""}`} value={sensorType} onChange={(e) => setSensorType(resetValue(e.target.value))} aria-label="Filter by sensor">
+            <option value="" hidden>Sensor</option>
+            <option value={RESET_VALUE}>All</option>
+            {sensorOptions.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${videoSpec ? styles.filterActive : ""}`} value={videoSpec} onChange={(e) => setVideoSpec(resetValue(e.target.value))} aria-label="Filter by video">
+            <option value="" hidden>Video</option>
+            <option value={RESET_VALUE}>All</option>
+            {VIDEO_OPTIONS.map((v) => (
+              <option key={v} value={v}>{v}+</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${priceRange ? styles.filterActive : ""}`} value={priceRange} onChange={(e) => setPriceRange(resetValue(e.target.value))} aria-label="Filter by price">
+            <option value="" hidden>Price</option>
+            <option value={RESET_VALUE}>All</option>
+            <option value="0-500">Under $500</option>
+            <option value="500-1000">$500 - $1,000</option>
+            <option value="1000-2000">$1,000 - $2,000</option>
+            <option value="2000-4000">$2,000 - $4,000</option>
+            <option value="4000+">$4,000+</option>
+          </select>
+        </div>
+
+        <div className={styles.chipRow}>
+          <ChipGroup label="Mount" value={mount} onChange={handleMountChange} styles={styles} options={[
+            { label: "All", value: "" }, { label: "X", value: "X" }, { label: "GFX", value: "GFX" },
+          ]} />
+          <ChipGroup label="IBIS" value={ibis} onChange={setIbis} styles={styles} options={[
+            { label: "All", value: "" }, { label: "Yes", value: "yes" }, { label: "No", value: "no" },
+          ]} />
+          <ChipGroup label="WR" value={wr} onChange={setWr} styles={styles} options={[
+            { label: "All", value: "" }, { label: "Yes", value: "yes" }, { label: "No", value: "no" },
+          ]} />
+          <ChipGroup label="Status" value={discontinued} onChange={setDiscontinued} styles={styles} options={[
+            { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
+          ]} />
+        </div>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className={styles.emptyState}>No cameras match the current filters.</p>
+      ) : (
+        <>
+          {/* Table — desktop */}
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  {COLUMNS.map((col) => (
+                    <th
+                      key={col.key}
+                      className={ALIGN_CLASSES[col.align]}
+                      onClick={() => toggleSort(col.key)}
+                      aria-sort={
+                        sortKey === col.key
+                          ? sortDirection === "asc" ? "ascending" : "descending"
+                          : "none"
+                      }
+                    >
+                      {col.label}
+                      <span className={styles.sortIndicator}>
+                        {sortKey === col.key
+                          ? (sortDirection === "asc" ? "\u2191" : "\u2193")
+                          : "\u2195"}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((cam) => (
+                  <tr key={`${cam.series}-${cam.model}`} className={cam.isDiscontinued ? styles.rowDiscontinued : undefined}>
+                    <td>{cam.model}</td>
+                    <td className={styles.cellRight}>{cam.year}</td>
+                    <td className={styles.cellRight}>{cam.megapixels}</td>
+                    <td>{cam.sensor}</td>
+                    <td className={styles.cellCenter}><span className={cam.hasIbis ? styles.dotOn : styles.dotOff} /></td>
+                    <td className={styles.cellCenter}><span className={cam.isWeatherSealed ? styles.dotOn : styles.dotOff} /></td>
+                    <td className={styles.cellRight}>{cam.burstFps ?? "\u2013"}</td>
+                    <td className={styles.cellCenter}>{cam.videoSpec}</td>
+                    <td className={styles.cellRight}>{cam.batteryLife ?? "\u2013"}</td>
+                    <td className={styles.cellRight}>{cam.weight}g</td>
+                    <td className={styles.cellRight}>~${cam.price}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards — mobile */}
+          <div className={styles.cards}>
+            {sorted.map((cam) => (
+              <div key={`${cam.series}-${cam.model}`} className={`${styles.card} ${cam.isDiscontinued ? styles.cardDiscontinued : ""}`}>
+                <div className={styles.cardHeader}>
+                  <span className={styles.cardTitle}>{cam.model}</span>
+                  <span className={styles.cardPrice}>~${cam.price}</span>
+                </div>
+                <div className={styles.cardSpecs}>
+                  <span>{cam.year}</span>
+                  <span>{cam.megapixels}MP</span>
+                  <span>{cam.sensor}</span>
+                  <span>{cam.videoSpec}</span>
+                  {cam.burstFps && <span>{cam.burstFps}fps</span>}
+                  {cam.batteryLife && <span>{cam.batteryLife} shots</span>}
+                  <span>{cam.weight}g</span>
+                </div>
+                <div className={styles.cardBadges}>
+                  {cam.hasIbis && <span className={styles.badge}>IBIS</span>}
+                  {cam.isWeatherSealed && <span className={styles.badge}>WR</span>}
+                  {cam.isDiscontinued && <span className={styles.badge}>Discontinued</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <p className={styles.footnote}>
+        All prices are approximate USD estimates.
+        See <a href="/trade-deals">Trade Deals</a> for current market rates.
+      </p>
+    </div>
+  );
+}
+
+export default CameraExplorer;

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -2,6 +2,8 @@ import { useState, useMemo } from "react";
 import type { Lens } from "../../../types/lens";
 import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
+import { ChipGroup } from "../shared/ChipGroup";
+import { RESET_VALUE, resetValue } from "../shared/constants";
 import styles from "./LensExplorer.module.css";
 
 interface LensExplorerProps {
@@ -52,8 +54,6 @@ const PRICE_RANGES: Record<string, [number, number]> = {
   "2000+": [2000, Infinity],
 };
 
-const RESET_VALUE = "__all__";
-
 const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
   left: undefined,
   right: styles.cellRight,
@@ -65,31 +65,6 @@ function formatFL(lens: Lens): string {
     return `${lens.focalLengthMin}mm`;
   }
   return `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
-}
-
-interface ChipGroupProps {
-  label: string;
-  value: string;
-  options: { label: string; value: string }[];
-  onChange: (value: string) => void;
-}
-
-function ChipGroup({ label, value, options, onChange }: ChipGroupProps) {
-  return (
-    <div className={styles.chipGroup}>
-      <span className={styles.chipLabel}>{label}</span>
-      {options.map((opt) => (
-        <button
-          key={opt.value}
-          type="button"
-          className={`${styles.chip} ${value === opt.value ? styles.chipOn : ""}`}
-          onClick={() => onChange(opt.value)}
-        >
-          {opt.label}
-        </button>
-      ))}
-    </div>
-  );
 }
 
 function LensExplorer({ lenses }: LensExplorerProps) {
@@ -144,10 +119,6 @@ function LensExplorer({ lenses }: LensExplorerProps) {
   }, [lenses, search, mount, type, brand, ois, wr, af, discontinued, fl, maxAp, priceRange]);
 
   const { sorted, sortKey, sortDirection, toggleSort } = useSort<Lens, LensSortKey>(filtered, "focalLengthMin");
-
-  function resetValue(value: string): string {
-    return value === RESET_VALUE ? "" : value;
-  }
 
   function handleMountChange(value: string): void {
     setMount(value);
@@ -246,22 +217,22 @@ function LensExplorer({ lenses }: LensExplorerProps) {
         </div>
 
         <div className={styles.chipRow}>
-          <ChipGroup label="Mount" value={mount} onChange={handleMountChange} options={[
+          <ChipGroup label="Mount" value={mount} onChange={handleMountChange} styles={styles} options={[
             { label: "All", value: "" }, { label: "X", value: "X" }, { label: "GFX", value: "GFX" },
           ]} />
-          <ChipGroup label="Type" value={type} onChange={setType} options={[
+          <ChipGroup label="Type" value={type} onChange={setType} styles={styles} options={[
             { label: "All", value: "" }, { label: "Prime", value: "prime" }, { label: "Zoom", value: "zoom" },
           ]} />
-          <ChipGroup label="AF" value={af} onChange={setAf} options={[
+          <ChipGroup label="AF" value={af} onChange={setAf} styles={styles} options={[
             { label: "All", value: "" }, { label: "AF", value: "yes" }, { label: "MF", value: "no" },
           ]} />
-          <ChipGroup label="OIS" value={ois} onChange={setOis} options={[
+          <ChipGroup label="OIS" value={ois} onChange={setOis} styles={styles} options={[
             { label: "All", value: "" }, { label: "Yes", value: "yes" }, { label: "No", value: "no" },
           ]} />
-          <ChipGroup label="WR" value={wr} onChange={setWr} options={[
+          <ChipGroup label="WR" value={wr} onChange={setWr} styles={styles} options={[
             { label: "All", value: "" }, { label: "Yes", value: "yes" }, { label: "No", value: "no" },
           ]} />
-          <ChipGroup label="Status" value={discontinued} onChange={setDiscontinued} options={[
+          <ChipGroup label="Status" value={discontinued} onChange={setDiscontinued} styles={styles} options={[
             { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
           ]} />
         </div>

--- a/src/components/interactive/shared/ChipGroup.tsx
+++ b/src/components/interactive/shared/ChipGroup.tsx
@@ -1,0 +1,28 @@
+interface ChipGroupProps {
+  label: string;
+  value: string;
+  options: { label: string; value: string }[];
+  onChange: (value: string) => void;
+  styles: Record<string, string>;
+}
+
+function ChipGroup({ label, value, options, onChange, styles }: ChipGroupProps) {
+  return (
+    <div className={styles.chipGroup}>
+      <span className={styles.chipLabel}>{label}</span>
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          className={`${styles.chip} ${value === opt.value ? styles.chipOn : ""}`}
+          onClick={() => onChange(opt.value)}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export { ChipGroup };
+export type { ChipGroupProps };

--- a/src/components/interactive/shared/constants.ts
+++ b/src/components/interactive/shared/constants.ts
@@ -1,0 +1,7 @@
+const RESET_VALUE = "__all__";
+
+function resetValue(value: string): string {
+  return value === RESET_VALUE ? "" : value;
+}
+
+export { RESET_VALUE, resetValue };

--- a/src/pages/cameras/index.astro
+++ b/src/pages/cameras/index.astro
@@ -1,9 +1,9 @@
 ---
 import Base from "../../layouts/Base.astro";
 import { cameras } from "../../data/cameras";
+import CameraExplorer from "../../components/interactive/CameraExplorer/CameraExplorer";
 ---
 
 <Base title="Cameras — Fuji.me!" description="Browse all Fujifilm camera bodies with specs and features.">
-  <h1>Cameras</h1>
-  <p>{cameras.length} cameras in the database.</p>
+  <CameraExplorer client:load cameras={cameras} />
 </Base>


### PR DESCRIPTION
## Summary
- Camera Explorer at `/cameras` — 11 sortable columns, 10+ filters
- Extract shared `ChipGroup` component and `RESET_VALUE`/`resetValue` constants
- Both Lens and Camera explorers import from `shared/`
- Remove dead CSS, fix React keys, update CLAUDE.md
- Part of #105

## Test plan
- [x] `npm run check:all` — 0 errors, 258 pages
- [x] All filters, chips, sorting work
- [x] Mobile card layout renders
- [x] Shared ChipGroup works in both explorers

🤖 Generated with [Claude Code](https://claude.com/claude-code)