### PR TITLE
feat: add landing page with value proposition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ npm test          # run tests (Vitest)
 ### 2.6 Data rules
 
 - All editable content in `src/data/*.ts` — never hardcode data in components
+- Never hardcode derived counts or statistics — compute them from the data source at build time
 - TypeScript files, not JSON — gives type checking at build time and IDE autocomplete on the data itself; a missing field is a compile error, not a runtime surprise
 - Astro imports `.ts` data at build time; data never ships as JS to the browser
 - Prices in USD by default (configurable in `src/data/config.ts`), rounded up to nearest $250

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const navLinks = [
   <body>
     <header class="site-header">
       <nav class="nav" aria-label="Main navigation">
-        <a href="/lenses" class="nav-brand">Wuseria</a>
+        <a href="/" class="nav-brand">Wuseria</a>
         <button
           class="nav-toggle"
           type="button"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,173 @@
 ---
-import "../styles/global.css";
+import Base from "../layouts/Base.astro";
+import { lenses } from "../data/lenses";
+import { cameras } from "../data/cameras";
+import accessories from "../data/accessories";
+import { getCollection } from "astro:content";
+import { SCORED_GENRES } from "../components/interactive/GenreGuide/types";
+
+const wikiEntries = await getCollection("wiki");
+const lensCount = lenses.length;
+const cameraCount = cameras.length;
+const accessoryCount = accessories.length;
+const genreCount = SCORED_GENRES.length;
+const wikiCount = wikiEntries.length;
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0;url=/lenses" />
-    <link rel="canonical" href="/lenses" />
-    <title>Wuseria — Fujifilm Lens and Camera Explorer</title>
-    <style>
-      html { background-color: var(--color-bg); color: var(--color-text); }
-    </style>
-  </head>
-  <body>
-  </body>
-</html>
+<Base
+  title="Wuseria — Fujifilm Lens and Camera Explorer"
+  description={`Every Fujifilm lens scored for your genre. ${lensCount} lenses rated against ${genreCount} photography genres using optical quality data from trusted lab reviews.`}
+>
+  <section class="hero">
+    <h1 class="hero-title">
+      Every Fujifilm lens.<br>
+      <strong>Scored for your genre.</strong>
+    </h1>
+    <p class="hero-subtitle">
+      {lensCount} lenses rated against {genreCount} photography genres — backed by optical quality
+      data from trusted lab reviews, not marketing specs.
+    </p>
+  </section>
+
+  <section class="stats">
+    <a href="/lenses" class="stat">
+      <span class="stat-number">{lensCount}</span>
+      <span class="stat-label">Lenses</span>
+    </a>
+    <a href="/genre" class="stat">
+      <span class="stat-number">{genreCount}</span>
+      <span class="stat-label">Genres</span>
+    </a>
+    <a href="/cameras" class="stat">
+      <span class="stat-number">{cameraCount}</span>
+      <span class="stat-label">Cameras</span>
+    </a>
+    <a href="/accessories" class="stat">
+      <span class="stat-number">{accessoryCount}</span>
+      <span class="stat-label">Accessories</span>
+    </a>
+    <a href="/wiki" class="stat">
+      <span class="stat-number">{wikiCount}</span>
+      <span class="stat-label">Wiki articles</span>
+    </a>
+  </section>
+
+  <section class="methodology">
+    <h2 class="section-title">How scoring works</h2>
+    <p class="section-desc">
+      Each genre weights optical fields differently — nightscape penalizes coma,
+      portrait rewards bokeh, architecture demands low distortion. Scores come
+      from lab measurements, not manufacturer claims.
+      <a href="/wiki/optical-scoring">See how scoring works.</a>
+    </p>
+  </section>
+
+  <section class="about">
+    <h2 class="section-title">Why Wuseria?</h2>
+    <p class="section-desc">
+      Built by <a href="https://braboj.me">Branimir Georgiev</a> at
+      <a href="https://imbra.io">Imbra</a> — an engineer who builds
+      systems for a living and photographs as a hobby. After spending
+      countless hours compiling specs, reading reviews, and building
+      spreadsheets to find the best lenses on a budget, one gap kept
+      coming back: plenty of data, zero genre recommendations. Wuseria
+      closes that gap — document everything, share everything.
+    </p>
+  </section>
+</Base>
+
+<style>
+  .hero {
+    text-align: center;
+    padding: var(--space-2xl) 0;
+  }
+
+  .hero-title {
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    font-weight: 300;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--color-text);
+  }
+
+  .hero-title strong {
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+
+  .hero-subtitle {
+    max-width: 40rem;
+    margin: var(--space-lg) auto 0;
+    font-size: var(--font-size-lg);
+    color: var(--color-text-muted);
+    line-height: var(--line-height);
+  }
+
+  .stats {
+    display: flex;
+    justify-content: center;
+    gap: var(--space-xl);
+    padding: var(--space-xl) 0;
+    border-top: 1px solid var(--color-border);
+    flex-wrap: wrap;
+  }
+
+  .stat {
+    text-align: center;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .stat:hover .stat-number {
+    color: var(--color-accent);
+  }
+
+  .stat-number {
+    display: block;
+    font-size: clamp(1.5rem, 3vw, 2.5rem);
+    font-weight: 700;
+    color: var(--color-text);
+    line-height: 1;
+    transition: color 0.15s;
+  }
+
+  .stat-label {
+    display: block;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-top: var(--space-xs);
+  }
+
+  .methodology,
+  .about {
+    padding: var(--space-xl) 0;
+    border-top: 1px solid var(--color-border);
+    text-align: center;
+  }
+
+  .about {
+    padding-bottom: var(--space-2xl);
+  }
+
+  .section-title {
+    font-size: var(--font-size-xl);
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .section-desc {
+    max-width: 40rem;
+    margin: var(--space-md) auto 0;
+    font-size: var(--font-size-base);
+    color: var(--color-text-muted);
+    line-height: var(--line-height);
+  }
+
+  .section-desc a {
+    color: var(--color-link);
+  }
+
+  .section-desc a:hover {
+    color: var(--color-link-hover);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Replaces bare meta-refresh redirect with a proper landing page
- Hero: "Every Fujifilm lens. / **Scored for your genre.**" (weight + accent alternation)
- Stats strip: lens/genre/camera/accessory/wiki counts computed from data at build time
- "How scoring works" section linking to wiki
- "Why Wuseria?" origin story with braboj.me and imbra.io links
- Nav-brand "Wuseria" now links to `/` instead of `/lenses`
- CLAUDE.md: added rule against hardcoded derived counts

Closes #314

## Test plan
- [ ] `npm run check:all` passes (457 pages)
- [ ] Landing page renders correctly on desktop and mobile
- [ ] Stats numbers match actual data counts
- [ ] All links work (nav, stats, scoring wiki, braboj.me, imbra.io)
- [ ] Nav-brand links to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)