### PR TITLE
fix: sidebar and matrix bottom-aligned

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -76,6 +76,10 @@
   gap: var(--space-sm);
 }
 
+.sidebar .sidebarPanel:last-child {
+  flex: 1;
+}
+
 .sidebarPanel {
   background-color: var(--color-bg-surface);
   border: 1px solid var(--color-border);
@@ -100,6 +104,13 @@
 
 .main {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.main .matrixPanel {
+  flex: 1;
 }
 
 .evHeader {
@@ -326,7 +337,6 @@
   background-color: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   padding: 10px 14px;
-  margin-top: var(--space-sm);
 }
 
 .matrix {


### PR DESCRIPTION
Equipment panel and matrix panel now stretch to fill their columns, aligning at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)