### PR TITLE
feat: lens detail cards + optical quality score column

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -6,8 +6,12 @@ import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
 import styles from "./LensExplorer.module.css";
 
+interface ExplorerLens extends Lens {
+  opticalQuality?: number | null;
+}
+
 interface LensExplorerProps {
-  lenses: Lens[];
+  lenses: ExplorerLens[];
 }
 
 type LensSortKey =
@@ -20,6 +24,7 @@ type LensSortKey =
   | "isWeatherSealed"
   | "afMotor"
   | "weight"
+  | "opticalQuality"
   | "price";
 
 type ColumnAlign = "left" | "right" | "center";
@@ -34,6 +39,7 @@ const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
   { key: "isWeatherSealed", label: "WR", align: "center" },
   { key: "afMotor", label: "AF", align: "center" },
   { key: "weight", label: "Weight", align: "right" },
+  { key: "opticalQuality", label: "OQ", align: "right" },
   { key: "price", label: "Price", align: "right" },
 ];
 
@@ -120,9 +126,9 @@ function LensExplorer({ lenses }: LensExplorerProps) {
     });
   }, [lenses, search, mount, type, brand, ois, wr, af, discontinued, fl, maxAp, priceRange]);
 
-  const availableFirst = useCallback((a: Lens, b: Lens) =>
+  const availableFirst = useCallback((a: ExplorerLens, b: ExplorerLens) =>
     Number(a.isDiscontinued ?? false) - Number(b.isDiscontinued ?? false), []);
-  const { sorted, sortKey, sortDirection, toggleSort } = useSort<Lens, LensSortKey>(filtered, "focalLengthMin", "asc", availableFirst);
+  const { sorted, sortKey, sortDirection, toggleSort } = useSort<ExplorerLens, LensSortKey>(filtered, "focalLengthMin", "asc", availableFirst);
 
   function handleMountChange(value: string): void {
     setMount(value);
@@ -289,6 +295,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                     <td className={styles.cellCenter}><span className={lens.isWeatherSealed ? styles.dotOn : styles.dotOff} /></td>
                     <td className={styles.cellCenter}>{lens.afMotor ?? "MF"}</td>
                     <td className={styles.cellRight}>{lens.weight}g</td>
+                    <td className={styles.cellRight}>{lens.opticalQuality != null ? lens.opticalQuality.toFixed(1) : "\u2013"}</td>
                     <td className={styles.cellRight}>~${lens.price}</td>
                   </tr>
                 ))}
@@ -310,6 +317,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                   <span>{formatFL(lens)}</span>
                   <span>f/{lens.maxAperture}</span>
                   <span>{lens.weight}g</span>
+                  {lens.opticalQuality != null && <span>OQ {lens.opticalQuality.toFixed(1)}</span>}
                   {lens.year && <span>{lens.year}</span>}
                 </div>
                 <div className={styles.cardBadges}>

--- a/src/pages/lenses/index.astro
+++ b/src/pages/lenses/index.astro
@@ -1,10 +1,16 @@
 ---
 import Base from "../../layouts/Base.astro";
 import { lenses } from "../../data/lenses";
+import { computeOpticalQuality } from "../../utils/scoring";
 import LensExplorer from "../../components/interactive/LensExplorer/LensExplorer";
+
+const lensesWithOQ = lenses.map((l) => ({
+  ...l,
+  opticalQuality: computeOpticalQuality(l),
+}));
 ---
 
 <Base title="Lenses — Fuji.me!" description="Browse all Fujifilm-compatible lenses with specs and genre scores.">
-  <LensExplorer client:load lenses={lenses} />
+  <LensExplorer client:load lenses={lensesWithOQ} />
 </Base>
 

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -276,6 +276,56 @@ function isScoredGenre(genre: Genre): genre is ScoredGenre {
 }
 
 // =============================================================================
+// OVERALL OPTICAL QUALITY — genre-usage-derived weights
+// =============================================================================
+
+const OPTICAL_WEIGHTS: Record<OpticalField, number> = {
+  centerStopped: 4,
+  centerWideOpen: 3,
+  longitudinalCA: 2,
+  lateralCA: 1.5,
+  cornerStopped: 1.5,
+  coma: 1.5,
+  distortion: 1,
+  astigmatism: 1,
+  flareResistance: 1,
+  bokeh: 1,
+  sphericalAberration: 0.5,
+  vignettingWideOpen: 0.5,
+  vignettingStopped: 0.5,
+  cornerWideOpen: 0.5,
+};
+
+/**
+ * Compute an overall optical quality score (0–10) from a weighted average
+ * of available optical fields. Returns null if fewer than 7 fields present.
+ *
+ * Weights are derived from genre formula usage: fields that appear as primary
+ * in more genres get higher weight, so lenses that perform well across many
+ * genres score higher.
+ */
+function computeOpticalQuality(lens: Lens): number | null {
+  if (opticalFieldCount(lens) < MIN_OPTICAL_FIELDS) return null;
+
+  let sumW = 0;
+  let sumWV = 0;
+
+  for (const field of OPTICAL_FIELDS) {
+    const val = lens[field];
+    if (val == null) continue;
+    const w = OPTICAL_WEIGHTS[field];
+    sumW += w;
+    sumWV += w * val;
+  }
+
+  if (sumW === 0) return null;
+
+  // Weighted average is 0–2, scale to 0–10
+  const avg = sumWV / sumW;
+  return Math.round(avg * 5 * 10) / 10;
+}
+
+// =============================================================================
 // EXPORTS
 // =============================================================================
 
@@ -291,7 +341,10 @@ export {
   opticalFieldCount,
   genreFormulas,
   OPTICAL_FIELDS,
+  OPTICAL_WEIGHTS,
   MIN_OPTICAL_FIELDS,
+  // Overall optical quality
+  computeOpticalQuality,
   // Lookup helpers
   getGenreMark,
   isEditorialPick,


### PR DESCRIPTION
## Summary

- **Lens detail pages**: sections wrapped in bordered cards with surface background, clean h1 header, tilt-shift fields shown when applicable, "Not yet scored" card for unscored lenses
- **Optical Quality (OQ) score**: genre-usage-derived weighted average of 14 optical fields (0-10 scale). Fields primary in more genres get higher weight. 94/241 lenses scored.
- OQ column added to Lens Explorer table (sortable) + badge in mobile cards

## Test plan

- [ ] Lens detail page shows card sections with clear visual separation
- [ ] OQ column shows scores (e.g. 7.2) or dash for unscored lenses
- [ ] OQ column is sortable
- [ ] Mobile cards show "OQ 7.2" in specs row
- [ ] `npm run build` passes (458 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)