### PR TITLE
feat: add Plausible analytics to all pages

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -36,6 +36,12 @@ const navLinks = [
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <slot name="head" />
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script is:inline async src="https://plausible.io/js/pa-IzIFXRqgnkNi7teUCVHkf.js"></script>
+    <script is:inline>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
   </head>
   <body>
     <header class="site-header">


### PR DESCRIPTION
## Summary
- Adds Plausible analytics script to Base.astro layout (all pages)
- Privacy-friendly: no cookies, no consent banner, no third-party tracking
- Uses `is:inline` to skip Astro's TS processing on third-party scripts

Closes #316

## Test plan
- [ ] `npm run check:all` passes
- [ ] Plausible dashboard shows pageviews after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)