### PR TITLE
fix: improve contrast ratio on muted text for WCAG AA compliance

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,7 +9,7 @@
   --color-bg-hover: #242836;
   --color-border: #2e3345;
   --color-text: #e1e4ed;
-  --color-text-muted: #8a8fa8;
+  --color-text-muted: #9a9fb6;
   --color-accent: #e8a045;
   --color-accent-hover: #f0b560;
   --color-link: #6c9bff;


### PR DESCRIPTION
## Summary
- Bump `--color-text-muted` from `#8a8fa8` to `#9a9fb6` to fix Lighthouse contrast failures on card components
- Badge text on `--color-bg-hover`: 4.59:1 → 5.59:1
- Card text on `--color-bg-surface`: 5.26:1 → 6.41:1

Closes #349

## Test plan
- [ ] Run Lighthouse on /lenses — accessibility score should be ≥ 95
- [ ] Visual check: muted text still reads as secondary/subdued
- [ ] Verify badges, prices, and spec values are legible on mobile cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)