### PR TITLE
fix: column header alignment matches values

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -510,12 +510,12 @@
   color: var(--color-text);
 }
 
-.cellRight {
+.table .cellRight {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-.cellCenter {
+.table .cellCenter {
   text-align: center;
 }
 


### PR DESCRIPTION
Specificity fix — .table .cellRight now overrides .table th left-alignment.