### PR TITLE
fix: consistent mark pips for full and half steps

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -253,9 +253,17 @@
    ========================================================================== */
 
 .markDots {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.1em;
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.pip {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-text-muted);
 }
 
 .markDash {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -99,9 +99,18 @@ function MarkPips({ mark }: { mark: number | null }) {
   const full = Math.floor(mark);
   const half = mark % 1 >= 0.5;
   const color = MARK_PALETTE[Math.ceil(mark)] || "#8a8070";
+  const pips: React.ReactNode[] = [];
+  for (let i = 0; i < full; i++) {
+    pips.push(<span key={i} className={styles.pip} style={{ backgroundColor: color }} />);
+  }
+  if (half) {
+    pips.push(
+      <span key="half" className={styles.pip} style={{ background: `linear-gradient(to right, ${color} 50%, transparent 50%)` }} />
+    );
+  }
   return (
-    <span className={styles.markDots} style={{ color }} aria-label={`Mark ${mark} of 5`}>
-      {"●".repeat(full)}{half ? "◐" : ""}
+    <span className={styles.markDots} aria-label={`Mark ${mark} of 5`}>
+      {pips}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Replace mixed Unicode symbols (● and ◐) with CSS-based circles. Each pip is an identical 8px circle — full pips solid-filled, half pips use a 50% linear gradient. Consistent size and rendering across all marks.

## Test plan

- [x] `npm test` — 94 tests pass
- [ ] Visual: mark 4.5 shows 4 full + 1 half circle, all same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)