### PR TITLE
Fix code review and structure audit quick wins

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,14 @@
   "singleQuote": false,
   "trailingComma": "all",
   "printWidth": 80,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,6 @@ src/
         GenreGuide.module.css
         exposure.ts               // EV scene evaluation logic
         exposure.test.ts
-      TradeDealsFilter/
-        TradeDealsFilter.tsx      // Filter deals (client:visible)
-        TradeDealsFilter.module.css
   data/
     lenses.ts                     // Lens[]
     cameras.ts                    // Camera[]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ See [CLAUDE.md](CLAUDE.md) for full project conventions:
 - Run `npm run check:all` before every commit
 - No `any` in TypeScript, no inline styles, no hardcoded data in components
 
+## Configuration
+
+No environment variables are required. Site-level settings (currency, site
+name) are in `src/data/config.ts`. All content lives in `src/data/*.ts`
+files, type-checked at build time.
+
 ## Links
 
 - [Architecture decisions](docs/decisions/)

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -26,9 +26,8 @@ already cloned without it, run `git submodule update --init`.
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173). You should see a blank
-page (no UI yet — the project is in data migration phase). Confirm the dev
-server starts without errors.
+Open [http://localhost:4321](http://localhost:4321). You should be redirected
+to the Lens Explorer page. Confirm the dev server starts without errors.
 
 To verify linting:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.2",
+        "prettier-plugin-astro": "^0.14.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.4"
@@ -6665,6 +6666,28 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-astro/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -7100,6 +7123,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -7386,6 +7426,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",
+    "prettier-plugin-astro": "^0.14.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.4"

--- a/src/components/static/GenreScoreBadge.astro
+++ b/src/components/static/GenreScoreBadge.astro
@@ -4,8 +4,8 @@ interface Props {
 }
 
 const { mark } = Astro.props;
-const palette = ["", "#2a2520", "#4a4540", "#7a7060", "#c08830", "#e8a045"];
-const color = palette[mark] || "#8a8070";
+const palette = ["", "var(--color-mark-1)", "var(--color-mark-2)", "var(--color-mark-3)", "var(--color-mark-4)", "var(--color-mark-5)"];
+const color = palette[mark] || "var(--color-mark-fallback)";
 const dots = "●".repeat(mark);
 ---
 

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -99,7 +99,7 @@ const compat = "compatibleWith" in accessory && Array.isArray(accessory.compatib
 
     <section class="links">
       {accessory.officialUrl && (
-        <a href={accessory.officialUrl} target="_blank" rel="nofollow sponsored" class="link-button">Official product page</a>
+        <a href={accessory.officialUrl} target="_blank" rel="noopener noreferrer" class="link-button">Official product page</a>
       )}
       <a href="/accessories" class="back-link">Back to Accessories</a>
     </section>

--- a/src/pages/cameras/[slug].astro
+++ b/src/pages/cameras/[slug].astro
@@ -120,7 +120,7 @@ const jsonLd = {
 
     <section class="links">
       {camera.officialUrl && (
-        <a href={camera.officialUrl} target="_blank" rel="nofollow sponsored" class="link-button">Official product page</a>
+        <a href={camera.officialUrl} target="_blank" rel="noopener noreferrer" class="link-button">Official product page</a>
       )}
       <a href="/cameras" class="back-link">Back to Camera Explorer</a>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,7 @@
+---
+import "../styles/global.css";
+---
+
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -5,7 +9,7 @@
     <link rel="canonical" href="/lenses" />
     <title>Wuseria — Fujifilm Lens and Camera Explorer</title>
     <style>
-      html { background-color: #0f1117; color: #e1e4ed; }
+      html { background-color: var(--color-bg); color: var(--color-text); }
     </style>
   </head>
   <body>

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -185,7 +185,7 @@ const jsonLd = {
       <h2>Links</h2>
       <div class="link-row">
         {lens.officialUrl && (
-          <a href={lens.officialUrl} target="_blank" rel="nofollow sponsored" class="link-button">Official product page</a>
+          <a href={lens.officialUrl} target="_blank" rel="noopener noreferrer" class="link-button">Official product page</a>
         )}
         {lens.reviewSources && Object.entries(lens.reviewSources).map(([source, url]) => (
           <a href={url} target="_blank" rel="nofollow" class="link-button">{source}</a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,14 @@
   --color-link: #6c9bff;
   --color-link-hover: #8db3ff;
 
+  /* Mark level colors (genre score pips) */
+  --color-mark-1: #2a2520;
+  --color-mark-2: #4a4540;
+  --color-mark-3: #7a7060;
+  --color-mark-4: #c08830;
+  --color-mark-5: #e8a045;
+  --color-mark-fallback: #8a8070;
+
   /* Spacing */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;


### PR DESCRIPTION
## Summary
- Replace hardcoded hex colors with CSS custom properties in GenreScoreBadge and index.astro (#293)
- Fix `rel="nofollow sponsored"` → `rel="noopener noreferrer"` on official product links across all detail pages (#294)
- Remove phantom TradeDealsFilter entry from CLAUDE.md project structure (#292)
- Install and configure `prettier-plugin-astro` for .astro file formatting (#297)
- Fix stale ONBOARDING.md — port 5173→4321, updated page description (#298)
- Add missing Configuration section to README (#296)

## Test plan
- [x] `npm run check:all` passes (lint + check + test + build)
- [x] 458 pages built successfully
- [x] CSS custom properties resolve correctly in built index.html
- [x] Visual spot-check: GenreScoreBadge colors unchanged
- [x] Verify official product links have correct `rel` attribute in browser

Closes #292, closes #293, closes #294, closes #296, closes #297, closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)