### PR TITLE
feat: add macro genre to pages and tabs

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -85,11 +85,11 @@ describe("GenreGuide", () => {
     expect(screen.getByRole("heading", { name: "Astrophotography" })).toBeInTheDocument();
   });
 
-  it("shows genre tabs for all 8 genres", () => {
+  it("shows genre tabs for all 9 genres", () => {
     render(<GenreGuide lenses={testLenses} />);
     const tablist = screen.getByRole("tablist");
     const tabs = within(tablist).getAllByRole("tab");
-    expect(tabs).toHaveLength(8);
+    expect(tabs).toHaveLength(9);
   });
 
   it("switches genre when tab is clicked", async () => {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -37,7 +37,7 @@ const ND_OPTIONS = [
 
 const SCORED_GENRES: ScoredGenre[] = [
   "astro", "landscape", "architecture", "street",
-  "travel", "portrait", "sport", "wildlife",
+  "travel", "portrait", "sport", "wildlife", "macro",
 ];
 
 const FL_CHIPS: Record<string, { label: string; fl: number }[]> = {

--- a/src/pages/genre/[genre].astro
+++ b/src/pages/genre/[genre].astro
@@ -9,7 +9,7 @@ import { lenses } from "../../data/lenses";
 export const getStaticPaths = (() => {
   const genres: ScoredGenre[] = [
     "astro", "landscape", "architecture", "street",
-    "travel", "portrait", "sport", "wildlife",
+    "travel", "portrait", "sport", "wildlife", "macro",
   ];
   return genres.map((genre) => ({
     params: { genre },

--- a/src/pages/genre/index.astro
+++ b/src/pages/genre/index.astro
@@ -15,7 +15,7 @@ const genres = Object.values(genreConfigs).map((config) => ({
 <Base title="Genre Guide — Fuji.me!" description="Explore the best Fujifilm lenses for each photography genre, scored by optical suitability.">
   <div class="hero">
     <h1>Genre Guide</h1>
-    <p class="hero-sub">8 photography genres. Find the best optics for your style.</p>
+    <p class="hero-sub">9 photography genres. Find the best optics for your style.</p>
   </div>
 
   <div class="genre-grid">


### PR DESCRIPTION
## Summary

- Add macro to genre static paths so `/genre/macro` renders
- Add macro tab to GenreGuide component
- Update genre index to say "9 photography genres"
- Fix test expecting 8 tabs → 9

## Test plan

- [x] `npm test` — 81 tests pass
- [x] `/genre/` shows 9 genre cards
- [x] `/genre/macro` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)