### PR TITLE
fix: maximize GenreGuide screener width

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -58,31 +58,6 @@
   color: var(--color-bg);
 }
 
-/* ==========================================================================
-   Genre header
-   ========================================================================== */
-
-.genreHeader {
-  margin-bottom: var(--space-md);
-}
-
-.genreName {
-  font-size: var(--font-size-xl);
-  font-weight: 700;
-  margin-bottom: var(--space-xs);
-}
-
-.genreLabel {
-  font-size: var(--font-size-sm);
-  color: var(--color-accent);
-  font-family: var(--font-mono);
-  margin-bottom: var(--space-xs);
-}
-
-.genreDesc {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-}
 
 /* ==========================================================================
    Two-column layout
@@ -544,8 +519,8 @@
 @media (min-width: 640px) {
   .layout {
     display: grid;
-    grid-template-columns: 220px 1fr;
-    gap: var(--space-md);
+    grid-template-columns: 190px 1fr;
+    gap: var(--space-sm);
   }
 
   .tableWrap {

--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -77,12 +77,12 @@ const testLenses: Lens[] = [
 describe("GenreGuide", () => {
   it("renders with default genre (street)", () => {
     render(<GenreGuide lenses={testLenses} />);
-    expect(screen.getByRole("heading", { name: "Street Photography" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /street/i, selected: true })).toBeInTheDocument();
   });
 
   it("renders with a specified default genre", () => {
     render(<GenreGuide lenses={testLenses} defaultGenre="astro" />);
-    expect(screen.getByRole("heading", { name: "Astrophotography" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /astro/i, selected: true })).toBeInTheDocument();
   });
 
   it("shows genre tabs for all 9 genres", () => {
@@ -97,7 +97,7 @@ describe("GenreGuide", () => {
     render(<GenreGuide lenses={testLenses} />);
 
     await user.click(screen.getByRole("tab", { name: /portrait/i }));
-    expect(screen.getByRole("heading", { name: "Portrait Photography" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /portrait/i, selected: true })).toBeInTheDocument();
   });
 
   it("shows mark pips for scored lenses", () => {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -362,13 +362,6 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
         ))}
       </div>
 
-      {/* Genre header */}
-      <div className={styles.genreHeader}>
-        <h2 className={styles.genreName}>{config.name}</h2>
-        <p className={styles.genreLabel}>{config.tagline}</p>
-        <p className={styles.genreDesc}>{config.description}</p>
-      </div>
-
       {/* Two-column layout: sidebar + main */}
       <div className={styles.layout}>
 


### PR DESCRIPTION
## Summary

- Narrow sidebar (190px), tighter gap — gives lens table more room
- Remove redundant genre header (tabs + EV header already show genre info)
- Tests updated to check active tab state instead of removed heading

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)