### PR TITLE
docs: add ADR-012 domain name trademark risk

### DIFF
--- a/docs/decisions/012-domain-name-risk.md
+++ b/docs/decisions/012-domain-name-risk.md
@@ -1,0 +1,69 @@
+# ADR-012: Domain name trademark risk (fujime.app)
+
+**Status:** Under review
+**Date:** 2026-04-09
+
+## Context
+
+The project uses fujime.app as its domain. "Fuji" is a registered trademark
+of FUJIFILM Holdings Corporation. The site includes affiliate links, making
+it commercial in nature. This creates trademark risk.
+
+## Risk assessment
+
+**UDRP (domain dispute):** To take the domain, Fujifilm would need to prove:
+1. Domain is confusingly similar to their trademark — likely yes
+2. Registrant has no legitimate interest — debatable (informational site)
+3. Registered in bad faith — weak argument (not cybersquatting)
+
+Fan sites can win UDRP disputes if non-commercial. Affiliate links weaken
+this defense.
+
+**Trademark infringement:** Using brand names in affiliate site domains can
+result in cease and desist letters, fines up to $10,000 per domain under the
+Anticybersquatting Consumer Protection Act, affiliate program termination,
+and lawsuits.
+
+**Fujifilm policy:** Their terms state trademarks "must not be used in any
+manner without the express prior written consent." Brand guidelines exist
+for the X Series.
+
+## Options
+
+1. **Keep fujime.app** — accept risk, add disclaimers, hope for no enforcement
+2. **Rename to a brand-neutral domain** — eliminates risk entirely
+3. **Contact Fujifilm** — request explicit permission or a fan site license
+
+## Domain name candidates
+
+| Domain | Pros | Cons |
+|--------|------|------|
+| fujime.app | Memorable, direct | Trademark risk (contains "fuji") |
+| **lenspip.me** | Zero risk, unique, short, "pip" nods to scoring visualization, multi-system ready, fits me! series | Needs brand awareness from scratch |
+| wisteria.me | Zero risk, elegant, "fuji" = wisteria in Japanese | Subtle, doesn't scale to multi-system |
+| lensgrade.me | Clear, describes scoring, multi-system ready | Generic |
+| xmount.me | Recognizable to Fuji shooters | "X" prefix associations, Fuji-specific |
+
+## Decision
+
+Under review. **lenspip.me** is the top candidate — zero trademark risk,
+unique, descriptive (lens scoring with pips), multi-system ready for Phase 4
+expansion, and fits the me! series (.me TLD).
+
+## References
+
+- [WIPO Guide to UDRP](https://www.wipo.int/amc/en/domains/guide/)
+- [UDRP: When It Works and When It Doesn't](https://www.knobbe.com/blog/domain-name-disputes-when-udrp-works-and-when-it-doesnt/)
+- [Avoiding Trademark Pitfalls in Affiliate Marketing](https://thepma.org/avoiding-trademark-pitfalls-in-affiliate-marketing/)
+- [Avoid Trademark Infringement When Choosing a Domain Name](https://www.nolo.com/legal-encyclopedia/avoid-trademark-infringement-domain-name-29032.html)
+- [Online Use of Third Party Trademarks](https://www.americanbar.org/groups/business_law/resources/business-law-today/2016-february/online-use-of-third-party-trademarks/)
+- [Fujifilm Terms of Use](https://www.fujifilm.com/us/en/terms)
+- [Fujifilm X Series Brand Guidelines](https://www.fujifilm-x.com/en-us/brand-guidelines/)
+
+## Consequences
+
+If kept: must add "Not affiliated with FUJIFILM" disclaimer on every page.
+Site operates at Fujifilm's discretion — they can enforce at any time.
+
+If renamed: domain change before launch is low-cost. After launch, SEO and
+brand equity are lost. Change sooner rather than later.


### PR DESCRIPTION
## Summary
- Document trademark risk with fujime.app (UDRP, ACPA, Fujifilm IP policies)
- Evaluate domain name candidates
- Top candidate: lenspip.me (zero risk, unique, multi-system ready)

## Test plan
- [x] ADR follows format from base/docs.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)