### PR TITLE
fix: remove tagline from EV header

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -436,7 +436,6 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
           {/* EV header */}
           <div className={styles.evHeader}>
             <span className={styles.evLabel}>EV {ev} — {sceneLabel(ev)}</span>
-            <span className={styles.evTagline}>{config.tagline}</span>
           </div>
 
           {/* Controls — matching prototype order: Mount → FL → ISO → ND → MP */}


### PR DESCRIPTION
EV header shows only scene info. Genre tagline removed — redundant with tab + matrix title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)