### PR TITLE
fix: improve scoring methodology footnotes

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -470,9 +470,10 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
       )}
 
       <p className={styles.footnote}>
-        Marks represent optical suitability (sharpness, coma, bokeh). OIS, WR, AF,
-        and weight are display attributes and do not affect the mark. Focal length is a
-        creative choice, not a scoring criterion. All prices are approximate USD estimates.
+        Marks score optical suitability only — resolution, aberrations, bokeh quality —
+        from lab measurements and trusted field reviews. OIS, autofocus, weather sealing,
+        and build quality do not affect the mark. Focal length is a creative choice shown
+        as a filter, not a scoring input. Prices are approximate USD estimates.
       </p>
     </div>
   );

--- a/src/pages/genre/index.astro
+++ b/src/pages/genre/index.astro
@@ -31,9 +31,10 @@ const genres = Object.values(genreConfigs).map((config) => ({
   </div>
 
   <p class="footnote">
-    Marks represent optical suitability — sharpness, coma, bokeh, MTF — not feature perks.
-    OIS, WR, AF, and weight are display attributes shown alongside scores but do not affect the mark.
-    Focal length is a creative choice, not a scoring criterion.
+    Marks score optical suitability only — resolution, aberrations, bokeh quality —
+    from lab measurements and trusted field reviews. OIS, autofocus, weather sealing,
+    and build quality do not affect the mark. Focal length is a creative choice shown
+    as a filter, not a scoring input.
   </p>
 </Base>
 


### PR DESCRIPTION
## Summary

Clarify scoring footnotes across genre index and GenreGuide to precisely describe what marks measure and their data sources.

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)