### PR TITLE
feat: filter panel + separate matrix panel

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -279,10 +279,35 @@
    Results
    ========================================================================== */
 
-.resultCount {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+/* ==========================================================================
+   Filter panel — above lens table
+   ========================================================================== */
+
+.filterPanel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
   margin-bottom: var(--space-sm);
+}
+
+.clearBtn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  cursor: pointer;
+  padding: 2px 6px;
+}
+
+.clearBtn:hover {
+  color: var(--color-text);
 }
 
 .emptyState {
@@ -295,8 +320,15 @@
    Exposure matrix — astro rule-of-500 grid
    ========================================================================== */
 
+.matrixPanel {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  padding: 10px 14px;
+  margin-top: var(--space-sm);
+}
+
 .matrix {
-  margin-top: var(--space-xs);
+  /* no extra spacing — inside matrixPanel */
 }
 
 .matrixTitle {

--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -106,9 +106,10 @@ describe("GenreGuide", () => {
     expect(pips.length).toBeGreaterThan(0);
   });
 
-  it("shows lens count", () => {
+  it("shows filter panel with dropdowns", () => {
     render(<GenreGuide lenses={testLenses} defaultGenre="portrait" />);
-    expect(screen.getByText(/\d+ lens/)).toBeInTheDocument();
+    // Filter panel has Brand, Mark, Price, Weight labels
+    expect(screen.getAllByText("Mark").length).toBeGreaterThanOrEqual(2); // filter + table header
   });
 
   it("displays footnote about scoring methodology", () => {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -210,6 +210,10 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
   const [aoV, setAoV] = useState(defaults.fl);
   const [sortBy, setSortBy] = useState<SortKey>("mark");
   const [sortAsc, setSortAsc] = useState(false);
+  const [brandFilter, setBrandFilter] = useState("");
+  const [markFilter, setMarkFilter] = useState("");
+  const [priceFilter, setPriceFilter] = useState("");
+  const [weightFilter, setWeightFilter] = useState("");
   const sceneListRef = useRef<HTMLDivElement>(null);
 
   const config = genreConfigs[genre];
@@ -225,6 +229,10 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
     setNd([]);
     setSortBy("mark");
     setSortAsc(false);
+    setBrandFilter("");
+    setMarkFilter("");
+    setPriceFilter("");
+    setWeightFilter("");
   }
 
   // ── Scene scroll ───────────────────────────────────────────────────────
@@ -297,8 +305,15 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
       return sortAsc ? v : -v;
     });
 
-    return enriched;
-  }, [lenses, genre, crop, ev, iso, mp, sortBy, sortAsc, isAstro]);
+    // Apply filters
+    return enriched.filter((el) => {
+      if (brandFilter && el.lens.brand !== brandFilter) return false;
+      if (markFilter && el.mark < Number(markFilter)) return false;
+      if (priceFilter && el.lens.price > Number(priceFilter)) return false;
+      if (weightFilter && el.lens.weight > Number(weightFilter)) return false;
+      return true;
+    });
+  }, [lenses, genre, crop, ev, iso, mp, sortBy, sortAsc, isAstro, brandFilter, markFilter, priceFilter, weightFilter]);
 
   // ── Sort handler ───────────────────────────────────────────────────────
   function handleSort(key: SortKey): void {
@@ -481,16 +496,81 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
             )}
           </div>
 
-          {/* Astro exposure matrix */}
-          {isAstro && <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />}
           </div>{/* end controlPanel */}
+
+          {/* Exposure matrix — separate panel */}
+          {isAstro && (
+            <div className={styles.matrixPanel}>
+              <ExposureMatrix crop={crop} iso={iso} ev={ev} aoV={aoV} />
+            </div>
+          )}
         </div>{/* end main */}
       </div>{/* end layout */}
 
-      {/* Results — full width below the grid */}
-      <p className={styles.resultCount}>
-        {enrichedLenses.length} lens{enrichedLenses.length !== 1 ? "es" : ""}
-      </p>
+      {/* Filter panel — full width */}
+      <div className={styles.filterPanel}>
+        <div className={styles.controlGroup}>
+          <span className={styles.controlLabel}>Brand</span>
+          <select
+            className={styles.controlSelect}
+            value={brandFilter}
+            onChange={(e) => setBrandFilter(e.target.value)}
+          >
+            <option value="">All</option>
+            {[...new Set(enrichedLenses.map((el) => el.lens.brand))].sort().map((b) => (
+              <option key={b} value={b}>{b}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.controlGroup}>
+          <span className={styles.controlLabel}>Mark</span>
+          <select
+            className={styles.controlSelect}
+            value={markFilter}
+            onChange={(e) => setMarkFilter(e.target.value)}
+          >
+            <option value="">All</option>
+            {[5, 4.5, 4, 3.5, 3, 2.5, 2, 1.5, 1].map((v) => (
+              <option key={v} value={v}>≥ {v}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.controlGroup}>
+          <span className={styles.controlLabel}>Price</span>
+          <select
+            className={styles.controlSelect}
+            value={priceFilter}
+            onChange={(e) => setPriceFilter(e.target.value)}
+          >
+            <option value="">Any</option>
+            {[500, 1000, 1500, 2000, 4000].map((v) => (
+              <option key={v} value={v}>≤ ~${v}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.controlGroup}>
+          <span className={styles.controlLabel}>Weight</span>
+          <select
+            className={styles.controlSelect}
+            value={weightFilter}
+            onChange={(e) => setWeightFilter(e.target.value)}
+          >
+            <option value="">Any</option>
+            {[200, 300, 500, 800, 1500].map((v) => (
+              <option key={v} value={v}>≤ {v}g</option>
+            ))}
+          </select>
+        </div>
+        {(brandFilter || markFilter || priceFilter || weightFilter) && (
+          <button
+            type="button"
+            className={styles.clearBtn}
+            onClick={() => { setBrandFilter(""); setMarkFilter(""); setPriceFilter(""); setWeightFilter(""); }}
+          >
+            ✕ clear
+          </button>
+        )}
+      </div>
 
       {enrichedLenses.length === 0 ? (
         <p className={styles.emptyState}>No lenses match the current settings.</p>


### PR DESCRIPTION
## Summary

- Filter panel with Brand, Mark, Price, Weight dropdowns + clear button
- Exposure matrix moved to its own panel (better on mobile)
- Lens counter removed (redundant)
- Filters reset on genre change

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)