### PR TITLE
fix: amber wording — noise reduction not noise acceptance

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -228,7 +228,7 @@ function ExposureMatrix({ crop, iso, ev, aoV }: { crop: number; iso: number; ev:
         Max exposure before star trails = 500 / (crop x FL). Each cell shows
         the longest untracked exposure at that aperture and focal length.
         Green means your selected ISO is enough. Amber means you are within
-        one stop — recoverable in post processing with some noise. Red means
+        one stop — recoverable with exposure push and noise reduction. Red means
         the exposure does not gather enough light at this ISO.
       </p>
     </div>


### PR DESCRIPTION
"recoverable with exposure push and noise reduction" instead of "with some noise".