### PR TITLE
fix: mobile nav, filter layout, redirect flash, wiki cleanup

### DIFF
--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -5,7 +5,7 @@
 ```
 Phase 1 — Launch & Scoring (COMPLETE):
   Static site (Astro + React islands), deployed to GitHub Pages
-  -> 458 pages: 240+ lenses, 38 cameras, 46 accessories, 115 wiki, 9 genre screeners
+  -> 448 pages: 240+ lenses, 38 cameras, 46 accessories, 105 wiki, 9 genre screeners
   -> Genre scoring with OQ (Optical Quality) weighted formula
   -> Affiliate links as plain <a> tags with tracking params
   -> Domain: wuseria.com
@@ -341,3 +341,57 @@ Key decisions:
 - Full rebrand (not hybrid) to avoid Fujifilm trademark risk
 - wuseria.com confirmed after evaluating alternatives (Wusi, LensAtlas, Visu, etc.)
 - TS 5.9 over dropping @astrojs/check or using .npmrc workaround
+
+### Session 13 — 2026-04-16
+
+Tool: Claude Code (Opus 4.6)
+
+**Bug fixes, mobile UX, wiki cleanup**
+
+Mobile nav:
+- Added hamburger menu for screens < 640px (CSS + inline script, no React island)
+- Brand + toggle on mobile, full horizontal nav on desktop
+- Animated hamburger-to-X icon with aria-expanded for accessibility
+- Bumped nav link font from 0.875rem to 1rem, added active underline indicator
+- Increased brand-to-links spacing with gap: 2rem
+
+Filter layout:
+- Replaced flex-wrap with CSS Grid (2-col on mobile, auto-fit on desktop)
+- Applied to filter dropdowns and chip rows across all 3 explorers
+- Deterministic stacking — no more unpredictable wrap behaviour
+
+Redirect flash:
+- Styled index.astro redirect page with dark background (#0f1117)
+- Removed visible "Redirecting..." text — instant dark-to-dark transition
+
+Lens explorer cards:
+- Replaced focal length with filter thread using Φ symbol in mobile cards
+
+Lint / type fixes:
+- Removed unused imports (ScoredGenre, OPTICAL_FIELDS, MIN_OPTICAL_FIELDS)
+- Added missing FL_RANGES to useMemo dependency array
+- Fixed 26 TypeScript errors in scripts: double-cast through unknown
+- Removed stale git worktree that was polluting lint results
+
+Wiki cleanup:
+- Removed 10 academic/lab entries: angular-resolution, diffraction-limited-system,
+  integrating-sphere, ulbricht-sphere, siemens-star, sitf, strehl-ratio,
+  superlens, optical-resolution, aliasing
+- Added Post-Processing category to content schema
+- Moved 4 entries to Post-Processing: deblurring, deconvolution,
+  gamma-correction, super-resolution-imaging
+- Moved oversampling and moiré pattern from Optics to Sensor
+- Wiki guiding principle established: entries should help beginners decide
+  what to shoot and which lens to buy — no lab-only or theoretical content
+
+Issues created:
+- #254-#258 — Aberration wiki entries (astigmatism, distortion, chromatic
+  aberration, spherical aberration, vignetting)
+- #259 — Create Aberrations category and migrate entries
+- #260-#263 — Post-processing technique entries (focus stacking, HDR,
+  star stacking, panorama stitching)
+
+Key decisions:
+- Hamburger menu over horizontal scroll — users can't discover hidden links
+- CSS Grid over flex-wrap for filters — deterministic 2-col on mobile
+- Wiki rationale: beginner-friendly, decision-oriented, not academic

--- a/scripts/audit-suffixes.ts
+++ b/scripts/audit-suffixes.ts
@@ -12,7 +12,7 @@ for (const { suffix, field, label, matchValue } of checks) {
   let issues = 0;
 
   for (const l of lenses) {
-    const a = l as Record<string, unknown>;
+    const a = l as unknown as Record<string, unknown>;
     const model = String(a.model);
     const brand = String(a.brand);
     if (brand !== "Fujifilm") continue;

--- a/scripts/check-completeness.ts
+++ b/scripts/check-completeness.ts
@@ -1,7 +1,7 @@
 import { lenses } from "../src/data/lenses";
 import { OPTICAL_FIELDS } from "../src/utils/scoring";
 
-const scored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped != null);
+const scored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped != null);
 
 console.log("=== Data Completeness ===");
 console.log("Scored: " + scored.length + " / " + lenses.length);
@@ -9,7 +9,7 @@ console.log("");
 
 console.log("=== Incomplete lenses ===");
 for (const l of scored) {
-  const a = l as Record<string, unknown>;
+  const a = l as unknown as Record<string, unknown>;
   const filled = OPTICAL_FIELDS.filter((f) => a[f] != null).length;
   const missing = OPTICAL_FIELDS.filter((f) => a[f] == null).map(String);
   const pct = Math.round((filled / 14) * 100);
@@ -23,9 +23,9 @@ for (const l of scored) {
 }
 
 console.log("");
-const complete = scored.filter((l) => OPTICAL_FIELDS.every((f) => (l as Record<string, unknown>)[f] != null));
-const above10 = scored.filter((l) => OPTICAL_FIELDS.filter((f) => (l as Record<string, unknown>)[f] != null).length >= 10);
-const below10 = scored.filter((l) => OPTICAL_FIELDS.filter((f) => (l as Record<string, unknown>)[f] != null).length < 10);
+const complete = scored.filter((l) => OPTICAL_FIELDS.every((f) => (l as unknown as Record<string, unknown>)[f] != null));
+const above10 = scored.filter((l) => OPTICAL_FIELDS.filter((f) => (l as unknown as Record<string, unknown>)[f] != null).length >= 10);
+const below10 = scored.filter((l) => OPTICAL_FIELDS.filter((f) => (l as unknown as Record<string, unknown>)[f] != null).length < 10);
 
 console.log("=== Summary ===");
 console.log("Complete (14/14): " + complete.length + "/" + scored.length);

--- a/scripts/check-gfx-nightscape.ts
+++ b/scripts/check-gfx-nightscape.ts
@@ -1,16 +1,15 @@
 import { lenses } from "../src/data/lenses";
 
 const gfxScored = lenses.filter(
-  (l) => l.mount === "GFX" && (l as Record<string, unknown>).centerStopped != null
+  (l) => l.mount === "GFX" && (l as unknown as Record<string, unknown>).centerStopped != null
 );
 
 console.log("GFX scored: " + gfxScored.length);
 console.log("");
 
 for (const l of gfxScored) {
-  const a = l as Record<string, unknown>;
+  const a = l as unknown as Record<string, unknown>;
   const marks = a.genreMarks as Record<string, number> | undefined;
-  const hasNightscape = marks?.nightscape != null;
   const coma = a.coma;
   const astig = a.astigmatism;
   const aperture = a.maxAperture;

--- a/scripts/check-macro.ts
+++ b/scripts/check-macro.ts
@@ -1,8 +1,8 @@
 import { lenses } from "../src/data/lenses";
 
-const scored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped != null);
-const missingMag = scored.filter((l) => (l as Record<string, unknown>).maxMagnification == null);
-const missingMfd = scored.filter((l) => (l as Record<string, unknown>).minFocusDistance == null);
+const scored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped != null);
+const missingMag = scored.filter((l) => (l as unknown as Record<string, unknown>).maxMagnification == null);
+const missingMfd = scored.filter((l) => (l as unknown as Record<string, unknown>).minFocusDistance == null);
 
 console.log("Scored lenses: " + scored.length);
 console.log("Missing maxMagnification: " + missingMag.length);
@@ -12,7 +12,7 @@ console.log("");
 if (missingMag.length > 0) {
   console.log("=== Missing maxMagnification ===");
   for (const l of missingMag) {
-    const a = l as Record<string, unknown>;
+    const a = l as unknown as Record<string, unknown>;
     console.log("  " + a.brand + " " + a.model);
   }
 }
@@ -20,14 +20,14 @@ console.log("");
 if (missingMfd.length > 0) {
   console.log("=== Missing minFocusDistance ===");
   for (const l of missingMfd) {
-    const a = l as Record<string, unknown>;
+    const a = l as unknown as Record<string, unknown>;
     console.log("  " + a.brand + " " + a.model);
   }
 }
 
 console.log("=== All scored lenses mag/mfd ===");
 for (const l of scored) {
-  const a = l as Record<string, unknown>;
+  const a = l as unknown as Record<string, unknown>;
   const mag = a.maxMagnification as number;
   const mfd = a.minFocusDistance as number;
   console.log(

--- a/scripts/check-nightscape-missing.ts
+++ b/scripts/check-nightscape-missing.ts
@@ -1,12 +1,12 @@
 import { lenses } from "../src/data/lenses";
 
-const scored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped != null);
+const scored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped != null);
 const nightscape = scored.filter((l) => {
-  const marks = (l as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
+  const marks = (l as unknown as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
   return marks?.nightscape != null;
 });
 const missing = scored.filter((l) => {
-  const marks = (l as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
+  const marks = (l as unknown as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
   return marks?.nightscape == null;
 });
 
@@ -16,7 +16,7 @@ console.log("Missing nightscape: " + missing.length);
 console.log("");
 console.log("=== Missing nightscape (why?) ===");
 for (const l of missing) {
-  const a = l as Record<string, unknown>;
+  const a = l as unknown as Record<string, unknown>;
   const coma = a.coma;
   const astig = a.astigmatism;
   const reasons: string[] = [];

--- a/scripts/check-nightscape-visible.ts
+++ b/scripts/check-nightscape-visible.ts
@@ -1,7 +1,7 @@
 import { lenses } from "../src/data/lenses";
 
 const nightscape = lenses.filter((l) => {
-  const marks = (l as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
+  const marks = (l as unknown as Record<string, unknown>).genreMarks as Record<string, number> | undefined;
   return marks?.nightscape != null;
 });
 

--- a/scripts/check-sensors.ts
+++ b/scripts/check-sensors.ts
@@ -1,9 +1,9 @@
 import { lenses } from "../src/data/lenses";
 
-const scored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped != null);
+const scored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped != null);
 
 for (const l of scored) {
-  const lens = l as Record<string, unknown>;
+  const lens = l as unknown as Record<string, unknown>;
   const line = [
     String(lens.model).padEnd(40),
     "cS=" + String(lens.centerStopped ?? "-").padEnd(5),

--- a/scripts/list-unscored.ts
+++ b/scripts/list-unscored.ts
@@ -1,7 +1,7 @@
 import { lenses } from "../src/data/lenses";
 
-const unscored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped == null);
-const scored = lenses.filter((l) => (l as Record<string, unknown>).centerStopped != null);
+const unscored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped == null);
+const scored = lenses.filter((l) => (l as unknown as Record<string, unknown>).centerStopped != null);
 
 console.log("Scored: " + scored.length + " / " + lenses.length);
 console.log("Unscored: " + unscored.length);
@@ -9,7 +9,7 @@ console.log("");
 
 const byBrand: Record<string, string[]> = {};
 for (const l of unscored) {
-  const a = l as Record<string, unknown>;
+  const a = l as unknown as Record<string, unknown>;
   const b = String(a.brand);
   if (!byBrand[b]) byBrand[b] = [];
   byBrand[b].push(String(a.model));

--- a/scripts/test-genre.ts
+++ b/scripts/test-genre.ts
@@ -96,25 +96,25 @@ function focusDistanceScore(mfd: number): number {
 }
 
 for (const lens of lenses) {
-  const l = lens as Record<string, unknown>;
+  const l = lens as unknown as Record<string, unknown>;
   if (l.centerStopped == null) continue;
 
   const name = String(l.model);
 
   // Compute derived scores
   if (config.primary.includes("_apertureScore") || config.secondary.includes("_apertureScore")) {
-    (l as Record<string, unknown>)._apertureScore = apertureScore(l.maxAperture as number);
+    (l as unknown as Record<string, unknown>)._apertureScore = apertureScore(l.maxAperture as number);
   }
   if (config.primary.includes("_weightScore") || config.secondary.includes("_weightScore")) {
-    (l as Record<string, unknown>)._weightScore = weightScore(l.weight as number);
+    (l as unknown as Record<string, unknown>)._weightScore = weightScore(l.weight as number);
   }
   if (config.primary.includes("_magnificationScore") || config.secondary.includes("_magnificationScore")) {
     const mag = l.maxMagnification as number | undefined;
-    if (mag != null) (l as Record<string, unknown>)._magnificationScore = magnificationScore(mag);
+    if (mag != null) (l as unknown as Record<string, unknown>)._magnificationScore = magnificationScore(mag);
   }
   if (config.primary.includes("_focusDistanceScore") || config.secondary.includes("_focusDistanceScore")) {
     const mfd = l.minFocusDistance as number | undefined;
-    if (mfd != null) (l as Record<string, unknown>)._focusDistanceScore = focusDistanceScore(mfd);
+    if (mfd != null) (l as unknown as Record<string, unknown>)._focusDistanceScore = focusDistanceScore(mfd);
   }
 
   // Check primaries

--- a/scripts/test-landscape.ts
+++ b/scripts/test-landscape.ts
@@ -13,7 +13,7 @@ const allOptical = [
 ];
 
 for (const lens of lenses) {
-  const l = lens as Record<string, unknown>;
+  const l = lens as unknown as Record<string, unknown>;
   if (l.centerStopped == null) continue;
 
   const name = String(l.model);

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
@@ -39,9 +39,15 @@
 }
 
 .filterRow {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .filterRow {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
 }
 
 .searchInput {
@@ -73,8 +79,8 @@
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
   cursor: pointer;
-  flex: 1;
   min-width: 0;
+  width: 100%;
 }
 
 .filterSelect:focus {
@@ -110,9 +116,17 @@
    ========================================================================== */
 
 .chipRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .chipRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+  }
 }
 
 .chipGroup {

--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -39,9 +39,15 @@
 }
 
 .filterRow {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .filterRow {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
 }
 
 .searchInput {
@@ -73,8 +79,8 @@
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
   cursor: pointer;
-  flex: 1;
   min-width: 0;
+  width: 100%;
 }
 
 .filterSelect:focus {
@@ -110,9 +116,17 @@
    ========================================================================== */
 
 .chipRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .chipRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+  }
 }
 
 .chipGroup {

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -274,7 +274,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
       if (latcaFilter && (el.lens.lateralCA == null || el.lens.lateralCA < Number(latcaFilter))) return false;
       return true;
     });
-  }, [lenses, genre, cropFactor, ev, iso, selectedFl, magnification, sortBy, sortAsc, isNightscape, brandFilter, markFilter, priceFilter, weightFilter, apertureFilter, comaFilter, astigFilter, typeFilter, wrFilter, cornerFilter, distFilter, flareFilter, bokehFilter, locaFilter, latcaFilter]);
+  }, [lenses, genre, cropFactor, ev, iso, selectedFl, magnification, sortBy, sortAsc, isNightscape, brandFilter, markFilter, priceFilter, weightFilter, apertureFilter, comaFilter, astigFilter, typeFilter, wrFilter, cornerFilter, distFilter, flareFilter, bokehFilter, locaFilter, latcaFilter, FL_RANGES]);
 
   // -- Sort handler ---------------------------------------------------------
   function handleSort(key: SortKey): void {

--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -39,9 +39,15 @@
 }
 
 .filterRow {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .filterRow {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
 }
 
 .searchInput {
@@ -73,8 +79,8 @@
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
   cursor: pointer;
-  flex: 1;
   min-width: 0;
+  width: 100%;
 }
 
 .filterSelect:focus {
@@ -110,9 +116,17 @@
    ========================================================================== */
 
 .chipRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .chipRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+  }
 }
 
 .chipGroup {

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -20,6 +20,7 @@ type LensSortKey =
   | "year"
   | "focalLengthMin"
   | "maxAperture"
+  | "filterThread"
   | "hasOis"
   | "isWeatherSealed"
   | "afMotor"
@@ -35,6 +36,7 @@ const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
   { key: "year", label: "Year", align: "left" },
   { key: "focalLengthMin", label: "FL", align: "right" },
   { key: "maxAperture", label: "f/", align: "right" },
+  { key: "filterThread", label: "\u03A6", align: "right" },
   { key: "hasOis", label: "OIS", align: "center" },
   { key: "isWeatherSealed", label: "WR", align: "center" },
   { key: "afMotor", label: "AF", align: "center" },
@@ -44,6 +46,8 @@ const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
 ];
 
 const APERTURE_OPTIONS = ["0.95", "1.0", "1.2", "1.4", "1.8", "2.0", "2.8", "3.5", "4.0", "4.5", "5.6", "6.3", "8.0"];
+
+const FILTER_THREAD_OPTIONS = ["39", "43", "46", "49", "52", "55", "58", "62", "67", "72", "77", "82", "95"];
 
 const FL_RANGES: Record<string, [number, number]> = {
   "0-14": [0, 14],
@@ -86,6 +90,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
   const [discontinued, setDiscontinued] = useState("");
   const [fl, setFl] = useState("");
   const [maxAp, setMaxAp] = useState("");
+  const [filterThread, setFilterThread] = useState("");
   const [priceRange, setPriceRange] = useState("");
 
   const slugMap = useMemo(
@@ -117,6 +122,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
         if (lens.focalLengthMax < min || lens.focalLengthMin > max) return false;
       }
       if (maxAp && lens.maxAperture > parseFloat(maxAp)) return false;
+      if (filterThread && lens.filterThread !== Number(filterThread)) return false;
       if (priceRange) {
         const [min, max] = PRICE_RANGES[priceRange];
         if (lens.price < min || lens.price > max) return false;
@@ -124,7 +130,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
       if (q && !`${lens.brand} ${lens.model}`.toLowerCase().includes(q)) return false;
       return true;
     });
-  }, [lenses, search, mount, type, brand, ois, wr, af, discontinued, fl, maxAp, priceRange]);
+  }, [lenses, search, mount, type, brand, ois, wr, af, discontinued, fl, maxAp, filterThread, priceRange]);
 
   const availableFirst = useCallback((a: ExplorerLens, b: ExplorerLens) =>
     Number(a.isDiscontinued ?? false) - Number(b.isDiscontinued ?? false), []);
@@ -140,7 +146,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
     }
   }
 
-  const hasFilters = search || mount || type || brand || ois || wr || af || discontinued || fl || maxAp || priceRange;
+  const hasFilters = search || mount || type || brand || ois || wr || af || discontinued || fl || maxAp || filterThread || priceRange;
 
   function clearFilters(): void {
     setSearch("");
@@ -153,6 +159,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
     setDiscontinued("");
     setFl("");
     setMaxAp("");
+    setFilterThread("");
     setPriceRange("");
   }
 
@@ -211,6 +218,14 @@ function LensExplorer({ lenses }: LensExplorerProps) {
             <option value={RESET_VALUE}>All</option>
             {APERTURE_OPTIONS.map((ap) => (
               <option key={ap} value={ap}>f/{ap} or faster</option>
+            ))}
+          </select>
+
+          <select className={`${styles.filterSelect} ${filterThread ? styles.filterActive : ""}`} value={filterThread} onChange={(e) => setFilterThread(resetValue(e.target.value))} aria-label="Filter by filter thread">
+            <option value="" hidden>{"\u03A6"} Thread</option>
+            <option value={RESET_VALUE}>All</option>
+            {FILTER_THREAD_OPTIONS.map((t) => (
+              <option key={t} value={t}>{"\u03A6"}{t}mm</option>
             ))}
           </select>
 
@@ -291,6 +306,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                     <td>{lens.year ?? ""}</td>
                     <td className={styles.cellRight}>{formatFL(lens)}</td>
                     <td className={styles.cellRight}>{lens.maxAperture}</td>
+                    <td className={styles.cellRight}>{lens.filterThread ?? "\u2013"}</td>
                     <td className={styles.cellCenter}><span className={lens.hasOis ? styles.dotOn : styles.dotOff} /></td>
                     <td className={styles.cellCenter}><span className={lens.isWeatherSealed ? styles.dotOn : styles.dotOff} /></td>
                     <td className={styles.cellCenter}>{lens.afMotor ?? "MF"}</td>
@@ -316,7 +332,6 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                 <div className={styles.cardSpecs}>
                   <span>f/{lens.maxAperture}</span>
                   <span>{lens.weight}g</span>
-                  {lens.filterThread != null && <span>{"\u03A6"}{lens.filterThread}</span>}
                   {lens.opticalQuality != null && <span>OQ {lens.opticalQuality.toFixed(1)}</span>}
                   {lens.year && <span>{lens.year}</span>}
                 </div>

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -314,9 +314,9 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                   <span className={styles.cardPrice}>~${lens.price}</span>
                 </div>
                 <div className={styles.cardSpecs}>
-                  <span>{formatFL(lens)}</span>
                   <span>f/{lens.maxAperture}</span>
                   <span>{lens.weight}g</span>
+                  {lens.filterThread != null && <span>{"\u03A6"}{lens.filterThread}</span>}
                   {lens.opticalQuality != null && <span>OQ {lens.opticalQuality.toFixed(1)}</span>}
                   {lens.year && <span>{lens.year}</span>}
                 </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,7 @@ const wiki = defineCollection({
       "Lenses",
       "Lighting",
       "Optics",
+      "Post-Processing",
       "Sensor",
     ])).min(1),
     summary: z.string(),

--- a/src/content/wiki/aliasing.md
+++ b/src/content/wiki/aliasing.md
@@ -1,9 +1,0 @@
----
-title: "Aliasing"
-fullTitle: "Aliasing"
-categories:
-  - "Optics"
-summary: "Artefact caused when the sensor resolution is insufficient to capture fine detail, resulting in moiré patterns or stair-stepping on diagonal lines."
----
-
-Artefact caused when the sensor resolution is insufficient to capture fine detail, resulting in moiré patterns or stair-stepping on diagonal lines. Prevented by anti-aliasing filters.

--- a/src/content/wiki/angular-resolution.md
+++ b/src/content/wiki/angular-resolution.md
@@ -1,9 +1,0 @@
----
-title: "Angular resolution"
-fullTitle: "Angular Resolution"
-categories:
-  - "Optics"
-summary: "The minimum angle between two point sources that a system can resolve as distinct."
----
-
-The minimum angle between two point sources that a system can resolve as distinct. For a camera: limited by both the diffraction limit (aperture) and sensor pixel pitch. Determines effective resolving power at a given distance.

--- a/src/content/wiki/deblurring.md
+++ b/src/content/wiki/deblurring.md
@@ -2,7 +2,7 @@
 title: "Deblurring"
 fullTitle: "Deblurring"
 categories:
-  - "Optics"
+  - "Post-Processing"
 summary: "Post-processing technique to recover sharpness from motion blur or defocus blur."
 ---
 

--- a/src/content/wiki/deconvolution.md
+++ b/src/content/wiki/deconvolution.md
@@ -2,7 +2,7 @@
 title: "Deconvolution"
 fullTitle: "Deconvolution"
 categories:
-  - "Optics"
+  - "Post-Processing"
 summary: "Mathematical process to reverse the blurring effect of a known optical system (PSF)."
 ---
 

--- a/src/content/wiki/diffraction-limited-system.md
+++ b/src/content/wiki/diffraction-limited-system.md
@@ -1,9 +1,0 @@
----
-title: "Diffraction-limited system"
-fullTitle: "Diffraction-Limited System"
-categories:
-  - "Optics"
-summary: "An optical system where performance is limited by diffraction rather than aberrations or manufacturing imperfections."
----
-
-An optical system where performance is limited by diffraction rather than aberrations or manufacturing imperfections. Represents the theoretical maximum sharpness for a given aperture.

--- a/src/content/wiki/gamma-correction.md
+++ b/src/content/wiki/gamma-correction.md
@@ -2,7 +2,7 @@
 title: "Gamma correction"
 fullTitle: "Gamma Correction"
 categories:
-  - "Optics"
+  - "Post-Processing"
 summary: "A nonlinear tone mapping applied to image data to match human perception of brightness."
 ---
 

--- a/src/content/wiki/integrating-sphere.md
+++ b/src/content/wiki/integrating-sphere.md
@@ -1,9 +1,0 @@
----
-title: "Integrating sphere"
-fullTitle: "Integrating Sphere"
-categories:
-  - "Optics"
-summary: "A hollow sphere with diffuse white interior coating used to measure total luminous flux from a light source."
----
-
-A hollow sphere with diffuse white interior coating used to measure total luminous flux from a light source. Used in lens and sensor calibration laboratories.

--- a/src/content/wiki/moir-pattern.md
+++ b/src/content/wiki/moir-pattern.md
@@ -2,7 +2,7 @@
 title: "Moiré pattern"
 fullTitle: "Moiré Pattern"
 categories:
-  - "Optics"
+  - "Sensor"
 summary: "An interference pattern that appears when two regular patterns (e."
 ---
 

--- a/src/content/wiki/optical-resolution.md
+++ b/src/content/wiki/optical-resolution.md
@@ -1,9 +1,0 @@
----
-title: "Optical resolution"
-fullTitle: "Optical Resolution"
-categories:
-  - "Optics"
-summary: "The true resolving power of a lens, independent of sensor resolution."
----
-
-The true resolving power of a lens, independent of sensor resolution. Expressed as line pairs per millimetre (lp/mm). A lens must exceed the sensor's Nyquist frequency to avoid resolution bottleneck.

--- a/src/content/wiki/oversampling.md
+++ b/src/content/wiki/oversampling.md
@@ -2,7 +2,7 @@
 title: "Oversampling"
 fullTitle: "Oversampling"
 categories:
-  - "Optics"
+  - "Sensor"
 summary: "Capturing at higher resolution than needed and downsampling."
 ---
 

--- a/src/content/wiki/siemens-star.md
+++ b/src/content/wiki/siemens-star.md
@@ -1,9 +1,0 @@
----
-title: "Siemens star"
-fullTitle: "Siemens Star"
-categories:
-  - "Optics"
-summary: "A test chart consisting of alternating black and white wedges radiating from a centre point."
----
-
-A test chart consisting of alternating black and white wedges radiating from a centre point. Used to measure resolving power and detect astigmatism or other aberrations at different field positions.

--- a/src/content/wiki/sitf.md
+++ b/src/content/wiki/sitf.md
@@ -1,9 +1,0 @@
----
-title: "SiTF"
-fullTitle: "Signal Transfer Function"
-categories:
-  - "Optics"
-summary: "Describes how a sensor or imaging system converts scene radiance to output signal."
----
-
-Describes how a sensor or imaging system converts scene radiance to output signal. Used in scientific imaging to characterise linearity and dynamic range.

--- a/src/content/wiki/strehl-ratio.md
+++ b/src/content/wiki/strehl-ratio.md
@@ -1,9 +1,0 @@
----
-title: "Strehl ratio"
-fullTitle: "Strehl Ratio"
-categories:
-  - "Optics"
-summary: "A measure of optical quality comparing peak intensity of an aberrated system to a perfect diffraction-limited system."
----
-
-A measure of optical quality comparing peak intensity of an aberrated system to a perfect diffraction-limited system. Value of 1.0 = perfect. Values above 0.8 are considered diffraction-limited.

--- a/src/content/wiki/super-resolution-imaging.md
+++ b/src/content/wiki/super-resolution-imaging.md
@@ -2,7 +2,7 @@
 title: "Super-resolution imaging"
 fullTitle: "Super-Resolution Imaging"
 categories:
-  - "Optics"
+  - "Post-Processing"
 summary: "Techniques to produce images with resolution beyond the sensor's native limit."
 ---
 

--- a/src/content/wiki/superlens.md
+++ b/src/content/wiki/superlens.md
@@ -1,9 +1,0 @@
----
-title: "Superlens"
-fullTitle: "Superlens"
-categories:
-  - "Optics"
-summary: "A theoretical or experimental optical device using metamaterials with negative refractive index to overcome the diffraction limit."
----
-
-A theoretical or experimental optical device using metamaterials with negative refractive index to overcome the diffraction limit. Not yet practical for photography.

--- a/src/content/wiki/ulbricht-sphere.md
+++ b/src/content/wiki/ulbricht-sphere.md
@@ -1,9 +1,0 @@
----
-title: "Ulbricht sphere"
-fullTitle: "Ulbricht Sphere"
-categories:
-  - "Optics"
-summary: "Another name for an integrating sphere, named after German physicist Ulbricht."
----
-
-Another name for an integrating sphere, named after German physicist Ulbricht. Used to achieve spatially uniform illumination for radiometric measurements.

--- a/src/data/lenses.test.ts
+++ b/src/data/lenses.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { lenses } from "./lenses";
-import type { ScoredGenre } from "../types/genre";
 import { OPTICAL_FIELDS, genreFormulas } from "../utils/scoring";
 
 // =============================================================================

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -40,7 +40,20 @@ const navLinks = [
     <header class="site-header">
       <nav class="nav" aria-label="Main navigation">
         <a href="/lenses" class="nav-brand">Wuseria</a>
-        <ul class="nav-links" role="list">
+        <button
+          class="nav-toggle"
+          type="button"
+          aria-label="Toggle menu"
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <svg class="nav-toggle-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <line class="bar bar1" x1="3" y1="5" x2="17" y2="5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+            <line class="bar bar2" x1="3" y1="10" x2="17" y2="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+            <line class="bar bar3" x1="3" y1="15" x2="17" y2="15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+          </svg>
+        </button>
+        <ul class="nav-links" id="nav-menu" role="list">
           {navLinks.map((link) => (
             <li>
               <a
@@ -54,6 +67,13 @@ const navLinks = [
         </ul>
       </nav>
     </header>
+    <script is:inline>
+      document.querySelector('.nav-toggle').addEventListener('click', function () {
+        const expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', String(!expanded));
+        document.querySelector('.nav-links').classList.toggle('open');
+      });
+    </script>
 
     <main class="main">
       <slot />
@@ -74,17 +94,17 @@ const navLinks = [
     z-index: 10;
     background-color: var(--color-bg-surface);
     border-bottom: 1px solid var(--color-border);
-    height: var(--nav-height);
   }
 
   .nav {
     display: flex;
     align-items: center;
-    gap: var(--space-lg);
+    flex-wrap: wrap;
+    gap: var(--space-xl);
     max-width: var(--max-width);
     margin: 0 auto;
     padding: 0 var(--space-md);
-    height: 100%;
+    min-height: var(--nav-height);
   }
 
   .nav-brand {
@@ -98,29 +118,60 @@ const navLinks = [
     color: var(--color-accent);
   }
 
+  /* Hamburger toggle — mobile only */
+  .nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: var(--space-xs);
+    margin-left: auto;
+  }
+
+  .nav-toggle:hover {
+    color: var(--color-text);
+  }
+
+  .nav-toggle-icon .bar {
+    transition: transform 0.2s, opacity 0.2s;
+    transform-origin: center;
+  }
+
+  .nav-toggle[aria-expanded="true"] .bar1 {
+    transform: translateY(5px) rotate(45deg);
+  }
+
+  .nav-toggle[aria-expanded="true"] .bar2 {
+    opacity: 0;
+  }
+
+  .nav-toggle[aria-expanded="true"] .bar3 {
+    transform: translateY(-5px) rotate(-45deg);
+  }
+
   .nav-links {
     display: flex;
     gap: var(--space-sm);
     list-style: none;
-    overflow-x: auto;
   }
 
   .nav-link {
     display: block;
     padding: var(--space-xs) var(--space-sm);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-base);
     color: var(--color-text-muted);
-    border-radius: var(--radius);
     white-space: nowrap;
+    border-bottom: 2px solid transparent;
   }
 
   .nav-link:hover {
     color: var(--color-text);
-    background-color: var(--color-bg-hover);
   }
 
   .nav-link.active {
     color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
   }
 
   .main {
@@ -142,15 +193,27 @@ const navLinks = [
     color: var(--color-text-muted);
   }
 
-  /* Mobile: hide nav links, show brand only */
+  /* Mobile: hamburger menu */
   @media (max-width: 640px) {
+    .nav-toggle {
+      display: block;
+    }
+
     .nav-links {
-      gap: var(--space-xs);
+      display: none;
+      flex-direction: column;
+      width: 100%;
+      gap: 0;
+      padding: var(--space-sm) 0;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .nav-links.open {
+      display: flex;
     }
 
     .nav-link {
-      font-size: 0.75rem;
-      padding: var(--space-xs);
+      padding: var(--space-sm) var(--space-sm);
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,8 +4,10 @@
     <meta http-equiv="refresh" content="0;url=/lenses" />
     <link rel="canonical" href="/lenses" />
     <title>Wuseria — Fujifilm Lens and Camera Explorer</title>
+    <style>
+      html { background-color: #0f1117; color: #e1e4ed; }
+    </style>
   </head>
   <body>
-    <p>Redirecting to <a href="/lenses">Lenses</a>...</p>
   </body>
 </html>

--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -12,8 +12,6 @@ import {
   resolveField,
   opticalFieldCount,
   genreFormulas,
-  OPTICAL_FIELDS,
-  MIN_OPTICAL_FIELDS,
   getGenreMark,
   isEditorialPick,
   lensesForGenre,


### PR DESCRIPTION
## Summary

- Add hamburger menu for mobile nav (< 640px) with animated toggle and aria support
- Replace flex-wrap with CSS Grid (2-col mobile) for filter dropdowns and chip rows across all 3 explorers
- Style redirect page with dark background to prevent white flash on first visit
- Bump nav link font size, add active underline indicator, increase brand spacing
- Replace FL with filter thread (Φ) in lens explorer mobile cards
- Fix 26 TypeScript errors in scripts, unused imports, and useMemo deps
- Remove 10 academic wiki entries, add Post-Processing category, recategorize 6 entries

## Test plan

- [x] Mobile (< 640px): hamburger toggles nav, links stack vertically, X animation works
- [x] Desktop (>= 640px): horizontal nav, no hamburger visible, active underline on current page
- [x] Filter dropdowns stack in 2-col grid on mobile across lenses, cameras, accessories
- [x] Chip rows stack in 2-col grid on mobile across lenses, cameras, accessories
- [x] Homepage loads with dark background (no white flash)
- [x] Lens explorer mobile cards show Φ{size} instead of focal length
- [x] Wiki index renders without removed entries, Post-Processing category appears
- [x] `npm run check:all` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)