### PR TITLE
fix: clarify FL-independent shutter in tripod matrices

### DIFF
--- a/src/components/interactive/GenreGuide/ArchitectureMatrix.tsx
+++ b/src/components/interactive/GenreGuide/ArchitectureMatrix.tsx
@@ -66,7 +66,8 @@ function ArchitectureMatrix({ cropFactor, iso, ev, nd, selectedFl }: Architectur
         <span className={styles.lsDramaticText}>●</span> people vanish
       </div>
       <p className={styles.matrixExplain}>
-        Each cell shows the shutter speed at that aperture. Blue freezes
+        Each cell shows the shutter speed at that aperture. On a tripod, shutter
+        speed depends on aperture and light, not focal length. Blue freezes
         people sharply. Amber blurs movement. Teal makes people disappear
         from long exposures — ideal for empty architecture shots.
       </p>

--- a/src/components/interactive/GenreGuide/LandscapeMatrix.tsx
+++ b/src/components/interactive/GenreGuide/LandscapeMatrix.tsx
@@ -66,7 +66,8 @@ function LandscapeMatrix({ cropFactor, iso, ev, nd, selectedFl, title }: Landsca
         <span className={styles.lsDramaticText}>●</span> dramatic (&gt;30s)
       </div>
       <p className={styles.matrixExplain}>
-        Each cell shows the shutter speed at that aperture. Blue freezes motion.
+        Each cell shows the shutter speed at that aperture. On a tripod, shutter
+        speed depends on aperture and light, not focal length. Blue freezes motion.
         Green gives silky water and cloud streaks. Teal creates dramatic long
         exposures where moving objects disappear.
       </p>


### PR DESCRIPTION
## Summary
- Added explanatory note to Landscape and Architecture EV matrices explaining that shutter speed on a tripod depends on aperture and light, not focal length
- FL columns are retained for layout consistency — identical values per row are correct physics, not a bug

Closes #295

## Test plan
- [x] Verify `npm run check:all` passes
- [x] Check /genre/landscape matrix — explain text mentions FL independence
- [x] Check /genre/architecture matrix — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)