### PR TITLE
fix: chips inline with label

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -136,8 +136,8 @@
 
 .controlGroup {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
+  align-items: center;
+  gap: var(--space-sm);
 }
 
 .controlLabel {


### PR DESCRIPTION
## Summary

Chip buttons now sit to the right of their label (Mount, FL, ISO, ND) instead of below.

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)