### PR TITLE
fix: rename Astronomy to Nightscape

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -82,7 +82,7 @@ describe("GenreGuide", () => {
 
   it("renders with a specified default genre", () => {
     render(<GenreGuide lenses={testLenses} defaultGenre="astro" />);
-    expect(screen.getByRole("tab", { name: /astro/i, selected: true })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /nightscape/i, selected: true })).toBeInTheDocument();
   });
 
   it("shows genre tabs for all 9 genres", () => {

--- a/src/data/genres.ts
+++ b/src/data/genres.ts
@@ -8,10 +8,10 @@ import type { EvScene } from "../types/common";
 const genreConfigs: Record<ScoredGenre, GenreConfig> = {
   astro: {
     genre: "astro",
-    name: "Astrophotography",
+    name: "Nightscape Photography",
     tagline: "Untracked tripod · Beat the startrails · 500 rule",
     description:
-      "Wide-field and deep-sky imaging on a fixed tripod. Low coma, low astigmatism, and fast apertures matter most.",
+      "Stars, Milky Way, and night landscapes on a fixed tripod. Low coma, low astigmatism, and fast apertures matter most.",
     typicalFl: ["ultra-wide", "wide"],
   },
   landscape: {


### PR DESCRIPTION
Broader label covering stars, Milky Way, nightscapes — not just deep sky.