### PR TITLE
fix: exposure matrix layout — inside controls, mobile-friendly

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -253,11 +253,9 @@
    ========================================================================== */
 
 .matrix {
-  margin-bottom: var(--space-md);
-  background-color: var(--color-bg-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  padding: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-sm);
+  margin-top: var(--space-sm);
 }
 
 .matrixTitle {
@@ -277,6 +275,7 @@
   border-collapse: collapse;
   font-size: 10px;
   font-family: var(--font-mono);
+  width: 100%;
 }
 
 .matrixCorner {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -445,10 +445,10 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
             ))}
           </div>
         </div>
-      </div>
 
-      {/* Astro exposure matrix */}
-      {isAstro && <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />}
+        {/* Astro exposure matrix — inside controls panel */}
+        {isAstro && <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />}
+      </div>
 
       {/* Results count */}
       <p className={styles.resultCount}>


### PR DESCRIPTION
## Summary

- Move exposure matrix inside the controls panel (was a separate card)
- Remove double-border/padding — uses top border separator instead
- Table fills width on mobile

## Test plan

- [x] `npm test` — 94 tests pass
- [ ] Visual: matrix flows naturally within controls on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)