### PR TITLE
feat: astro EV labels describe sky conditions

### DIFF
--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -119,6 +119,18 @@ const evScenes: EvScene[] = [
 // =============================================================================
 
 const genreEvLabels: Partial<Record<ScoredGenre, Record<number, string>>> = {
+  astro: {
+    1: "Heavy light pollution — brightest stars only",
+    0: "Suburban glow — planets and major constellations",
+    [-1]: "Suburban fringe — Milky Way faintly visible",
+    [-2]: "Full moon — washes out faint nebulae",
+    [-3]: "Half moon — Milky Way core visible low on horizon",
+    [-4]: "Crescent moon — Milky Way clearly visible",
+    [-5]: "No moon, slight airglow — deep sky objects emerge",
+    [-6]: "Dark site — Milky Way casts shadows, zodiacal light",
+    [-7]: "Pristine dark site — Milky Way structure, faint nebulae",
+    [-8]: "Exceptional darkness — limiting magnitude 7+",
+  },
   landscape: {
     16: "Snow field / bright beach",
     15: "Sunny open landscape",


### PR DESCRIPTION
## Summary

Add astro-specific EV scene labels that describe what you'd see in the sky at each light level, from heavy light pollution (EV 1) to exceptional darkness (EV -8).

## Test plan

- [x] `npm test` — 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)