### PR TITLE
chore: rebrand from Fuji.me! to Wuseria

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
-# Fuji.me!
+# Wuseria
 
-Lightweight Fuji lens and camera explorer with genre-based scoring.
-Domain: fujime.app. Part of the me! series by braboj.me.
+Fujifilm lens and camera explorer with genre-based scoring.
+Domain: wuseria.com. By braboj.me.
 
 For architecture decisions, see `docs/decisions/`. For development history, see `docs/dev-journal.md`.
 
@@ -136,7 +136,7 @@ src/
 public/
   favicon.svg
   icons.svg
-  CNAME                           // fujime.app
+  CNAME                           // wuseria.com
   robots.txt
 astro.config.mjs
 tsconfig.json

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Fuji.me!
+# Wuseria
 
-Lightweight Fuji lens and camera explorer with genre-based scoring.
+Fujifilm lens and camera explorer with genre-based scoring.
 
-**Domain:** [fujime.app](https://fujime.app)
-**Part of the me! series by [braboj.me](https://braboj.me)**
+**Domain:** [wuseria.com](https://wuseria.com)
+**By [braboj.me](https://braboj.me)**
 
 ## What it does
 
-Fuji.me! helps Fujifilm photographers find the right lens for their shooting
+Wuseria helps Fujifilm photographers find the right lens for their shooting
 genre. It scores every Fuji X and GFX lens against genres like nightscape,
 landscape, portrait, street, architecture, sport, wildlife, travel, and macro
 -- backed by optical quality data from trusted review sources.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: "https://fujime.app",
+  site: "https://wuseria.com",
   output: "static",
   prefetch: {
     prefetchAll: true,

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,6 +1,6 @@
 # Onboarding
 
-New contributor guide for Fuji.me!
+New contributor guide for Wuseria
 
 ## 1. Prerequisites
 
@@ -51,7 +51,7 @@ npm run lint
 
 ## 5. Project context
 
-Fuji.me! scores Fujifilm lenses against shooting genres (landscape, portrait,
+Wuseria scores Fujifilm lenses against shooting genres (landscape, portrait,
 street, astro, etc.) using MTF chart data from trusted review sources. See
 [docs/decisions/](decisions/) for architecture decisions and
 `src/types/` for the data model.

--- a/docs/decisions/002-hosting.md
+++ b/docs/decisions/002-hosting.md
@@ -9,7 +9,7 @@ The site is fully static (Astro output). Needs a CDN-backed host with custom dom
 
 ## Decision
 
-Deploy to GitHub Pages via GitHub Actions. Custom domain: fujime.app.
+Deploy to GitHub Pages via GitHub Actions. Custom domain: wuseria.com.
 
 ## Alternatives considered
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,4 +1,4 @@
-# Fuji.me! — Development Journal
+# Wuseria — Development Journal
 
 ## Architecture Overview
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "me-fuji",
+  "name": "wuseria",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-fujime.app
+wuseria.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://fujime.app/sitemap-index.xml
+Sitemap: https://wuseria.com/sitemap-index.xml

--- a/src/content/wiki/coma.md
+++ b/src/content/wiki/coma.md
@@ -16,4 +16,4 @@ For nightscape and astrophotography, coma is the most important optical flaw to 
 
 Stopping down reduces coma significantly — most lenses improve dramatically by f/2.8. But nightscape shooters need wide apertures for light gathering, so a lens that controls coma wide open is far more valuable than one that only sharpens stopped down.
 
-In the Fuji.me! scoring system, coma is rated 0-2 based on corner star rendering at maximum aperture. A score of 2 means minimal coma even wide open — stars stay tight points across the frame. A score of 0 means heavy coma that makes the lens unsuitable for astrophotography without stopping down.
+In the Wuseria scoring system, coma is rated 0-2 based on corner star rendering at maximum aperture. A score of 2 means minimal coma even wide open — stars stay tight points across the frame. A score of 0 means heavy coma that makes the lens unsuitable for astrophotography without stopping down.

--- a/src/content/wiki/mtf-charts.md
+++ b/src/content/wiki/mtf-charts.md
@@ -18,4 +18,4 @@ A great lens shows both lines above 0.8 across the frame at 10 lp/mm, and above 
 
 MTF charts have limitations: they are measured at a single aperture (usually wide open and f/8), do not capture chromatic aberration, coma, or flare, and lab conditions do not match real-world shooting. Use them as one input alongside field reports, sample images, and optical scores.
 
-In Fuji.me!, the center/corner stopped and wide-open scores are derived from MTF data and lab tests. They are simplified to a 0-2 scale for quick comparison across the entire lens lineup.
+In Wuseria, the center/corner stopped and wide-open scores are derived from MTF data and lab tests. They are simplified to a 0-2 scale for quick comparison across the entire lens lineup.

--- a/src/content/wiki/scoring-methodology.md
+++ b/src/content/wiki/scoring-methodology.md
@@ -2,13 +2,13 @@
 title: "Scoring Methodology"
 categories:
   - "Optics"
-summary: "How Fuji.me! scores lenses for each photography genre using optical data and weighted formulas."
+summary: "How Wuseria scores lenses for each photography genre using optical data and weighted formulas."
 related:
   - "mtf-charts"
   - "coma"
 ---
 
-Fuji.me! scores lenses on a 0-100 scale for each photography genre. Scores are calculated from optical performance data, not marketing specs or subjective reviews. The goal is to answer: "How well does this lens perform for this specific genre?"
+Wuseria scores lenses on a 0-100 scale for each photography genre. Scores are calculated from optical performance data, not marketing specs or subjective reviews. The goal is to answer: "How well does this lens perform for this specific genre?"
 
 Each genre uses a weighted formula that emphasizes the optical qualities most important for that type of photography. For example, nightscape scoring heavily weights coma and wide-open corner sharpness, while portrait scoring emphasizes bokeh and center sharpness wide open.
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,7 +6,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = "Lightweight Fuji lens and camera explorer with genre-based scoring." } = Astro.props;
+const { title, description = "Fujifilm lens and camera explorer with genre-based scoring." } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 
 const navLinks = [
@@ -30,7 +30,7 @@ const navLinks = [
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonicalUrl} />
-    <meta property="og:site_name" content="Fuji.me!" />
+    <meta property="og:site_name" content="Wuseria" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
@@ -39,7 +39,7 @@ const navLinks = [
   <body>
     <header class="site-header">
       <nav class="nav" aria-label="Main navigation">
-        <a href="/" class="nav-brand">Fuji.me!</a>
+        <a href="/" class="nav-brand">Wuseria</a>
         <ul class="nav-links" role="list">
           {navLinks.map((link) => (
             <li>
@@ -61,7 +61,7 @@ const navLinks = [
 
     <footer class="site-footer">
       <p class="footer-text">
-        Fuji.me! — part of the <a href="https://braboj.me">me! series</a> by braboj.me
+        Wuseria — Fujifilm lens &amp; camera explorer by <a href="https://braboj.me">braboj.me</a>
       </p>
     </footer>
   </body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Base from "../layouts/Base.astro";
 ---
 
-<Base title="404 — Fuji.me!" description="Page not found.">
+<Base title="404 — Wuseria" description="Page not found.">
   <h1>404</h1>
   <p>Page not found. <a href="/">Back to homepage</a>.</p>
 </Base>

--- a/src/pages/accessories.astro
+++ b/src/pages/accessories.astro
@@ -4,6 +4,6 @@ import accessories from "../data/accessories";
 import AccessoriesExplorer from "../components/interactive/AccessoriesExplorer/AccessoriesExplorer";
 ---
 
-<Base title="Accessories — Fuji.me!" description="Fujifilm accessories: flashes, grips, batteries, adapters, and more.">
+<Base title="Accessories — Wuseria" description="Fujifilm accessories: flashes, grips, batteries, adapters, and more.">
   <AccessoriesExplorer client:load accessories={accessories} />
 </Base>

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -56,7 +56,7 @@ const compat = "compatibleWith" in accessory && Array.isArray(accessory.compatib
   : [];
 ---
 
-<Base title={`${accessory.brand} ${accessory.model} — Fuji.me!`} description={accessory.description}>
+<Base title={`${accessory.brand} ${accessory.model} — Wuseria`} description={accessory.description}>
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <div class="detail">

--- a/src/pages/cameras/[slug].astro
+++ b/src/pages/cameras/[slug].astro
@@ -44,7 +44,7 @@ const jsonLd = {
 };
 ---
 
-<Base title={`${camera.model} — Fuji.me!`} description={`Specs and features for the Fujifilm ${camera.model}.`}>
+<Base title={`${camera.model} — Wuseria`} description={`Specs and features for the Fujifilm ${camera.model}.`}>
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <div class="detail">

--- a/src/pages/cameras/index.astro
+++ b/src/pages/cameras/index.astro
@@ -4,6 +4,6 @@ import { cameras } from "../../data/cameras";
 import CameraExplorer from "../../components/interactive/CameraExplorer/CameraExplorer";
 ---
 
-<Base title="Cameras — Fuji.me!" description="Browse all Fujifilm camera bodies with specs and features.">
+<Base title="Cameras — Wuseria" description="Browse all Fujifilm camera bodies with specs and features.">
   <CameraExplorer client:load cameras={cameras} />
 </Base>

--- a/src/pages/genre/[genre].astro
+++ b/src/pages/genre/[genre].astro
@@ -23,7 +23,7 @@ const config = genreConfigs[genre as ScoredGenre];
 ---
 
 <Base
-  title={`${config.name} — Genre Guide — Fuji.me!`}
+  title={`${config.name} — Genre Guide — Wuseria`}
   description={`Best Fujifilm lenses for ${config.name.toLowerCase()}, scored by optical performance. ${config.description}`}
 >
   <GenreGuide

--- a/src/pages/genre/index.astro
+++ b/src/pages/genre/index.astro
@@ -5,7 +5,7 @@ import { lenses } from "../../data/lenses";
 ---
 
 <Base
-  title="Genre Guide — Fuji.me!"
+  title="Genre Guide — Wuseria"
   description="Explore the best Fujifilm lenses for each photography genre, scored by optical performance."
 >
   <GenreGuide

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Base from "../layouts/Base.astro";
 ---
 
-<Base title="Fuji.me! — Fujifilm Lens and Camera Explorer">
-  <h1>Fuji.me!</h1>
-  <p>Lightweight Fuji lens and camera explorer with genre-based scoring.</p>
+<Base title="Wuseria — Fujifilm Lens and Camera Explorer">
+  <h1>Wuseria</h1>
+  <p>Fujifilm lens and camera explorer with genre-based scoring.</p>
 </Base>

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -77,7 +77,7 @@ const jsonLd = {
 };
 ---
 
-<Base title={`${lens.brand} ${lens.model} — Fuji.me!`} description={`Specs and genre scores for the ${lens.brand} ${lens.model}.`}>
+<Base title={`${lens.brand} ${lens.model} — Wuseria`} description={`Specs and genre scores for the ${lens.brand} ${lens.model}.`}>
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <div class="detail">

--- a/src/pages/lenses/index.astro
+++ b/src/pages/lenses/index.astro
@@ -10,7 +10,7 @@ const lensesWithOQ = lenses.map((l) => ({
 }));
 ---
 
-<Base title="Lenses — Fuji.me!" description="Browse all Fujifilm-compatible lenses with specs and genre scores.">
+<Base title="Lenses — Wuseria" description="Browse all Fujifilm-compatible lenses with specs and genre scores.">
   <LensExplorer client:load lenses={lensesWithOQ} />
 </Base>
 

--- a/src/pages/trade-deals.astro
+++ b/src/pages/trade-deals.astro
@@ -2,7 +2,7 @@
 import Base from "../layouts/Base.astro";
 ---
 
-<Base title="Trade Deals — Fuji.me!" description="Current deals on Fujifilm lenses and cameras.">
+<Base title="Trade Deals — Wuseria" description="Current deals on Fujifilm lenses and cameras.">
   <h1>Trade Deals</h1>
   <p>Coming soon.</p>
 </Base>

--- a/src/pages/wiki/[slug].astro
+++ b/src/pages/wiki/[slug].astro
@@ -29,13 +29,13 @@ const jsonLd = {
   url: canonicalUrl.href,
   publisher: {
     "@type": "Organization",
-    name: "Fuji.me!",
+    name: "Wuseria",
     url: Astro.site?.href,
   },
 };
 ---
 
-<Base title={`${entry.data.title} — Wiki — Fuji.me!`} description={entry.data.summary}>
+<Base title={`${entry.data.title} — Wiki — Wuseria`} description={entry.data.summary}>
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <article class="wiki-article">
     <div class="title-row">

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -7,7 +7,7 @@ const sorted = [...entries].sort((a, b) => a.data.title.localeCompare(b.data.tit
 const categories = [...new Set(entries.flatMap((e) => e.data.categories))].sort();
 ---
 
-<Base title="Wiki — Fuji.me!" description="Photography terms and concepts explained for Fujifilm shooters.">
+<Base title="Wiki — Wuseria" description="Photography terms and concepts explained for Fujifilm shooters.">
   <h1>Wiki</h1>
   <p class="subtitle">{entries.length} photography terms and concepts.</p>
 


### PR DESCRIPTION
## Summary
- Replaces all "Fuji.me!" references with "Wuseria" and "fujime.app" with "wuseria.com" across 26 files
- Updates config (astro.config.mjs, package.json, CNAME, robots.txt), layouts, all page titles, wiki content, and docs
- Historical files (ADR-012, prototype) left untouched as they document the decision

## Test plan
- [x] `npm run build` passes — 458 pages generated
- [x] No new lint errors introduced (pre-existing 13 errors unchanged)
- [x] Grep confirms no remaining "Fuji.me!" or "fujime.app" outside historical files
- [x] Visual check: nav brand, footer, homepage title, page titles all show "Wuseria"

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)