### PR TITLE
fix: add missing genre guide and optical scoring wiki entries

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,7 @@ const wiki = defineCollection({
       "Composition",
       "Exposure",
       "Focus",
+      "Genre",
       "Geometry",
       "Lenses",
       "Lighting",

--- a/src/content/wiki/architecture-photography.md
+++ b/src/content/wiki/architecture-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Architecture Photography"
+categories:
+  - "Genre"
+summary: "Geometric precision with minimal distortion and corner-to-corner sharpness at stopped-down apertures."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Architecture photography captures buildings, interiors, and urban structures with an emphasis on geometric accuracy and fine detail. Straight lines, symmetry, and even sharpness across the frame are non-negotiable.
+
+## What matters in an architecture lens
+
+The primary scoring factors are **corner sharpness stopped down**, **center sharpness stopped down**, and **distortion**. Architecture demands sharpness across the entire frame at f/8 to f/11, and any barrel or pincushion distortion warps the straight lines that define the subject.
+
+## Secondary factors
+
+**Lateral chromatic aberration** creates color fringing on high-contrast edges like window frames against bright sky. **Vignetting stopped down** should be minimal to keep exposure even across the frame. **Flare resistance** matters for interiors with bright windows or exterior shots with direct sun.
+
+## Typical focal lengths
+
+Ultra-wide (6-15mm) and wide (16-27mm) lenses are standard for architecture. Tilt-shift lenses offer perspective correction, though Fujifilm's X-mount has limited native tilt-shift options.
+
+## Shooting style
+
+Architecture photographers use tripods, shoot at the lens sweet spot (typically f/8), and often bracket for HDR to handle high dynamic range between interiors and exteriors. Distortion can be corrected in software, but lenses with inherently low distortion save time and preserve resolution.

--- a/src/content/wiki/landscape-photography.md
+++ b/src/content/wiki/landscape-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Landscape Photography"
+categories:
+  - "Genre"
+summary: "Sharp from corner to corner at the sweet-spot aperture. What makes a lens good for landscape work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Landscape photography captures natural and rural scenes with an emphasis on depth, detail, and corner-to-corner sharpness. Most landscape shots are taken on a tripod at stopped-down apertures (f/8 to f/11), so wide-open performance matters less than peak sharpness.
+
+## What matters in a landscape lens
+
+The primary scoring factors are **corner sharpness stopped down** and **center sharpness stopped down**. A landscape lens must resolve fine detail across the entire frame at its sweet-spot aperture.
+
+## Secondary factors
+
+**Distortion** affects straight lines at the frame edges — barrel or pincushion distortion can ruin horizon shots. **Lateral chromatic aberration** creates color fringing on high-contrast edges like tree branches against sky. **Vignetting stopped down** should be minimal. **Flare resistance** matters for backlit scenes and sun-in-frame compositions. **Astigmatism** and **coma** contribute at lower weight.
+
+## Typical focal lengths
+
+Ultra-wide (6-15mm) and wide (16-27mm) lenses dominate landscape work, though telephoto compression landscapes are increasingly popular.
+
+## Shooting style
+
+Landscape photographers typically use tripods, remote shutter releases, and bracketed exposures. Shutter speed is flexible (seconds to minutes), so aperture and ISO can be optimized for sharpness. This is why stopped-down performance outweighs wide-open capability in the scoring formula.

--- a/src/content/wiki/macro-photography.md
+++ b/src/content/wiki/macro-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Macro Photography"
+categories:
+  - "Genre"
+summary: "Close-up imaging of small subjects. What makes a lens good for macro work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Macro photography captures small subjects at high magnification — insects, flowers, textures, and small objects rendered at or near life-size on the sensor. Depth of field is extremely shallow at macro distances, so technique and lens quality both matter.
+
+## What matters in a macro lens
+
+The primary scoring factors are **center sharpness stopped down** and **magnification ratio**. Macro photographers stop down to f/8 or f/11 to gain depth of field, so the lens must be sharp at those apertures. Higher magnification (0.5x, 1.0x, or beyond) determines how close and how large the subject can be rendered.
+
+## Secondary factors
+
+**Distortion** affects the accuracy of small-subject rendering. **Lateral and longitudinal chromatic aberration** create color fringing on fine high-contrast details like insect wings and petal edges. **Spherical aberration** affects focus transition quality. **Bokeh** matters because macro shots have very shallow depth of field and prominent out-of-focus areas.
+
+## Typical focal lengths
+
+Standard (28-56mm) and tele (57-150mm) macro lenses are most common. Longer macro focal lengths provide more working distance — important for skittish insect subjects. On Fuji X-mount, the XF 80mm f/2.8 Macro and XF 30mm f/2.8 Macro are the native options.
+
+## Shooting style
+
+Macro photographers use tripods, focus rails, and focus stacking (combining multiple shots at different focus distances) to overcome the extremely shallow depth of field. Flash or LED ring lights are common to provide sufficient light at stopped-down apertures. The magnification ratio is the single most important spec when choosing a macro lens.

--- a/src/content/wiki/nightscape-photography.md
+++ b/src/content/wiki/nightscape-photography.md
@@ -1,0 +1,34 @@
+---
+title: "Nightscape Photography"
+categories:
+  - "Genre"
+summary: "Stars, Milky Way, and night landscapes on a fixed tripod. What makes a lens good for nightscape work."
+related:
+  - "optical-scoring"
+  - "coma"
+  - "scoring-methodology"
+---
+
+Nightscape photography captures stars, the Milky Way, and night landscapes using long exposures on a fixed tripod. The camera does not track the sky, so exposure time is limited by the Rule of 500 — beyond that threshold, stars trail into streaks.
+
+## What matters in a nightscape lens
+
+The most important optical qualities are **coma**, **astigmatism**, and **maximum aperture**. These are the primary scoring factors in Wuseria's nightscape formula.
+
+**Coma** stretches point stars into comet or bird-wing shapes near the corners. A lens with heavy coma is unusable for widefield astrophotography without stopping down, which costs light gathering. Coma cannot be corrected in post-processing.
+
+**Astigmatism** turns stars into crosses or elongated shapes when sagittal and meridional MTF lines diverge. Like coma, it is worst in the corners and at wide apertures.
+
+**Fast aperture** (f/1.4 or f/2.0) is critical because exposure time is limited by star trailing. A wider aperture collects more light in the allowed time window, keeping ISO manageable and noise low.
+
+## Secondary factors
+
+Corner sharpness wide open, chromatic aberration, vignetting, and spherical aberration also contribute to the nightscape score, but with less weight. Vignetting is common at wide apertures and correctable in post, so it penalizes less than coma.
+
+## Typical focal lengths
+
+Ultra-wide (6-15mm) and wide (16-27mm) lenses are most common for nightscape. Wider fields capture more sky and allow longer exposures before stars trail.
+
+## Exposure planning
+
+The Wuseria nightscape screener includes an EV matrix mapping dark-sky conditions (Bortle scale) to viable ISO and shutter speed combinations. Scene brightness ranges from EV 1 (city center) to EV -8 (pristine dark site at solar minimum).

--- a/src/content/wiki/optical-scoring.md
+++ b/src/content/wiki/optical-scoring.md
@@ -1,0 +1,42 @@
+---
+title: "Optical Scoring"
+fullTitle: "How Wuseria Scores Lenses"
+categories:
+  - "Optics"
+summary: "How marks, optical quality, and genre scores work in Wuseria."
+related:
+  - "scoring-methodology"
+  - "mtf-charts"
+---
+
+Wuseria rates every lens with enough optical data on two scales: a per-genre **mark** (1 to 5 in half-star steps) and an overall **Optical Quality** score (0 to 10).
+
+## Genre marks
+
+Each genre has a formula with **primary** and **secondary** optical fields. Primary fields carry 3x the weight of secondary fields. The weighted average of all available fields produces a raw score on a 0-2 scale, which maps to marks 1 through 5.
+
+The primary floor rule prevents a lens from earning a high mark if any single primary field is weak. The final score is capped at the lowest primary field value. A lens with excellent secondary scores but poor coma control will still score low for nightscape.
+
+A lens must have at least 7 of 14 optical fields populated to receive any genre mark. Lenses without sufficient data show "Not yet scored" instead of a number.
+
+## Optical Quality (OQ)
+
+OQ is a single 0-10 number summarizing overall optical performance across all genres. It uses the same 14 optical fields but with weights derived from how often each field appears as a primary factor across all genre formulas. Fields important to many genres (like center sharpness stopped down) carry more weight than niche fields.
+
+## Mark scale
+
+| Mark | Meaning |
+|------|---------|
+| 5.0 | Exceptional — top-tier for the genre |
+| 4.0-4.5 | Very good — strong performer |
+| 3.0-3.5 | Good — competent for the genre |
+| 2.0-2.5 | Below average — usable with limitations |
+| 1.0-1.5 | Poor — not recommended for this genre |
+
+## Editorial picks
+
+Some lenses receive an editorial pick badge for a genre. These are lenses that real-world experience and photographer consensus recognize as exceptional, even if the formula alone does not fully capture their strengths.
+
+## Data sources
+
+Optical field scores come from lab tests and detailed field reports by trusted review sources: LensTip, Optical Limits, and DPReview. Each field is rated on a 0-2 scale where 0 is poor, 1 is average, and 2 is excellent. Scores are not estimated or interpolated — if a trusted source has not tested a field, it remains empty.

--- a/src/content/wiki/portrait-photography.md
+++ b/src/content/wiki/portrait-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Portrait Photography"
+categories:
+  - "Genre"
+summary: "Smooth bokeh and critical sharpness on the eyes. What makes a lens good for portrait work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Portrait photography isolates the subject from the background using shallow depth of field. The goal is flattering rendering — sharp eyes, smooth out-of-focus areas, and pleasing skin tones.
+
+## What matters in a portrait lens
+
+The primary scoring factors are **bokeh quality** and **center sharpness wide open**. Portraits are shot wide open or near-wide to maximize subject isolation. The center of the frame must be critically sharp (the subject's eyes), while the background should dissolve into smooth, non-distracting blur.
+
+## Secondary factors
+
+**Longitudinal chromatic aberration** (LoCA) creates purple or green fringing on out-of-focus highlights — distracting in bokeh-heavy portrait shots. **Spherical aberration** affects the transition between in-focus and out-of-focus areas. **Vignetting wide open** can be a creative asset in portraits (natural vignette draws the eye to center) but excessive vignetting requires correction.
+
+## Typical focal lengths
+
+Standard (28-56mm) and tele (57-150mm) lenses are the classic portrait range. On Fuji X-mount, the 56mm f/1.2 and 50mm f/2.0 are popular choices. Longer focal lengths provide more compression and background separation.
+
+## Shooting style
+
+Portrait photographers typically shoot handheld with continuous autofocus tracking the subject's eyes. The 2x FL rule (shutter speed = 2x focal length) accounts for subject movement. Fast apertures (f/1.2 to f/2.0) are standard for environmental and studio portraits alike.

--- a/src/content/wiki/sport-photography.md
+++ b/src/content/wiki/sport-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Sport Photography"
+categories:
+  - "Genre"
+summary: "Freeze motion with fast shutter speeds. What makes a lens good for sport work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Sport photography freezes fast-moving subjects at high shutter speeds. The photographer shoots handheld, often from a fixed position, tracking athletes or vehicles across the frame.
+
+## What matters in a sport lens
+
+The primary scoring factor is **center sharpness wide open**. Sport photographers shoot at or near maximum aperture to maintain the fast shutter speeds needed to freeze action (1/1000s or faster). The subject is typically centered or near-center, so corner performance matters less than in landscape or architecture.
+
+## Secondary factors
+
+**Aperture speed** determines how much light the lens gathers — faster lenses allow faster shutter speeds in the same conditions. **Longitudinal chromatic aberration** and **lateral chromatic aberration** affect image quality on high-contrast subjects (white jerseys, bright equipment).
+
+## Typical focal lengths
+
+Standard (28-56mm) and tele (57-150mm) lenses cover most court and field sports. Longer telephoto lenses are needed for stadium work from the stands.
+
+## Shooting style
+
+Sport photographers use continuous autofocus with high burst rates (8-20+ fps). The 4x FL rule (shutter speed = 4x focal length) accounts for both camera shake and subject movement. Image stabilization helps between bursts but does not replace fast shutter speeds for freezing action.

--- a/src/content/wiki/street-photography.md
+++ b/src/content/wiki/street-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Street Photography"
+categories:
+  - "Genre"
+summary: "Capture the moment handheld in changing light. What makes a lens good for street work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Street photography captures candid moments in public spaces. Speed and discretion matter — the photographer shoots handheld, often in mixed or low light, reacting to fleeting scenes.
+
+## What matters in a street lens
+
+The primary scoring factors are **center sharpness stopped down** and **aperture speed**. Street shooters typically stop down to f/5.6 or f/8 for zone focusing, but need a fast aperture as a fallback for low-light situations.
+
+## Secondary factors
+
+**Center sharpness wide open** matters for low-light and shallow depth-of-field shots. **Flare resistance** is important for backlit street scenes. **Longitudinal chromatic aberration** affects bokeh quality in subject-isolation shots. **Coma** contributes at lower weight for night street work.
+
+## Typical focal lengths
+
+Wide (16-27mm) and standard (28-56mm) lenses are the classic street range. The 23mm (35mm equivalent) and 35mm (50mm equivalent) are the most popular choices on Fuji X-mount.
+
+## Shooting style
+
+Street photographers prioritize small, light, and quiet gear. Autofocus speed matters less than on other genres because many street shooters use zone focusing — pre-setting focus distance and aperture so the camera is always ready to fire. Weight and size directly affect how long you can shoot and how unobtrusive you remain.

--- a/src/content/wiki/travel-photography.md
+++ b/src/content/wiki/travel-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Travel Photography"
+categories:
+  - "Genre"
+summary: "Versatile coverage in a light kit. What makes a lens good for travel work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Travel photography covers a wide range of subjects — landscapes, architecture, street scenes, food, people — all within the constraints of a portable kit. The best travel lens balances image quality, weight, and focal length versatility.
+
+## What matters in a travel lens
+
+The primary scoring factors are **center sharpness stopped down** and **weight**. A travel lens must be sharp at its sweet-spot aperture and light enough to carry all day without fatigue.
+
+## Secondary factors
+
+**Aperture speed** provides flexibility for low-light interiors and evening scenes. **Flare resistance** matters for outdoor shooting in variable conditions. **Longitudinal chromatic aberration** affects image quality in mixed-lighting situations.
+
+## Typical focal lengths
+
+Wide (16-27mm) and standard (28-56mm) lenses cover the most common travel scenarios. Zoom lenses with wide focal length ranges (18-55mm, 16-80mm) are popular for their versatility, though primes offer better optical quality at lower weight.
+
+## Shooting style
+
+Travel photographers shoot handheld almost exclusively. The 1/FL rule determines minimum shutter speed for sharp handheld shots. Image stabilization (OIS) extends this, allowing slower shutter speeds in dim conditions. Kit weight is a first-class concern — every gram counts when walking 10+ miles a day.

--- a/src/content/wiki/wildlife-photography.md
+++ b/src/content/wiki/wildlife-photography.md
@@ -1,0 +1,27 @@
+---
+title: "Wildlife Photography"
+categories:
+  - "Genre"
+summary: "Sharp at distance for unpredictable subjects. What makes a lens good for wildlife work."
+related:
+  - "optical-scoring"
+  - "scoring-methodology"
+---
+
+Wildlife photography captures animals in their natural habitat, often at considerable distance. Subjects are unpredictable — they move, flee, or appear briefly. The photographer needs reach, sharpness, and fast reflexes.
+
+## What matters in a wildlife lens
+
+The primary scoring factors are **center sharpness wide open** and **center sharpness stopped down**. Wildlife subjects are typically small in the frame even with long focal lengths, so resolving power in the center is critical at both wide and stopped-down apertures. Wide open is needed in dim forest or dawn/dusk conditions; stopped down gives peak sharpness in good light.
+
+## Secondary factors
+
+**Aperture speed** enables faster shutter speeds to freeze animal movement. **Longitudinal chromatic aberration** and **lateral chromatic aberration** affect fine detail on feathers, fur, and scales — high-contrast textures where fringing is most visible.
+
+## Typical focal lengths
+
+Tele (57-150mm) and super-tele (151mm+) lenses are standard for wildlife. On Fuji X-mount, the 1.5x crop factor extends effective reach — a 100-400mm lens becomes equivalent to 150-600mm.
+
+## Shooting style
+
+Wildlife photographers use continuous autofocus with animal/bird eye detection. The 4x FL rule applies for handheld shooting. Many wildlife setups involve a monopod or bean bag for stability with heavy telephoto lenses. Patience and fieldcraft matter as much as gear.


### PR DESCRIPTION
## Summary
- Adds 10 wiki entries that were linked from the Genre Guide but returned 404
- `optical-scoring.md` — explains marks, OQ, primary floor rule, data sources
- 9 genre guides — nightscape, landscape, architecture, street, travel, portrait, sport, wildlife, macro
- Adds "Genre" to wiki category schema in `content.config.ts`
- Page count: 458 → 468

## Test plan
- [x] `npm run build` passes (468 pages)
- [x] Click "How marks work" link in any genre screener — should load `/wiki/optical-scoring`
- [x] Click genre guide link (e.g. "Nightscape guide") — should load `/wiki/nightscape-photography`
- [x] Wiki index shows new entries under "Genre" category

Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)