### PR TITLE
fix: flex-wrap chip layout for both explorers

### DIFF
--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -116,15 +116,13 @@
    ========================================================================== */
 
 .chipRow {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--space-xs);
 }
 
 @media (min-width: 640px) {
   .chipRow {
-    display: flex;
-    flex-wrap: wrap;
     gap: var(--space-md);
   }
 }
@@ -156,6 +154,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+  flex: 1 1 auto;
+  text-align: center;
 }
 
 .chip:first-of-type {

--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -123,8 +123,6 @@
 
 @media (min-width: 640px) {
   .chipRow {
-    display: flex;
-    flex-wrap: wrap;
     gap: var(--space-md);
   }
 }
@@ -156,6 +154,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+  flex: 1 1 auto;
+  text-align: center;
 }
 
 .chip:first-of-type {


### PR DESCRIPTION
## Summary
- Replace fixed 2-column grid with flex-wrap on mobile for Lens and Camera explorers
- Chips grow to fill available space (`flex: 1 1 auto`) for better utilization
- Clean up redundant media query in Lens Explorer

## Test plan
- [x] Lens Explorer chips wrap correctly on mobile — no overflow
- [x] Camera Explorer chips wrap correctly on mobile
- [x] Status chip ("Available" / "Discontinued") fully visible
- [x] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)