### PR TITLE
fix: equipment font size matching prototype

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -93,7 +93,7 @@
 
 .equipmentList {
   padding: 8px 10px;
-  font-size: var(--font-size-sm);
+  font-size: 11px;
   color: var(--color-text-muted);
   line-height: 1.6;
 }


### PR DESCRIPTION
Equipment panel font 14px → 11px to match prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)