### PR TITLE
refactor: extract duplicated types and helpers to shared modules

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -4,6 +4,8 @@ import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
+import type { ColumnAlign } from "../shared/table";
+import { makeAlignClasses } from "../shared/table";
 import styles from "./AccessoriesExplorer.module.css";
 
 interface AccessoriesExplorerProps {
@@ -17,8 +19,6 @@ type AccessorySortKey =
   | "description"
   | "price";
 
-type ColumnAlign = "left" | "right";
-
 const COLUMNS: { key: AccessorySortKey; label: string; align: ColumnAlign }[] = [
   { key: "category", label: "Category", align: "left" },
   { key: "brand", label: "Brand", align: "left" },
@@ -27,10 +27,7 @@ const COLUMNS: { key: AccessorySortKey; label: string; align: ColumnAlign }[] = 
   { key: "price", label: "Price", align: "right" },
 ];
 
-const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
-  left: undefined,
-  right: styles.cellRight,
-};
+const ALIGN_CLASSES = makeAlignClasses(styles);
 
 const CATEGORY_LABELS: Record<string, string> = {
   "flash": "Flash",

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -4,6 +4,8 @@ import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
+import type { ColumnAlign } from "../shared/table";
+import { makeAlignClasses } from "../shared/table";
 import styles from "./CameraExplorer.module.css";
 
 interface CameraExplorerProps {
@@ -23,8 +25,6 @@ type CameraSortKey =
   | "weight"
   | "price";
 
-type ColumnAlign = "left" | "right" | "center";
-
 const COLUMNS: { key: CameraSortKey; label: string; align: ColumnAlign }[] = [
   { key: "model", label: "Model", align: "left" },
   { key: "year", label: "Year", align: "right" },
@@ -39,11 +39,7 @@ const COLUMNS: { key: CameraSortKey; label: string; align: ColumnAlign }[] = [
   { key: "price", label: "Price", align: "right" },
 ];
 
-const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
-  left: undefined,
-  right: styles.cellRight,
-  center: styles.cellCenter,
-};
+const ALIGN_CLASSES = makeAlignClasses(styles);
 
 const YEAR_RANGES: Record<string, [number, number]> = {
   "2022+": [2022, Infinity],

--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -3,25 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import GenreGuide from "./GenreGuide";
 import type { Lens } from "../../../types/lens";
-
-// =============================================================================
-// TEST FIXTURES
-// =============================================================================
-
-function makeLens(
-  overrides: Partial<Lens> & Pick<Lens, "brand" | "model">,
-): Lens {
-  return {
-    type: "prime",
-    mount: "X",
-    focalLengthMin: 35,
-    focalLengthMax: 35,
-    maxAperture: 1.4,
-    weight: 200,
-    price: 600,
-    ...overrides,
-  };
-}
+import { makeLens } from "../../../test/factories";
 
 const testLenses: Lens[] = [
   makeLens({

--- a/src/components/interactive/GenreGuide/GenreGuide.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.tsx
@@ -16,6 +16,7 @@ import {
   NIGHTSCAPE_ISO_BY_EV,
   MACRO_MAGNIFICATION_OPTIONS,
 } from "../../../data/genres";
+import { formatFL } from "../../../utils/formatting";
 import { getGenreMark, isEditorialPick } from "../../../utils/scoring";
 import { toSlug } from "../../../utils/slug";
 import { astroExposure, handheldExposure } from "./exposure";
@@ -1004,9 +1005,7 @@ function GenreGuide({ lenses, defaultGenre = "street" }: GenreGuideProps) {
                 <div className={styles.cardSpecs}>
                   <span>f/{el.lens.maxAperture}</span>
                   <span>
-                    {el.lens.focalLengthMin === el.lens.focalLengthMax
-                      ? `${el.lens.focalLengthMin}mm`
-                      : `${el.lens.focalLengthMin}-${el.lens.focalLengthMax}mm`}
+                    {formatFL(el.lens.focalLengthMin, el.lens.focalLengthMax)}
                   </span>
                   {isNightscape && el.rule500 != null && <span>{el.rule500}s</span>}
                   {(isNightscape || (!isLandscape && !isArchitecture && !isPortrait && !isStreet)) && el.idealIso != null && <span>ISO {fmtIso(el.idealIso)}</span>}

--- a/src/components/interactive/GenreGuide/exposure.test.ts
+++ b/src/components/interactive/GenreGuide/exposure.test.ts
@@ -1,21 +1,6 @@
 import { describe, it, expect } from "vitest";
-import type { Lens } from "../../../types/lens";
+import { makeLens } from "../../../test/factories";
 import { astroExposure, handheldExposure } from "./exposure";
-
-function makeLens(
-  overrides: Partial<Lens> & Pick<Lens, "brand" | "model">,
-): Lens {
-  return {
-    type: "prime",
-    mount: "X",
-    focalLengthMin: 35,
-    focalLengthMax: 35,
-    maxAperture: 1.4,
-    weight: 200,
-    price: 600,
-    ...overrides,
-  };
-}
 
 const xf16 = makeLens({
   brand: "Fujifilm",

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -2,8 +2,11 @@ import { useState, useMemo, useCallback } from "react";
 import type { Lens } from "../../../types/lens";
 import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
+import { formatFL } from "../../../utils/formatting";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
+import type { ColumnAlign } from "../shared/table";
+import { makeAlignClasses } from "../shared/table";
 import styles from "./LensExplorer.module.css";
 
 interface ExplorerLens extends Lens {
@@ -27,8 +30,6 @@ type LensSortKey =
   | "weight"
   | "opticalQuality"
   | "price";
-
-type ColumnAlign = "left" | "right" | "center";
 
 const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
   { key: "brand", label: "Brand", align: "left" },
@@ -73,18 +74,7 @@ const PRICE_RANGES: Record<string, [number, number]> = {
   "2000+": [2000, Infinity],
 };
 
-const ALIGN_CLASSES: Record<ColumnAlign, string | undefined> = {
-  left: undefined,
-  right: styles.cellRight,
-  center: styles.cellCenter,
-};
-
-function formatFL(lens: Lens): string {
-  if (lens.focalLengthMin === lens.focalLengthMax) {
-    return `${lens.focalLengthMin}mm`;
-  }
-  return `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
-}
+const ALIGN_CLASSES = makeAlignClasses(styles);
 
 function LensExplorer({ lenses }: LensExplorerProps) {
   const [search, setSearch] = useState("");
@@ -328,7 +318,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
                       </a>
                     </td>
                     <td>{lens.year ?? ""}</td>
-                    <td className={styles.cellRight}>{formatFL(lens)}</td>
+                    <td className={styles.cellRight}>{formatFL(lens.focalLengthMin, lens.focalLengthMax)}</td>
                     <td className={styles.cellRight}>{lens.maxAperture}</td>
                     <td className={styles.cellRight}>{lens.filterThread ?? "\u2013"}</td>
                     <td className={styles.cellCenter}><span className={lens.hasOis ? styles.dotOn : styles.dotOff} /></td>

--- a/src/components/interactive/shared/table.ts
+++ b/src/components/interactive/shared/table.ts
@@ -1,0 +1,14 @@
+type ColumnAlign = "left" | "right" | "center";
+
+function makeAlignClasses(
+  styles: Record<string, string>,
+): Record<ColumnAlign, string | undefined> {
+  return {
+    left: undefined,
+    right: styles.cellRight,
+    center: styles.cellCenter,
+  };
+}
+
+export type { ColumnAlign };
+export { makeAlignClasses };

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -4,6 +4,7 @@ import Base from "../../layouts/Base.astro";
 import { lenses } from "../../data/lenses";
 import { genreConfigs } from "../../data/genres";
 import { toSlug } from "../../utils/slug";
+import { formatFL } from "../../utils/formatting";
 import { opticalFieldCount, OPTICAL_FIELDS } from "../../utils/scoring";
 import type { ScoredGenre } from "../../types/genre";
 
@@ -19,12 +20,6 @@ const { lens } = Astro.props as Props;
 
 const slug = toSlug(`${lens.brand} ${lens.model}`);
 const canonicalUrl = new URL(`/lenses/${slug}`, Astro.site);
-
-function formatFL(): string {
-  return lens.focalLengthMin === lens.focalLengthMax
-    ? `${lens.focalLengthMin}mm`
-    : `${lens.focalLengthMin}-${lens.focalLengthMax}mm`;
-}
 
 function yesNo(val?: boolean): string {
   return val ? "Yes" : "No";
@@ -93,7 +88,7 @@ const jsonLd = {
         <h2>Specifications</h2>
         <table class="spec-table">
           <tbody>
-            <tr><td>Focal length</td><td>{formatFL()}</td></tr>
+            <tr><td>Focal length</td><td>{formatFL(lens.focalLengthMin, lens.focalLengthMax)}</td></tr>
             <tr><td>Max aperture</td><td>f/{lens.maxAperture}</td></tr>
             {lens.sweetSpotAperture && <tr><td>Sweet spot</td><td>f/{lens.sweetSpotAperture}</td></tr>}
             {lens.apertureBlades && <tr><td>Aperture blades</td><td>{lens.apertureBlades}{lens.hasCircularAperture ? " (circular)" : ""}</td></tr>}

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,18 @@
+import type { Lens } from "../types/lens";
+
+function makeLens(
+  overrides: Partial<Lens> & Pick<Lens, "brand" | "model">,
+): Lens {
+  return {
+    type: "prime",
+    mount: "X",
+    focalLengthMin: 35,
+    focalLengthMax: 35,
+    maxAperture: 1.4,
+    weight: 200,
+    price: 600,
+    ...overrides,
+  };
+}
+
+export { makeLens };

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -14,4 +14,11 @@ function formatShutter(seconds: number): string {
   return `1/${denom}`;
 }
 
-export { formatShutter };
+function formatFL(focalLengthMin: number, focalLengthMax: number): string {
+  if (focalLengthMin === focalLengthMax) {
+    return `${focalLengthMin}mm`;
+  }
+  return `${focalLengthMin}-${focalLengthMax}mm`;
+}
+
+export { formatShutter, formatFL };

--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Lens } from "../types/lens";
 import type { Genre, ScoredGenre } from "../types/genre";
 import { lenses } from "../data/lenses";
+import { makeLens } from "../test/factories";
 import {
   computeGenreMark,
   computeAllGenreMarks,
@@ -17,25 +18,6 @@ import {
   lensesForGenre,
   isScoredGenre,
 } from "./scoring";
-
-// =============================================================================
-// TEST FIXTURES
-// =============================================================================
-
-function makeLens(
-  overrides: Partial<Lens> & Pick<Lens, "brand" | "model">,
-): Lens {
-  return {
-    type: "prime",
-    mount: "X",
-    focalLengthMin: 35,
-    focalLengthMax: 35,
-    maxAperture: 1.4,
-    weight: 200,
-    price: 600,
-    ...overrides,
-  };
-}
 
 function findLens(model: string): Lens {
   const lens = lenses.find((l) => l.model === model);


### PR DESCRIPTION
## Summary
- Extracted `ColumnAlign` type + `makeAlignClasses(styles)` factory to `shared/table.ts` (was duplicated in LensExplorer, CameraExplorer, AccessoriesExplorer)
- Extracted `formatFL()` to `utils/formatting.ts` (was duplicated in LensExplorer, GenreGuide, [slug].astro)
- Extracted `makeLens()` test factory to `test/factories.ts` (was duplicated in scoring.test.ts, exposure.test.ts, GenreGuide.test.tsx)

Net: 11 files changed, +58 −93 lines

Closes #290

## Test plan
- [x] `npm run check:all` passes (lint, types, tests, build)
- [x] Verify lens explorer table alignment unchanged
- [x] Verify camera explorer table alignment unchanged
- [x] Verify accessories explorer table alignment unchanged
- [x] Verify FL formatting on individual lens pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)