### PR TITLE
fix: EV header tagline visible

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -106,6 +106,8 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
   margin-bottom: 12px;
   padding-bottom: 8px;
   border-bottom: 1px solid var(--color-border);
@@ -119,7 +121,7 @@
 
 .evTagline {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 


### PR DESCRIPTION
Tagline bumped from 10px to 14px, flex-wrap added so it wraps on narrow panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)