### PR TITLE
test: add missing tests for explorers, formatting, slug, and useSort

### DIFF
--- a/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CameraExplorer from "./CameraExplorer";
+import { makeCamera } from "../../../test/factories";
+
+const cameras = [
+  makeCamera({ model: "X-T5", year: 2022, megapixels: 40, weight: 557, price: 1500, hasIbis: true, isWeatherSealed: true }),
+  makeCamera({ model: "X-T4", year: 2020, megapixels: 26, weight: 607, price: 1000, hasIbis: true, isWeatherSealed: true, isDiscontinued: true }),
+  makeCamera({ model: "X-S10", year: 2020, megapixels: 26, weight: 465, price: 750, hasIbis: true, series: "X-S" }),
+];
+
+describe("CameraExplorer", () => {
+  it("renders all cameras", () => {
+    render(<CameraExplorer cameras={cameras} />);
+    expect(screen.getAllByText("X-T5").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("X-T4").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("X-S10").length).toBeGreaterThan(0);
+  });
+
+  it("shows camera count", () => {
+    render(<CameraExplorer cameras={cameras} />);
+    expect(screen.getByText("3 / 3 Fujifilm cameras")).toBeInTheDocument();
+  });
+
+  it("filters by search", async () => {
+    const user = userEvent.setup();
+    render(<CameraExplorer cameras={cameras} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "X-T5");
+    expect(screen.getAllByText("X-T5").length).toBeGreaterThan(0);
+    expect(screen.queryByText("X-S10")).not.toBeInTheDocument();
+  });
+
+  it("clears filters", async () => {
+    const user = userEvent.setup();
+    render(<CameraExplorer cameras={cameras} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "X-T5");
+    expect(screen.queryByText("X-S10")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+    expect(screen.getAllByText("X-S10").length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no matches", async () => {
+    const user = userEvent.setup();
+    render(<CameraExplorer cameras={cameras} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "nonexistent");
+    expect(screen.getByText("No cameras match the current filters.")).toBeInTheDocument();
+  });
+
+  it("shows price footnote", () => {
+    render(<CameraExplorer cameras={cameras} />);
+    expect(screen.getByText(/approximate USD estimates/)).toBeInTheDocument();
+  });
+});

--- a/src/components/interactive/LensExplorer/LensExplorer.test.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LensExplorer from "./LensExplorer";
+import { makeLens } from "../../../test/factories";
+
+const lenses = [
+  makeLens({ brand: "Fujifilm", model: "XF 23mm f/1.4 R", focalLengthMin: 23, focalLengthMax: 23, maxAperture: 1.4, weight: 300, price: 950, mount: "X", hasOis: false, isWeatherSealed: false }),
+  makeLens({ brand: "Fujifilm", model: "XF 56mm f/1.2 R", focalLengthMin: 56, focalLengthMax: 56, maxAperture: 1.2, weight: 405, price: 1000, mount: "X", hasOis: false, isWeatherSealed: false }),
+  makeLens({ brand: "Fujifilm", model: "XF 16-55mm f/2.8 R LM WR", type: "zoom", focalLengthMin: 16, focalLengthMax: 55, maxAperture: 2.8, weight: 655, price: 1200, mount: "X", hasOis: false, isWeatherSealed: true }),
+];
+
+describe("LensExplorer", () => {
+  it("renders all lenses", () => {
+    render(<LensExplorer lenses={lenses} />);
+    expect(screen.getAllByText("XF 23mm f/1.4 R").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("XF 56mm f/1.2 R").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("XF 16-55mm f/2.8 R LM WR").length).toBeGreaterThan(0);
+  });
+
+  it("shows lens count", () => {
+    render(<LensExplorer lenses={lenses} />);
+    expect(screen.getByText("3 / 3 Fujifilm-compatible lenses")).toBeInTheDocument();
+  });
+
+  it("filters by search", async () => {
+    const user = userEvent.setup();
+    render(<LensExplorer lenses={lenses} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "56mm");
+    expect(screen.getAllByText("XF 56mm f/1.2 R").length).toBeGreaterThan(0);
+    expect(screen.queryByText("XF 23mm f/1.4 R")).not.toBeInTheDocument();
+  });
+
+  it("filters by type chip", async () => {
+    const user = userEvent.setup();
+    render(<LensExplorer lenses={lenses} />);
+    await user.click(screen.getByRole("button", { name: "Zoom" }));
+    expect(screen.getAllByText("XF 16-55mm f/2.8 R LM WR").length).toBeGreaterThan(0);
+    expect(screen.queryByText("XF 23mm f/1.4 R")).not.toBeInTheDocument();
+  });
+
+  it("clears filters", async () => {
+    const user = userEvent.setup();
+    render(<LensExplorer lenses={lenses} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "56mm");
+    expect(screen.queryByText("XF 23mm f/1.4 R")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+    expect(screen.getAllByText("XF 23mm f/1.4 R").length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no matches", async () => {
+    const user = userEvent.setup();
+    render(<LensExplorer lenses={lenses} />);
+    await user.type(screen.getByRole("textbox", { name: /search/i }), "nonexistent");
+    expect(screen.getByText("No lenses match the current filters.")).toBeInTheDocument();
+  });
+
+  it("shows price footnote", () => {
+    render(<LensExplorer lenses={lenses} />);
+    expect(screen.getByText(/approximate USD estimates/)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useSort.test.ts
+++ b/src/hooks/useSort.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSort } from "./useSort";
+
+interface Item {
+  name: string;
+  price: number;
+  year: number;
+}
+
+const items: Item[] = [
+  { name: "Bravo", price: 300, year: 2020 },
+  { name: "Alpha", price: 100, year: 2022 },
+  { name: "Charlie", price: 200, year: 2021 },
+];
+
+describe("useSort", () => {
+  it("sorts by default key ascending", () => {
+    const { result } = renderHook(() => useSort(items, "name"));
+    expect(result.current.sorted.map((i) => i.name)).toEqual(["Alpha", "Bravo", "Charlie"]);
+    expect(result.current.sortKey).toBe("name");
+    expect(result.current.sortDirection).toBe("asc");
+  });
+
+  it("sorts numbers ascending", () => {
+    const { result } = renderHook(() => useSort(items, "price"));
+    expect(result.current.sorted.map((i) => i.price)).toEqual([100, 200, 300]);
+  });
+
+  it("toggles to descending on same key", () => {
+    const { result } = renderHook(() => useSort(items, "price"));
+    act(() => result.current.toggleSort("price"));
+    expect(result.current.sortDirection).toBe("desc");
+    expect(result.current.sorted.map((i) => i.price)).toEqual([300, 200, 100]);
+  });
+
+  it("switches key and resets to ascending", () => {
+    type K = "name" | "price" | "year";
+    const { result } = renderHook(() => useSort<Item, K>(items, "price"));
+    act(() => result.current.toggleSort("price")); // desc
+    act(() => result.current.toggleSort("name")); // new key → asc
+    expect(result.current.sortKey).toBe("name");
+    expect(result.current.sortDirection).toBe("asc");
+  });
+
+  it("applies stable prefix sort", () => {
+    const withDiscontinued = [
+      { name: "B", price: 1, year: 2020, disc: true },
+      { name: "A", price: 2, year: 2021, disc: false },
+      { name: "C", price: 3, year: 2022, disc: false },
+    ];
+    const prefix = (a: typeof withDiscontinued[0], b: typeof withDiscontinued[0]) =>
+      Number(a.disc) - Number(b.disc);
+    const { result } = renderHook(() => useSort(withDiscontinued, "name", "asc", prefix));
+    expect(result.current.sorted.map((i) => i.name)).toEqual(["A", "C", "B"]);
+  });
+
+  it("handles null values by sorting them last", () => {
+    const withNulls = [
+      { name: "A", price: null as unknown as number, year: 2020 },
+      { name: "B", price: 100, year: 2021 },
+    ];
+    const { result } = renderHook(() => useSort(withNulls, "price"));
+    expect(result.current.sorted.map((i) => i.name)).toEqual(["B", "A"]);
+  });
+});

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,4 +1,5 @@
 import type { Lens } from "../types/lens";
+import type { Camera } from "../types/camera";
 
 function makeLens(
   overrides: Partial<Lens> & Pick<Lens, "brand" | "model">,
@@ -15,4 +16,22 @@ function makeLens(
   };
 }
 
-export { makeLens };
+function makeCamera(
+  overrides: Partial<Camera> & Pick<Camera, "model">,
+): Camera {
+  return {
+    mount: "X",
+    year: 2022,
+    series: "X-T",
+    evfPosition: "center",
+    formFactor: "standard",
+    sensor: "X-Trans IV",
+    megapixels: 26,
+    weight: 500,
+    price: 1500,
+    videoSpec: "4K",
+    ...overrides,
+  };
+}
+
+export { makeLens, makeCamera };

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { formatShutter, formatFL } from "./formatting";
+
+describe("formatShutter", () => {
+  it("formats hours", () => {
+    expect(formatShutter(3600)).toBe("1h");
+    expect(formatShutter(7200)).toBe("2h");
+  });
+
+  it("formats minutes", () => {
+    expect(formatShutter(60)).toBe("1m");
+    expect(formatShutter(300)).toBe("5m");
+  });
+
+  it("formats whole seconds", () => {
+    expect(formatShutter(1)).toBe("1s");
+    expect(formatShutter(30)).toBe("30s");
+  });
+
+  it("formats fractions", () => {
+    expect(formatShutter(1 / 250)).toBe("1/250");
+    expect(formatShutter(1 / 60)).toBe("1/60");
+    expect(formatShutter(1 / 4000)).toBe("1/4000");
+  });
+
+  it("rounds to nearest whole second", () => {
+    expect(formatShutter(1.4)).toBe("1s");
+    expect(formatShutter(29.7)).toBe("30s");
+  });
+
+  it("rounds fractional denominators", () => {
+    expect(formatShutter(0.008)).toBe("1/125");
+  });
+});
+
+describe("formatFL", () => {
+  it("formats prime (min === max)", () => {
+    expect(formatFL(23, 23)).toBe("23mm");
+  });
+
+  it("formats zoom (min !== max)", () => {
+    expect(formatFL(18, 55)).toBe("18-55mm");
+  });
+});

--- a/src/utils/slug.test.ts
+++ b/src/utils/slug.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { toSlug } from "./slug";
+
+describe("toSlug", () => {
+  it("lowercases and hyphenates", () => {
+    expect(toSlug("XF 23mm f/1.4")).toBe("xf-23mm-f1-4");
+  });
+
+  it("removes slashes", () => {
+    expect(toSlug("f/2.8")).toBe("f2-8");
+  });
+
+  it("collapses multiple special chars", () => {
+    expect(toSlug("XF  16mm  f/1.4  R  WR")).toBe("xf-16mm-f1-4-r-wr");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(toSlug(" -hello- ")).toBe("hello");
+  });
+
+  it("handles brand + model", () => {
+    expect(toSlug("Fujifilm XF 56mm f/1.2 R")).toBe("fujifilm-xf-56mm-f1-2-r");
+  });
+});


### PR DESCRIPTION
## Summary
- Added 5 missing test files identified in code review
- Added `makeCamera` factory to `test/factories.ts`
- Test suite: 10 files, 132 tests, all passing

| File | Tests | Coverage |
|------|-------|----------|
| `formatting.test.ts` | 8 | formatShutter (hours/min/sec/fractions/rounding), formatFL |
| `slug.test.ts` | 5 | toSlug edge cases (slashes, spacing, leading/trailing hyphens) |
| `useSort.test.ts` | 6 | direction toggle, key switch, stable prefix, null handling |
| `LensExplorer.test.tsx` | 7 | render, search, type filter, clear, empty state, footnote |
| `CameraExplorer.test.tsx` | 6 | render, search, clear, empty state, footnote |

Closes #291

## Test plan
- [x] `npm run check:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)