### PR TITLE
fix: astro dynamic ISO in EV header tagline

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -436,7 +436,11 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
           {/* EV header */}
           <div className={styles.evHeader}>
             <span className={styles.evLabel}>EV {ev} — {sceneLabel(ev)}</span>
-            <span className={styles.evTagline}>{config.tagline}</span>
+            <span className={styles.evTagline}>
+              {isAstro
+                ? `Untracked · Rule of 500 · ISO ${iso}`
+                : config.tagline}
+            </span>
           </div>
 
           {/* Controls — matching prototype order: Mount → FL → ISO → ND → MP */}


### PR DESCRIPTION
Astro EV header tagline now shows current ISO dynamically: \"Untracked · Rule of 500 · ISO 1600\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)