### PR TITLE
fix: control row spacing + Astro tab label

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -130,7 +130,7 @@
 .controls {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: 10px;
   margin-bottom: var(--space-sm);
 }
 

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -356,7 +356,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
             className={`${styles.genreTab} ${genre === g ? styles.genreTabActive : ""}`}
             onClick={() => handleGenreChange(g)}
           >
-            {genreConfigs[g].name.replace(" Photography", "")}
+            {genreConfigs[g].name.replace("photography", "").replace(" Photography", "").trim()}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary

- More spacing between control rows (10px gap)
- "Astrophotography" tab renamed to "Astro"

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)