### PR TITLE
fix: switch analytics from Plausible to Umami

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -36,12 +36,8 @@ const navLinks = [
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <slot name="head" />
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script is:inline async src="https://plausible.io/js/pa-IzIFXRqgnkNi7teUCVHkf.js"></script>
-    <script is:inline>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init()
-    </script>
+    <!-- Privacy-friendly analytics by Umami -->
+    <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f2aa0edb-3e74-4cc7-9a64-2a583aa8a53e"></script>
   </head>
   <body>
     <header class="site-header">


### PR DESCRIPTION
## Summary
- Replaces Plausible with Umami Cloud (free tier, up to 3 sites)
- Single script tag vs three — simpler integration
- Still privacy-friendly: no cookies, no consent banner

## Test plan
- [ ] `npm run check:all` passes
- [ ] Umami dashboard shows pageviews after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)