### PR TITLE
fix: EV -8 = Dark sky reserve

### DIFF
--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -111,7 +111,7 @@ const evScenes: EvScene[] = [
   { ev: -5, short: "Crescent moon" },
   { ev: -6, short: "Starlight landscape" },
   { ev: -7, short: "Milky Way" },
-  { ev: -8, short: "Deep sky" },
+  { ev: -8, short: "Dark sky reserve" },
 ];
 
 // =============================================================================


### PR DESCRIPTION
Renamed from misleading "Deep sky" to "Dark sky reserve".