### PR TITLE
docs: update README and add wuseria.me domain candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,19 @@ Lightweight Fuji lens and camera explorer with genre-based scoring.
 **Domain:** [fujime.app](https://fujime.app)
 **Part of the me! series by [braboj.me](https://braboj.me)**
 
-## Overview
+## What it does
 
-Fuji.me! helps Fujifilm photographers find the right lens or camera for their
-shooting genre. It scores every Fuji X and GFX lens against genres like
-landscape, portrait, street, and astro — backed by optical quality measurements
-from trusted review sources rather than subjective opinions.
+Fuji.me! helps Fujifilm photographers find the right lens for their shooting
+genre. It scores every Fuji X and GFX lens against genres like nightscape,
+landscape, portrait, street, architecture, sport, wildlife, travel, and macro
+-- backed by optical quality data from trusted review sources.
+
+- **Lens Explorer** -- browse, filter, and sort 240+ lenses by specs
+- **Camera Explorer** -- compare 38 Fujifilm bodies with sortable specs
+- **Accessories** -- 46 Fujifilm accessories with compatibility info
+- **Genre Guide** -- per-genre screeners with EV matrices, FL chips, and scored lens rankings
+- **Wiki** -- 115 photography terms and concepts with category filtering
+- **Detail pages** -- per-lens, per-camera, and per-accessory pages for SEO
 
 ## Quick start
 
@@ -23,84 +30,79 @@ npm install
 npm run dev
 ```
 
-Open [http://localhost:4321](http://localhost:4321) to see the site.
+Open [http://localhost:4321](http://localhost:4321).
 
-## Usage
+## Stack
 
-Browse lenses, cameras, and accessories. Filter by genre to see how each lens
-scores for your shooting style. Scores are computed from optical data — see
-[docs/decisions/](docs/decisions/) for architecture decisions.
-
-> Note: The site is in data migration phase. UI pages are planned for the
-> Astro migration (see issue #57).
+- **Framework:** Astro (static output, zero JS by default)
+- **Interactive components:** React islands via `@astrojs/react`
+- **Language:** TypeScript (strict mode)
+- **Wiki:** Astro Content Collections (Markdown files)
+- **Styling:** Astro scoped styles + CSS Modules for React islands
+- **Testing:** Vitest + React Testing Library
+- **Deployment:** GitHub Pages via GitHub Actions
 
 ## Project structure
 
 ```
-me-fuji/
-├── src/
-│   ├── components/
-│   │   ├── interactive/  # React islands (LensExplorer, CameraExplorer, GenreGuide)
-│   │   └── static/       # Astro components (zero JS shipped)
-│   ├── data/             # Static data files (lenses, cameras, genres, reviews, config)
-│   ├── test/             # Vitest setup
-│   ├── types/            # TypeScript interfaces for all domain entities
-│   ├── hooks/            # Reusable React hooks
-│   └── utils/            # Genre queries and formatting utilities
-├── docs/
-│   ├── decisions/        # Architecture Decision Records (ADR-001 to ADR-013)
-│   ├── dev-journal.md    # Development history and migration tracking
-│   ├── prototype/        # Original single-file prototype (reference only)
-│   ├── ONBOARDING.md     # New contributor guide
-│   ├── PLAYBOOK.md       # Operational reference
-│   └── solid-ai-templates/ # Quality convention templates (submodule)
-├── public/               # Static assets (favicon, icons, robots.txt)
-├── CLAUDE.md             # AI agent context and project conventions
-├── eslint.config.js      # ESLint 9 flat config
-├── vitest.config.ts      # Vitest configuration
-└── package.json
+src/
+  pages/            # Astro file-based routing
+  components/
+    interactive/    # React islands (LensExplorer, CameraExplorer, GenreGuide, etc.)
+    static/         # Astro components (zero JS)
+  content/
+    wiki/           # 115 Markdown wiki entries (Content Collections)
+  data/             # Lenses, cameras, accessories, genres, affiliates, reviews
+  types/            # TypeScript interfaces
+  hooks/            # Reusable React hooks
+  utils/            # Scoring, formatting, slug utilities
+  styles/           # Global CSS custom properties, dark theme
+docs/
+  decisions/        # Architecture Decision Records (ADR-001 to ADR-015)
+  dev-journal.md    # Development history
+  prototype/        # Original single-file prototype (reference only)
+  solid-ai-templates/  # Quality convention templates (submodule)
+public/             # Static assets (favicon, icons, robots.txt, CNAME)
 ```
 
-## Development setup
-
-```bash
-git clone --recursive https://github.com/Imbra-Ltd/me-fuji.git
-cd me-fuji
-npm install
-```
-
-The `--recursive` flag pulls the `docs/solid-ai-templates` submodule. If you
-already cloned without it, run `git submodule update --init`.
-
-### Commands
+## Commands
 
 ```bash
 npm run dev       # hot reload at localhost:4321
 npm run build     # production build to dist/
 npm run preview   # preview production build
 npm run lint      # ESLint
+npm run check     # astro check (validate .astro + type check)
 npm test          # run tests (Vitest)
-npm run check:all # lint + type check + test + build — full CI suite
+npm run check:all # lint + check + test + build -- full CI suite
 ```
 
-### Checks before committing
+## How to add a new lens
 
-```bash
-npm run check:all
-```
+1. Open `src/data/lenses.ts`
+2. Add a new entry to the `lenses` array following the `Lens` interface in `src/types/lens.ts`
+3. All fields are type-checked at build time -- the compiler will catch missing required fields
+4. Run `npm run check:all` before committing
 
-## Configuration reference
+## How to add a wiki entry
 
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| — | — | — | No environment variables required. All config is in `src/data/config.ts`. |
+1. Create a new `.md` file in `src/content/wiki/` (e.g. `my-topic.md`)
+2. Add frontmatter: `title`, `category`, `summary`, and optionally `fullTitle` and `related`
+3. Write the body in Markdown -- headings, lists, tables, links all work
+4. The schema in `src/content.config.ts` validates your frontmatter at build time
+
+## Conventions
+
+See [CLAUDE.md](CLAUDE.md) for full project conventions:
+- Conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+- Always work on a branch, never commit to main
+- Run `npm run check:all` before every commit
+- No `any` in TypeScript, no inline styles, no hardcoded data in components
 
 ## Links
 
 - [Architecture decisions](docs/decisions/)
 - [Development journal](docs/dev-journal.md)
-- [Onboarding guide](docs/ONBOARDING.md)
-- [Operational playbook](docs/PLAYBOOK.md)
 - [Quality conventions](docs/solid-ai-templates/)
 - [GitHub Issues](https://github.com/Imbra-Ltd/me-fuji/issues)
 

--- a/docs/decisions/012-domain-name-risk.md
+++ b/docs/decisions/012-domain-name-risk.md
@@ -45,6 +45,7 @@ for the X Series.
 | **wuseria.com** | Zero risk, short, playful twist on "wisteria", .com availability | Invented word, no immediate meaning |
 | **wuseria.app** | Same as .com but signals web app, modern TLD | Invented word, .app forces HTTPS |
 | **wuseria.io** | Same base, developer/tech-forward TLD | .io trending but pricier |
+| **wuseria.me** | Zero risk, playful twist on "wisteria", fits me! series (.me TLD) | Invented word, no immediate meaning |
 | lensgrade.me | Clear, describes scoring, multi-system ready | Generic |
 | xmount.me | Recognizable to Fuji shooters | "X" prefix associations, Fuji-specific |
 


### PR DESCRIPTION
## Summary

- Rewrite README to reflect current state: 240+ lenses, genre screeners, 115 wiki entries, detail pages
- Add "How to add a lens" and "How to add a wiki entry" sections
- Remove stale migration-phase references
- ADR-012: add wuseria.me as domain name candidate
- Closes #54

## Test plan

- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)