### PR TITLE
fix: remove Trade Deals stub page and links from explorers

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -256,7 +256,6 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
 
       <p className={styles.footnote}>
         All prices are approximate USD estimates.
-        See <a href="/trade-deals">Trade Deals</a> for current market rates.
       </p>
     </div>
   );

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -106,7 +106,6 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
 
       <p className={styles.footnote}>
         All prices are approximate USD estimates.
-        See <a href="/trade-deals">Trade Deals</a> for current market rates.
       </p>
     </div>
   );

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -112,7 +112,6 @@ function LensExplorer({ lenses }: LensExplorerProps) {
 
       <p className={styles.footnote}>
         All prices are approximate USD estimates.
-        See <a href="/trade-deals">Trade Deals</a> for current market rates.
       </p>
     </div>
   );

--- a/src/pages/trade-deals.astro
+++ b/src/pages/trade-deals.astro
@@ -1,8 +1,0 @@
----
-import Base from "../layouts/Base.astro";
----
-
-<Base title="Trade Deals — Wuseria" description="Current deals on Fujifilm lenses and cameras.">
-  <h1>Trade Deals</h1>
-  <p>Coming soon.</p>
-</Base>


### PR DESCRIPTION
## Summary
- Removes "See Trade Deals for current market rates" links from Lens, Camera, and Accessories explorers
- Deletes the stub `trade-deals.astro` page ("Coming soon")
- Trade Deals feature tracked in epic #243 for future implementation

Closes #317

## Test plan
- [ ] `npm run check:all` passes (457 pages)
- [ ] No remaining references to `/trade-deals` in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)