### PR TITLE
fix: drop EV -8, Milky Way is darkest scene

### DIFF
--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -111,7 +111,6 @@ const evScenes: EvScene[] = [
   { ev: -5, short: "Crescent moon" },
   { ev: -6, short: "Starlight landscape" },
   { ev: -7, short: "Milky Way" },
-  { ev: -8, short: "Zodiacal light visible" },
 ];
 
 // =============================================================================


### PR DESCRIPTION
No visual landmark for EV -8. Milky Way (EV -7) is now the darkest option.