### PR TITLE
fix: add explanation text below EV matrix

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -423,6 +423,13 @@
   color: #905030;
 }
 
+.matrixExplain {
+  margin-top: var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
 /* ==========================================================================
    Mark pips
    ========================================================================== */

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -205,6 +205,13 @@ function ExposureMatrix({ crop, iso, ev, aoV }: { crop: number; iso: number; ev:
         <span className={styles.matrixMarginalText}>●</span> within 1 stop{" "}
         <span className={styles.matrixOverText}>●</span> needs more ISO
       </div>
+      <p className={styles.matrixExplain}>
+        Max exposure before star trails = 500 / (crop x FL). Each cell shows
+        the longest untracked exposure at that aperture and focal length.
+        Green means your selected ISO is enough. Amber means you are within
+        one stop — push ISO or accept slight noise. Red means the lens
+        cannot gather enough light at this ISO without trailing.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Explains the rule of 500, what each cell shows, and what green/amber/red mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)