### PR TITLE
fix: matrix red explanation wording

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -209,8 +209,8 @@ function ExposureMatrix({ crop, iso, ev, aoV }: { crop: number; iso: number; ev:
         Max exposure before star trails = 500 / (crop x FL). Each cell shows
         the longest untracked exposure at that aperture and focal length.
         Green means your selected ISO is enough. Amber means you are within
-        one stop — push ISO or accept slight noise. Red means the lens
-        cannot gather enough light at this ISO without trailing.
+        one stop — push ISO or accept slight noise. Red means the exposure
+        does not gather enough light at this ISO.
       </p>
     </div>
   );


### PR DESCRIPTION
Red = not enough light at this ISO, not about trailing.