### PR TITLE
fix: wrap scene title, chips, matrix in panel

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -106,8 +106,8 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: var(--space-sm);
-  padding-bottom: var(--space-sm);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -121,6 +121,16 @@
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--color-text-muted);
+}
+
+/* ==========================================================================
+   Control panel — wraps EV header + chips + matrix
+   ========================================================================== */
+
+.controlPanel {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  padding: 10px 14px;
 }
 
 /* ==========================================================================

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -396,6 +396,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
 
         {/* Right: controls + matrix + results */}
         <div className={styles.main}>
+          <div className={styles.controlPanel}>
           {/* EV header */}
           <div className={styles.evHeader}>
             <span className={styles.evLabel}>EV {ev} — {sceneLabel(ev)}</span>
@@ -482,6 +483,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
 
           {/* Astro exposure matrix */}
           {isAstro && <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />}
+          </div>{/* end controlPanel */}
         </div>{/* end main */}
       </div>{/* end layout */}
 


### PR DESCRIPTION
## Summary

Group EV header + controls + exposure matrix in a single dark panel, matching the prototype's right-column container.

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)