### PR TITLE
feat: camera and accessory detail pages

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import type { Accessory, AccessoryCategory } from "../../../types/accessory";
 import { useSort } from "../../../hooks/useSort";
+import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
 import styles from "./AccessoriesExplorer.module.css";
@@ -92,7 +93,9 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
     });
   }, [accessories, search, category, mount, compatible, discontinued, priceRange]);
 
-  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Accessory, AccessorySortKey>(filtered, "category");
+  const availableFirst = useCallback((a: Accessory, b: Accessory) =>
+    Number(a.isDiscontinued ?? false) - Number(b.isDiscontinued ?? false), []);
+  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Accessory, AccessorySortKey>(filtered, "category", "asc", availableFirst);
 
   const hasFilters = search || category || mount || compatible || discontinued || priceRange;
 
@@ -206,7 +209,9 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
                   <tr key={`${acc.brand}-${acc.model}`} className={acc.isDiscontinued ? styles.rowDiscontinued : undefined}>
                     <td><span className={styles.categoryBadge}>{formatCategory(acc.category)}</span></td>
                     <td>{acc.brand}</td>
-                    <td className={styles.modelCell}>{acc.model}</td>
+                    <td className={styles.modelCell}>
+                      <a className={styles.lensLink} href={`/accessories/${toSlug(`${acc.brand} ${acc.model}`)}`}>{acc.model}</a>
+                    </td>
                     <td className={styles.descriptionCell}>
                       {acc.description}
                       {"compatibleWith" in acc && Array.isArray(acc.compatibleWith) && (
@@ -229,7 +234,7 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
             {sorted.map((acc) => (
               <div key={`${acc.brand}-${acc.model}`} className={`${styles.card} ${acc.isDiscontinued ? styles.cardDiscontinued : ""}`}>
                 <div className={styles.cardHeader}>
-                  <span className={styles.cardTitle}>{acc.brand} {acc.model}</span>
+                  <a className={styles.lensLink} href={`/accessories/${toSlug(`${acc.brand} ${acc.model}`)}`}>{acc.brand} {acc.model}</a>
                   <span className={styles.cardPrice}>~${acc.price}</span>
                 </div>
                 <p className={styles.cardDescription}>{acc.description}</p>

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from "react";
 import type { Camera } from "../../../types/camera";
 import { useSort } from "../../../hooks/useSort";
+import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
 import styles from "./CameraExplorer.module.css";
@@ -271,7 +272,9 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
               <tbody>
                 {sorted.map((cam) => (
                   <tr key={`${cam.series}-${cam.model}`} className={cam.isDiscontinued ? styles.rowDiscontinued : undefined}>
-                    <td>{cam.model}</td>
+                    <td>
+                      <a className={styles.lensLink} href={`/cameras/${toSlug(cam.model)}`}>{cam.model}</a>
+                    </td>
                     <td className={styles.cellRight}>{cam.year}</td>
                     <td className={styles.cellRight}>{cam.megapixels}</td>
                     <td>{cam.sensor}</td>
@@ -293,7 +296,7 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
             {sorted.map((cam) => (
               <div key={`${cam.series}-${cam.model}`} className={`${styles.card} ${cam.isDiscontinued ? styles.cardDiscontinued : ""}`}>
                 <div className={styles.cardHeader}>
-                  <span className={styles.cardTitle}>{cam.model}</span>
+                  <a className={styles.lensLink} href={`/cameras/${toSlug(cam.model)}`}>{cam.model}</a>
                   <span className={styles.cardPrice}>~${cam.price}</span>
                 </div>
                 <div className={styles.cardSpecs}>

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -1,0 +1,21 @@
+---
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import Base from "../../layouts/Base.astro";
+import accessories from "../../data/accessories";
+import { toSlug } from "../../utils/slug";
+
+export const getStaticPaths = (() => {
+  return accessories.map((accessory) => ({
+    params: { slug: toSlug(`${accessory.brand} ${accessory.model}`) },
+    props: { accessory },
+  }));
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { accessory } = Astro.props as Props;
+---
+
+<Base title={`${accessory.brand} ${accessory.model} — Fuji.me!`} description={`${accessory.description}`}>
+  <h1>{accessory.brand} {accessory.model}</h1>
+  <p>{accessory.category} — {accessory.description} — ~${accessory.price}</p>
+</Base>

--- a/src/pages/cameras/[slug].astro
+++ b/src/pages/cameras/[slug].astro
@@ -1,0 +1,21 @@
+---
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import Base from "../../layouts/Base.astro";
+import { cameras } from "../../data/cameras";
+import { toSlug } from "../../utils/slug";
+
+export const getStaticPaths = (() => {
+  return cameras.map((camera) => ({
+    params: { slug: toSlug(camera.model) },
+    props: { camera },
+  }));
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { camera } = Astro.props as Props;
+---
+
+<Base title={`${camera.model} — Fuji.me!`} description={`Specs and features for the Fujifilm ${camera.model}.`}>
+  <h1>{camera.model}</h1>
+  <p>{camera.mount} mount — {camera.sensor} — {camera.megapixels}MP — {camera.weight}g — ~${camera.price}</p>
+</Base>


### PR DESCRIPTION
## Summary

- Add `/cameras/[slug]` detail pages generated from camera data (38 pages)
- Add `/accessories/[slug]` detail pages generated from accessory data (47 pages)
- Camera explorer model names now link to `/cameras/[slug]`
- Accessories explorer model names now link to `/accessories/[slug]`
- Accessories sorted available-first, discontinued-last

## Test plan

- [ ] `/cameras/x-t5` loads with correct specs
- [ ] `/accessories/fujifilm-ef-x500` loads with correct description
- [ ] Camera explorer table and card model names are clickable links
- [ ] Accessories explorer table and card model names are clickable links
- [ ] Discontinued accessories sort to bottom
- [ ] `npm run build` passes (343 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)