### PR TITLE
fix: align sort button content with column text-align

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run check:all

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
@@ -247,6 +247,10 @@
   font-variant-numeric: tabular-nums;
 }
 
+.table th.cellRight .sortButton {
+  justify-content: flex-end;
+}
+
 .modelCell {
   max-width: 100px;
   white-space: normal;

--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -252,9 +252,17 @@
   font-variant-numeric: tabular-nums;
 }
 
+.table th.cellRight .sortButton {
+  justify-content: flex-end;
+}
+
 .table th.cellCenter,
 .table td.cellCenter {
   text-align: center;
+}
+
+.table th.cellCenter .sortButton {
+  justify-content: center;
 }
 
 /* Dot indicators (OIS, WR) */

--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -252,9 +252,17 @@
   font-variant-numeric: tabular-nums;
 }
 
+.table th.cellRight .sortButton {
+  justify-content: flex-end;
+}
+
 .table th.cellCenter,
 .table td.cellCenter {
   text-align: center;
+}
+
+.table th.cellCenter .sortButton {
+  justify-content: center;
 }
 
 /* Dot indicators (OIS, WR) */


### PR DESCRIPTION
## Summary
- Sort buttons inside `<th>` use `inline-flex`, which ignores `text-align` from parent
- Adds `justify-content: flex-end` for right-aligned columns (FL, f/, Weight, OQ, Price)
- Adds `justify-content: center` for center-aligned columns (OIS, WR, AF)
- Fixed across all three explorers: Lens, Camera, Accessories

Closes #311

## Test plan
- [ ] `npm run check:all` passes
- [ ] Column headers align with cell content in all three explorers
- [ ] Verify on desktop (table view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)