### PR TITLE
feat: add Accessories Explorer

### DIFF
--- a/docs/decisions/012-domain-name-risk.md
+++ b/docs/decisions/012-domain-name-risk.md
@@ -40,15 +40,16 @@ for the X Series.
 |--------|------|------|
 | fujime.app | Memorable, direct | Trademark risk (contains "fuji") |
 | **lenspip.me** | Zero risk, unique, short, "pip" nods to scoring visualization, multi-system ready, fits me! series | Needs brand awareness from scratch |
+| **lensing.me** | Zero risk, short, elegant, real cinematography term, fits me! series | Lens-specific — cameras/accessories are secondary |
 | wisteria.me | Zero risk, elegant, "fuji" = wisteria in Japanese | Subtle, doesn't scale to multi-system |
 | lensgrade.me | Clear, describes scoring, multi-system ready | Generic |
 | xmount.me | Recognizable to Fuji shooters | "X" prefix associations, Fuji-specific |
 
 ## Decision
 
-Under review. **lenspip.me** is the top candidate — zero trademark risk,
-unique, descriptive (lens scoring with pips), multi-system ready for Phase 4
-expansion, and fits the me! series (.me TLD).
+Under review. Top candidates: **lenspip.me** (unique, scoring-focused) and
+**lensing.me** (elegant, cinematography term). Both zero trademark risk,
+multi-system ready, and fit the me! series (.me TLD).
 
 ## References
 

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
@@ -1,0 +1,349 @@
+/* ==========================================================================
+   Hero
+   ========================================================================== */
+
+.hero {
+  margin-bottom: var(--space-lg);
+}
+
+.heroTitle {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
+.heroSub {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* ==========================================================================
+   Filters
+   ========================================================================== */
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.filterTop {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.filterRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.searchInput {
+  flex: 1;
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+}
+
+.searchInput::placeholder {
+  color: var(--color-text-muted);
+}
+
+.searchInput:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterSelect {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+
+.filterSelect:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.filterActive {
+  border-color: var(--color-accent);
+  background-color: var(--color-bg-hover);
+}
+
+.clearButton {
+  background: none;
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius);
+  color: var(--color-accent);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  padding: var(--space-sm);
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.clearButton:hover {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Chips
+   ========================================================================== */
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.chipGroup {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chipLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  font-weight: 600;
+  margin-right: var(--space-xs);
+  white-space: nowrap;
+}
+
+.chip {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  padding: 2px var(--space-sm);
+  cursor: pointer;
+}
+
+.chip:first-of-type {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+.chip:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.chip:not(:first-of-type) {
+  border-left: none;
+}
+
+.chip:hover {
+  color: var(--color-text);
+}
+
+.chipOn {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg);
+}
+
+.chipOn:hover {
+  color: var(--color-bg);
+}
+
+/* ==========================================================================
+   Empty state
+   ========================================================================== */
+
+.emptyState {
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+/* ==========================================================================
+   Table (desktop)
+   ========================================================================== */
+
+.tableWrap {
+  overflow-x: auto;
+  display: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.table th,
+.table td {
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.table th {
+  text-align: left;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-bg-surface);
+}
+
+.table th:hover {
+  color: var(--color-text);
+}
+
+.table th.cellRight,
+.table td.cellRight {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.modelCell {
+  max-width: 100px;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+.table td.descriptionCell {
+  white-space: normal;
+  max-width: 300px;
+  word-wrap: break-word;
+}
+
+.categoryBadge {
+  font-size: 0.7rem;
+  padding: 1px var(--space-xs);
+  border-radius: 2px;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.table tbody tr:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.sortIndicator {
+  margin-left: var(--space-xs);
+  font-size: 0.7em;
+  opacity: 0.4;
+}
+
+.rowDiscontinued {
+  opacity: 0.5;
+}
+
+.cardDiscontinued {
+  opacity: 0.5;
+}
+
+/* ==========================================================================
+   Cards (mobile — default)
+   ========================================================================== */
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.card {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardHeader .lensLink {
+  font-weight: 600;
+}
+
+.cardPrice {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardDescription {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-xs);
+  line-height: 1.4;
+}
+
+.cardSpecs {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.cardBadges {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.badge {
+  font-size: 0.7rem;
+  padding: 1px var(--space-xs);
+  border-radius: 2px;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+}
+
+/* ==========================================================================
+   Desktop
+   ========================================================================== */
+
+@media (min-width: 640px) {
+  .tableWrap {
+    display: block;
+  }
+
+  .cards {
+    display: none;
+  }
+}
+
+/* ==========================================================================
+   Footnote
+   ========================================================================== */
+
+.footnote {
+  margin-top: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -1,0 +1,228 @@
+import { useState, useMemo } from "react";
+import type { Accessory, AccessoryCategory } from "../../../types/accessory";
+import { useSort } from "../../../hooks/useSort";
+import { ChipGroup } from "../shared/ChipGroup";
+import { RESET_VALUE, resetValue } from "../shared/constants";
+import styles from "./AccessoriesExplorer.module.css";
+
+interface AccessoriesExplorerProps {
+  accessories: Accessory[];
+}
+
+type AccessorySortKey =
+  | "category"
+  | "brand"
+  | "model"
+  | "description"
+  | "price";
+
+type ColumnAlign = "left" | "right";
+
+const COLUMNS: { key: AccessorySortKey; label: string; align: ColumnAlign }[] = [
+  { key: "category", label: "Category", align: "left" },
+  { key: "brand", label: "Brand", align: "left" },
+  { key: "model", label: "Model", align: "left" },
+  { key: "description", label: "Description", align: "left" },
+  { key: "price", label: "Price", align: "right" },
+];
+
+const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
+  left: undefined,
+  right: styles.cellRight,
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  "flash": "Flash",
+  "battery-grip": "Battery Grip",
+  "hand-grip": "Hand Grip",
+  "battery": "Battery",
+  "charger": "Charger",
+  "lens-accessory": "Lens Accessory",
+  "adapter": "Adapter",
+  "remote": "Remote",
+  "audio": "Audio",
+  "cooling": "Cooling",
+  "body-accessory": "Body Accessory",
+};
+
+function formatCategory(category: AccessoryCategory): string {
+  return CATEGORY_LABELS[category] ?? category;
+}
+
+const PRICE_RANGES: Record<string, [number, number]> = {
+  "0-250": [0, 250],
+  "250-500": [250, 500],
+  "500-1000": [500, 1000],
+  "1000+": [1000, Infinity],
+};
+
+function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [mount, setMount] = useState("");
+  const [discontinued, setDiscontinued] = useState("");
+  const [priceRange, setPriceRange] = useState("");
+
+  const categories = useMemo(() => {
+    const cats = [...new Set(accessories.map((a) => a.category))].sort();
+    return cats;
+  }, [accessories]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return accessories.filter((acc) => {
+      if (category && acc.category !== category) return false;
+      if (mount && (!("mount" in acc) || acc.mount !== mount)) return false;
+      if (discontinued === "available" && acc.isDiscontinued) return false;
+      if (discontinued === "discontinued" && !acc.isDiscontinued) return false;
+      if (priceRange) {
+        const [min, max] = PRICE_RANGES[priceRange];
+        if (acc.price < min || acc.price > max) return false;
+      }
+      if (q && !`${acc.brand} ${acc.model} ${acc.description}`.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [accessories, search, category, mount, discontinued, priceRange]);
+
+  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Accessory, AccessorySortKey>(filtered, "category");
+
+  const hasFilters = search || category || mount || discontinued || priceRange;
+
+  function clearFilters(): void {
+    setSearch("");
+    setCategory("");
+    setMount("");
+    setDiscontinued("");
+    setPriceRange("");
+  }
+
+  return (
+    <div>
+      <div className={styles.hero}>
+        <h1 className={styles.heroTitle}>Accessories</h1>
+        <p className={styles.heroSub}>{sorted.length} / {accessories.length} Fujifilm accessories</p>
+      </div>
+      <div className={styles.filters}>
+        <div className={styles.filterTop}>
+          <input
+            className={styles.searchInput}
+            type="text"
+            placeholder="Search accessories..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search accessories"
+          />
+          {hasFilters && (
+            <button
+              className={styles.clearButton}
+              onClick={clearFilters}
+              type="button"
+              aria-label="Clear all filters"
+            >
+              &#x2715; Clear
+            </button>
+          )}
+        </div>
+
+        <div className={styles.filterRow}>
+          <select className={`${styles.filterSelect} ${category ? styles.filterActive : ""}`} value={category} onChange={(e) => setCategory(resetValue(e.target.value))} aria-label="Filter by category">
+            <option value="" hidden>Category</option>
+            <option value={RESET_VALUE}>All categories</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>{formatCategory(c)}</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${priceRange ? styles.filterActive : ""}`} value={priceRange} onChange={(e) => setPriceRange(resetValue(e.target.value))} aria-label="Filter by price">
+            <option value="" hidden>Price</option>
+            <option value={RESET_VALUE}>All</option>
+            <option value="0-250">Under $250</option>
+            <option value="250-500">$250 - $500</option>
+            <option value="500-1000">$500 - $1,000</option>
+            <option value="1000+">$1,000+</option>
+          </select>
+        </div>
+
+        <div className={styles.chipRow}>
+          <ChipGroup label="Mount" value={mount} onChange={setMount} styles={styles} options={[
+            { label: "All", value: "" }, { label: "X", value: "X" }, { label: "GFX", value: "GFX" },
+          ]} />
+          <ChipGroup label="Status" value={discontinued} onChange={setDiscontinued} styles={styles} options={[
+            { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
+          ]} />
+        </div>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className={styles.emptyState}>No accessories match the current filters.</p>
+      ) : (
+        <>
+          {/* Table — desktop */}
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  {COLUMNS.map((col) => (
+                    <th
+                      key={col.key}
+                      className={ALIGN_CLASSES[col.align]}
+                      onClick={() => toggleSort(col.key)}
+                      aria-sort={
+                        sortKey === col.key
+                          ? sortDirection === "asc" ? "ascending" : "descending"
+                          : "none"
+                      }
+                    >
+                      {col.label}
+                      <span className={styles.sortIndicator}>
+                        {sortKey === col.key
+                          ? (sortDirection === "asc" ? "\u2191" : "\u2193")
+                          : "\u2195"}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((acc) => (
+                  <tr key={`${acc.brand}-${acc.model}`} className={acc.isDiscontinued ? styles.rowDiscontinued : undefined}>
+                    <td><span className={styles.categoryBadge}>{formatCategory(acc.category)}</span></td>
+                    <td>{acc.brand}</td>
+                    <td className={styles.modelCell}>{acc.model}</td>
+                    <td className={styles.descriptionCell}>{acc.description}</td>
+                    <td className={styles.cellRight}>~${acc.price}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards — mobile */}
+          <div className={styles.cards}>
+            {sorted.map((acc) => (
+              <div key={`${acc.brand}-${acc.model}`} className={`${styles.card} ${acc.isDiscontinued ? styles.cardDiscontinued : ""}`}>
+                <div className={styles.cardHeader}>
+                  <span className={styles.cardTitle}>{acc.brand} {acc.model}</span>
+                  <span className={styles.cardPrice}>~${acc.price}</span>
+                </div>
+                <p className={styles.cardDescription}>{acc.description}</p>
+                <div className={styles.cardBadges}>
+                  <span className={styles.badge}>{formatCategory(acc.category)}</span>
+                  {"mount" in acc && acc.mount && <span className={styles.badge}>{acc.mount}</span>}
+                  {acc.isDiscontinued && <span className={styles.badge}>Discontinued</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <p className={styles.footnote}>
+        All prices are approximate USD estimates.
+        See <a href="/trade-deals">Trade Deals</a> for current market rates.
+      </p>
+    </div>
+  );
+}
+
+export default AccessoriesExplorer;

--- a/src/pages/accessories.astro
+++ b/src/pages/accessories.astro
@@ -1,9 +1,9 @@
 ---
 import Base from "../layouts/Base.astro";
 import accessories from "../data/accessories";
+import AccessoriesExplorer from "../components/interactive/AccessoriesExplorer/AccessoriesExplorer";
 ---
 
 <Base title="Accessories — Fuji.me!" description="Fujifilm accessories: flashes, grips, batteries, adapters, and more.">
-  <h1>Accessories</h1>
-  <p>{accessories.length} accessories in the database.</p>
+  <AccessoriesExplorer client:load accessories={accessories} />
 </Base>


### PR DESCRIPTION
## Summary
- Accessories Explorer at `/accessories` — 5 sortable columns, category/price/mount/status filters
- Search covers brand, model, and description text
- Category badges, description wrapping, mobile cards
- Update ADR-012 with lensing.me domain candidate
- Part of #105

## Data quality
- Accessory prices need audit (#110) — most are $250 placeholder values

## Test plan
- [x] `npm run check:all` — 0 errors, 258 pages
- [x] Category filter works across all 11 categories
- [x] Mount filter correctly handles accessories with/without mount field

🤖 Generated with [Claude Code](https://claude.com/claude-code)