### PR TITLE
fix: consistent 14px font for equipment and matrix

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -93,7 +93,7 @@
 
 .equipmentList {
   padding: 8px 10px;
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   line-height: 1.6;
 }
@@ -332,7 +332,7 @@
 }
 
 .matrixTitle {
-  font-size: 10px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   font-family: var(--font-mono);
   text-transform: uppercase;
@@ -346,7 +346,7 @@
 
 .matrixTable {
   border-collapse: collapse;
-  font-size: 10px;
+  font-size: var(--font-size-sm);
   font-family: var(--font-mono);
   width: 100%;
 }
@@ -394,7 +394,7 @@
 
 .matrixLegend {
   margin-top: var(--space-sm);
-  font-size: 10px;
+  font-size: var(--font-size-sm);
   font-family: var(--font-mono);
   color: var(--color-text-muted);
 }


### PR DESCRIPTION
## Summary

Revert equipment panel to 14px (was 11px). Bump EV matrix title, table, and legend from 10px to 14px. Better readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)