### PR TITLE
chore: update solid-ai-templates submodule to braboj org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/solid-ai-templates"]
 	path = docs/solid-ai-templates
-	url = https://github.com/Imbra-Ltd/solid-ai-templates.git
+	url = https://github.com/braboj/solid-ai-templates.git


### PR DESCRIPTION
## Summary
- Updates submodule URL from `Imbra-Ltd/solid-ai-templates` to `braboj/solid-ai-templates` after repo transfer
- Advances submodule from 7ae6b48 to d659b92 (v1.0.0) — 12 new commits including offline E2E, CI permissions fix, stale docs cleanup, and internal URL update

## Test plan
- [x] `npm run check:all` passes (457 pages built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)