### PR TITLE
feat: add Not scored option to OQ filter in Lens Explorer

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -53,7 +53,9 @@ function LensExplorer({ lenses }: LensExplorerProps) {
       if (maxAp && lens.maxAperture > parseFloat(maxAp)) return false;
       if (filterThread === "none" && lens.filterThread != null) return false;
       if (filterThread && filterThread !== "none" && lens.filterThread !== Number(filterThread)) return false;
-      if (oqRange) {
+      if (oqRange === "not-scored") {
+        if (lens.opticalQuality != null) return false;
+      } else if (oqRange) {
         const [min, max] = OQ_RANGES[oqRange];
         if (lens.opticalQuality == null || lens.opticalQuality < min || lens.opticalQuality > max) return false;
       }

--- a/src/components/interactive/LensExplorer/LensFilters.tsx
+++ b/src/components/interactive/LensExplorer/LensFilters.tsx
@@ -78,6 +78,7 @@ function LensFilters(props: LensFiltersProps) {
           <option value="6-7.9">6 – 7.9 (Good)</option>
           <option value="4-5.9">4 – 5.9 (Average)</option>
           <option value="0-3.9">0 – 3.9 (Below avg)</option>
+          <option value="not-scored">Not scored</option>
         </select>
 
         <select autoComplete="off" className={`${styles.filterSelect} ${priceRange ? styles.filterActive : ""}`} value={priceRange} onChange={(e) => setPriceRange(resetValue(e.target.value))} aria-label="Filter by price">


### PR DESCRIPTION
## Summary
- Adds "Not scored" option to the Optical Quality dropdown filter
- Shows only lenses without optical quality data (147 of 241)
- Useful for identifying which lenses still need scoring

## Test plan
- [ ] CI passes
- [ ] Selecting "Not scored" shows only lenses with OQ "–"
- [ ] Other OQ filters still work correctly
- [ ] "All" resets the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)