### PR TITLE
fix: mark pips use chip color scheme

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -263,7 +263,17 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  border: 1.5px solid var(--color-text-muted);
+  border: 1.5px solid var(--color-border);
+}
+
+.pipFull {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.pipHalf {
+  background: linear-gradient(to right, var(--color-accent) 50%, transparent 50%);
+  border-color: var(--color-accent);
 }
 
 .markDash {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -25,7 +25,6 @@ interface GenreGuideProps {
 // CONSTANTS
 // =============================================================================
 
-const MARK_PALETTE = ["", "#2a2520", "#4a4540", "#7a7060", "#c08830", "#e8a045"];
 const ISO_OPTIONS = [100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600];
 const ND_OPTIONS = [
   { label: "ND2", factor: 2 },
@@ -98,15 +97,12 @@ function MarkPips({ mark }: { mark: number | null }) {
   if (mark == null) return <span className={styles.markDash}>&ndash;</span>;
   const full = Math.floor(mark);
   const half = mark % 1 >= 0.5;
-  const color = MARK_PALETTE[Math.ceil(mark)] || "#8a8070";
   const pips: React.ReactNode[] = [];
   for (let i = 0; i < full; i++) {
-    pips.push(<span key={i} className={styles.pip} style={{ backgroundColor: color }} />);
+    pips.push(<span key={i} className={`${styles.pip} ${styles.pipFull}`} />);
   }
   if (half) {
-    pips.push(
-      <span key="half" className={styles.pip} style={{ background: `linear-gradient(to right, ${color} 50%, transparent 50%)` }} />
-    );
+    pips.push(<span key="half" className={`${styles.pip} ${styles.pipHalf}`} />);
   }
   return (
     <span className={styles.markDots} aria-label={`Mark ${mark} of 5`}>


### PR DESCRIPTION
## Summary

- Replace hardcoded per-mark color palette with theme CSS variables
- Full pips: `var(--color-accent)` fill + border (matches active chip)
- Half pips: 50% accent gradient + accent border
- Empty border: `var(--color-border)` (matches inactive chip)
- Remove unused `MARK_PALETTE` constant

## Test plan

- [x] `npm test` — 94 tests pass
- [ ] Visual: pips use same golden accent as active chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)