### PR TITLE
feat: JSON-LD structured data and Twitter Card meta

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -31,6 +31,11 @@ const navLinks = [
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:site_name" content="Fuji.me!" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <slot name="head" />
   </head>
   <body>
     <header class="site-header">

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -13,9 +13,30 @@ export const getStaticPaths = (() => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { accessory } = Astro.props as Props;
+
+const canonicalUrl = new URL(`/accessories/${toSlug(`${accessory.brand} ${accessory.model}`)}`, Astro.site);
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: `${accessory.brand} ${accessory.model}`,
+  description: accessory.description,
+  brand: { "@type": "Brand", name: accessory.brand },
+  url: canonicalUrl.href,
+  ...(accessory.officialUrl && { sameAs: accessory.officialUrl }),
+  offers: {
+    "@type": "Offer",
+    price: accessory.price,
+    priceCurrency: "USD",
+    availability: accessory.isDiscontinued
+      ? "https://schema.org/Discontinued"
+      : "https://schema.org/InStock",
+  },
+};
 ---
 
-<Base title={`${accessory.brand} ${accessory.model} — Fuji.me!`} description={`${accessory.description}`}>
+<Base title={`${accessory.brand} ${accessory.model} — Fuji.me!`} description={accessory.description}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <h1>{accessory.brand} {accessory.model}</h1>
   <p>{accessory.category} — {accessory.description} — ~${accessory.price}</p>
 </Base>

--- a/src/pages/cameras/[slug].astro
+++ b/src/pages/cameras/[slug].astro
@@ -13,9 +13,30 @@ export const getStaticPaths = (() => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { camera } = Astro.props as Props;
+
+const canonicalUrl = new URL(`/cameras/${toSlug(camera.model)}`, Astro.site);
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: `Fujifilm ${camera.model}`,
+  description: `Fujifilm ${camera.model} — ${camera.sensor}, ${camera.megapixels}MP, ${camera.weight}g.`,
+  brand: { "@type": "Brand", name: "Fujifilm" },
+  url: canonicalUrl.href,
+  ...(camera.officialUrl && { sameAs: camera.officialUrl }),
+  offers: {
+    "@type": "Offer",
+    price: camera.price,
+    priceCurrency: "USD",
+    availability: camera.isDiscontinued
+      ? "https://schema.org/Discontinued"
+      : "https://schema.org/InStock",
+  },
+};
 ---
 
 <Base title={`${camera.model} — Fuji.me!`} description={`Specs and features for the Fujifilm ${camera.model}.`}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <h1>{camera.model}</h1>
   <p>{camera.mount} mount — {camera.sensor} — {camera.megapixels}MP — {camera.weight}g — ~${camera.price}</p>
 </Base>

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -13,9 +13,30 @@ export const getStaticPaths = (() => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { lens } = Astro.props as Props;
+
+const canonicalUrl = new URL(`/lenses/${toSlug(`${lens.brand} ${lens.model}`)}`, Astro.site);
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: `${lens.brand} ${lens.model}`,
+  description: `${lens.brand} ${lens.model} — ${lens.mount} mount ${lens.type} lens, ${lens.weight}g.`,
+  brand: { "@type": "Brand", name: lens.brand },
+  url: canonicalUrl.href,
+  ...(lens.officialUrl && { sameAs: lens.officialUrl }),
+  offers: {
+    "@type": "Offer",
+    price: lens.price,
+    priceCurrency: "USD",
+    availability: lens.isDiscontinued
+      ? "https://schema.org/Discontinued"
+      : "https://schema.org/InStock",
+  },
+};
 ---
 
 <Base title={`${lens.brand} ${lens.model} — Fuji.me!`} description={`Specs and genre scores for the ${lens.brand} ${lens.model}.`}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <h1>{lens.brand} {lens.model}</h1>
   <p>{lens.mount} mount — {lens.type} — {lens.weight}g — ~${lens.price}</p>
 </Base>

--- a/src/pages/wiki/[slug].astro
+++ b/src/pages/wiki/[slug].astro
@@ -18,9 +18,25 @@ const { Content } = await render(entry);
 const relatedEntries = entry.data.related
   ? allEntries.filter((e) => entry.data.related!.includes(e.id))
   : [];
+
+const canonicalUrl = new URL(`/wiki/${entry.id}`, Astro.site);
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: entry.data.title,
+  description: entry.data.summary,
+  url: canonicalUrl.href,
+  publisher: {
+    "@type": "Organization",
+    name: "Fuji.me!",
+    url: Astro.site?.href,
+  },
+};
 ---
 
 <Base title={`${entry.data.title} — Wiki — Fuji.me!`} description={entry.data.summary}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <article class="wiki-article">
     <div class="title-row">
       <h1>{entry.data.title}</h1>


### PR DESCRIPTION
## Summary

- Add `Product` JSON-LD on all 240+ lens, 38 camera, and 46 accessory detail pages
- Add `Article` JSON-LD on all 115 wiki pages
- Add Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`) to Base.astro
- Add `og:site_name` and named `head` slot for per-page head injection
- Closes #48

## Test plan

- [ ] View source on a lens page — JSON-LD with `@type: Product` present
- [ ] View source on a wiki page — JSON-LD with `@type: Article` present
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Twitter Card meta tags visible in `<head>`
- [ ] `npm run build` passes (458 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)