### PR TITLE
fix: align marks left, update genre descriptions to match formulas

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -408,7 +408,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
                       className={
                         key === "weight" || key === "price" || key === "idealIso"
                           ? styles.cellRight
-                          : key === "mark" || key === "pick"
+                          : key === "pick"
                             ? styles.cellCenter
                             : undefined
                       }
@@ -423,7 +423,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
               <tbody>
                 {enrichedLenses.map((el) => (
                   <tr key={`${el.lens.brand}-${el.lens.model}`}>
-                    <td className={styles.cellCenter}><MarkPips mark={el.mark} /></td>
+                    <td><MarkPips mark={el.mark} /></td>
                     <td className={styles.cellCenter}><PickStar isPick={el.isPick} /></td>
                     <td>{el.lens.brand}</td>
                     <td>

--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -11,7 +11,7 @@ const genreConfigs: Record<ScoredGenre, GenreConfig> = {
     name: "Astrophotography",
     tagline: "Untracked tripod · Beat the startrails · 500 rule",
     description:
-      "Wide-field and deep-sky imaging on a fixed tripod. Fast apertures and sharp corners matter most.",
+      "Wide-field and deep-sky imaging on a fixed tripod. Low coma, low astigmatism, and fast apertures matter most.",
     typicalFl: ["ultra-wide", "wide"],
   },
   landscape: {
@@ -27,7 +27,7 @@ const genreConfigs: Record<ScoredGenre, GenreConfig> = {
     name: "Architecture Photography",
     tagline: "Tripod · maximize depth of field · sweet spot at f/8",
     description:
-      "Geometric precision with minimal distortion. Tilt-shift capability and corner-to-corner sharpness are prized.",
+      "Geometric precision with minimal distortion and corner-to-corner sharpness at stopped-down apertures.",
     typicalFl: ["ultra-wide", "wide"],
   },
   street: {
@@ -35,7 +35,7 @@ const genreConfigs: Record<ScoredGenre, GenreConfig> = {
     name: "Street Photography",
     tagline: "Handheld · capture the moment · 1/FL rule",
     description:
-      "Fast, discreet shooting in variable light. Compact size and wide aperture for low-light handheld work.",
+      "Sharp at the sweet spot and fast enough for low light. Stopped-down sharpness and wide aperture matter most.",
     typicalFl: ["wide", "standard"],
   },
   travel: {
@@ -59,7 +59,7 @@ const genreConfigs: Record<ScoredGenre, GenreConfig> = {
     name: "Sport Photography",
     tagline: "Handheld · freeze motion · 4x FL rule",
     description:
-      "Fast autofocus and high shutter speeds to freeze action. Long reach and tracking performance matter.",
+      "Sharp wide open to freeze action at fast shutter speeds. Wide-open center sharpness matters most.",
     typicalFl: ["standard", "tele"],
   },
   wildlife: {
@@ -67,7 +67,7 @@ const genreConfigs: Record<ScoredGenre, GenreConfig> = {
     name: "Wildlife Photography",
     tagline: "Handheld · capture behaviour · 4x FL rule",
     description:
-      "Long reach with sharp optics to photograph animals at distance. Teleconverter compatibility is a plus.",
+      "Sharp both wide open and stopped down for distant subjects. Center sharpness across apertures matters most.",
     typicalFl: ["tele", "super-tele"],
   },
   macro: {


### PR DESCRIPTION
## Summary

- Mark column left-aligned in table (was centered)
- 5 genre descriptions updated to reflect actual scoring primaries instead of features (AF, tilt-shift, compact size) that are not scoring inputs

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)