### PR TITLE
fix: remove duplicate tagline from EV header

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -436,11 +436,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
           {/* EV header */}
           <div className={styles.evHeader}>
             <span className={styles.evLabel}>EV {ev} — {sceneLabel(ev)}</span>
-            <span className={styles.evTagline}>
-              {isAstro
-                ? `Untracked · Rule of 500 · ISO ${iso}`
-                : config.tagline}
-            </span>
+            <span className={styles.evTagline}>{config.tagline}</span>
           </div>
 
           {/* Controls — matching prototype order: Mount → FL → ISO → ND → MP */}


### PR DESCRIPTION
EV header reverts to static genre tagline. Dynamic ISO info stays on the matrix title only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)