### PR TITLE
feat: add astro exposure matrix from prototype

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -249,6 +249,97 @@
 }
 
 /* ==========================================================================
+   Exposure matrix — astro rule-of-500 grid
+   ========================================================================== */
+
+.matrix {
+  margin-bottom: var(--space-md);
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md);
+}
+
+.matrixTitle {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-sm);
+}
+
+.matrixScroll {
+  overflow-x: auto;
+}
+
+.matrixTable {
+  border-collapse: collapse;
+  font-size: 10px;
+  font-family: var(--font-mono);
+}
+
+.matrixCorner {
+  padding: 4px 8px;
+  color: var(--color-text-muted);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.matrixColHead {
+  padding: 4px 8px;
+  color: var(--color-text-muted);
+  text-align: center;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.matrixRowHead {
+  padding: 4px 8px;
+  color: var(--color-accent);
+  border-right: 1px solid var(--color-border);
+}
+
+.matrixCell {
+  padding: 4px 8px;
+  text-align: center;
+}
+
+.matrixViable {
+  background-color: #0e180e;
+  color: #6aaa70;
+  font-weight: 600;
+}
+
+.matrixMarginal {
+  background-color: #181610;
+  color: #b09040;
+}
+
+.matrixOver {
+  background-color: #180e0e;
+  color: #905030;
+}
+
+.matrixLegend {
+  margin-top: var(--space-sm);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.matrixViableText {
+  color: #6aaa70;
+}
+
+.matrixMarginalText {
+  color: #b09040;
+}
+
+.matrixOverText {
+  color: #905030;
+}
+
+/* ==========================================================================
    Mark pips
    ========================================================================== */
 

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -117,6 +117,73 @@ function PickStar({ isPick }: { isPick: boolean }) {
 }
 
 // =============================================================================
+// EXPOSURE MATRIX — astro rule-of-500 grid
+// =============================================================================
+
+const MATRIX_FL_COLS: Record<number, number[]> = {
+  12:  [6, 8, 10, 12, 14, 16],
+  24:  [18, 21, 24, 28, 35],
+  50:  [35, 40, 50, 56],
+  135: [75, 85, 100, 135],
+  300: [200, 300, 400],
+};
+
+const MATRIX_APERTURES = [1.0, 1.2, 1.4, 1.8, 2.0, 2.8, 4.0];
+
+function ExposureMatrix({ crop, iso, ev, aoV }: { crop: number; iso: number; ev: number; aoV: number }) {
+  const cols = MATRIX_FL_COLS[aoV] || MATRIX_FL_COLS[12];
+
+  return (
+    <div className={styles.matrix}>
+      <div className={styles.matrixTitle}>
+        Rule of 500 · untracked · ISO {iso}
+      </div>
+      <div className={styles.matrixScroll}>
+        <table className={styles.matrixTable}>
+          <thead>
+            <tr>
+              <th className={styles.matrixCorner}>f/</th>
+              {cols.map((fl) => (
+                <th key={fl} className={styles.matrixColHead}>{fl}mm</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {MATRIX_APERTURES.map((ap) => (
+              <tr key={ap}>
+                <td className={styles.matrixRowHead}>{ap}</td>
+                {cols.map((fl) => {
+                  const maxT = Math.round(500 / (crop * fl));
+                  const needed = Math.round((ap * ap * 100) / (maxT * Math.pow(2, ev)));
+                  const viable = needed <= iso;
+                  const marginal = !viable && needed <= iso * 1.5;
+                  const label = maxT >= 60 ? `${Math.round(maxT / 60)}m` : `${maxT}s`;
+                  const cls = viable
+                    ? styles.matrixViable
+                    : marginal
+                      ? styles.matrixMarginal
+                      : styles.matrixOver;
+                  return (
+                    <td key={fl} className={`${styles.matrixCell} ${cls}`}>
+                      {label}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className={styles.matrixLegend}>
+        <span className={styles.matrixViableText}>●</span> within ISO{" "}
+        <span className={styles.matrixMarginalText}>●</span> within 1 stop{" "}
+        <span className={styles.matrixOverText}>●</span> needs more ISO
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
 // MAIN COMPONENT
 // =============================================================================
 
@@ -379,6 +446,9 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
           </div>
         </div>
       </div>
+
+      {/* Astro exposure matrix */}
+      {isAstro && <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />}
 
       {/* Results count */}
       <p className={styles.resultCount}>


### PR DESCRIPTION
## Summary

Port the rule-of-500 exposure grid from the prototype to the GenreGuide component. Shows max exposure time by aperture x focal length, color-coded by ISO viability (green/amber/red). Only renders for the astro genre.

## Test plan

- [x] `npm test` — 94 tests pass
- [ ] Visual: `/genre/astro` shows exposure matrix between controls and lens list
- [ ] FL chips change the matrix columns
- [ ] ISO/crop changes update the color coding

🤖 Generated with [Claude Code](https://claude.com/claude-code)