### PR TITLE
fix: improve LCP on Lens Explorer page

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -395,6 +395,32 @@
 }
 
 /* ==========================================================================
+   Show All
+   ========================================================================== */
+
+.showAllButton {
+  display: block;
+  margin: var(--space-md) auto;
+  padding: var(--space-sm) var(--space-lg);
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.showAllButton:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.showAllButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* ==========================================================================
    Footnote
    ========================================================================== */
 

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
 import type { ExplorerLens, LensExplorerProps, LensSortKey } from "./constants";
-import { FL_RANGES, OQ_RANGES, PRICE_RANGES } from "./constants";
+import { FL_RANGES, OQ_RANGES, PRICE_RANGES, INITIAL_PAGE_SIZE } from "./constants";
 import { LensFilters } from "./LensFilters";
 import { LensResults } from "./LensResults";
 import styles from "./LensExplorer.module.css";
@@ -80,6 +80,8 @@ function LensExplorer({ lenses }: LensExplorerProps) {
     }
   }
 
+  const [showAll, setShowAll] = useState(false);
+
   const hasFilters = !!(search || mount || type || brand || ois || wr || af || discontinued || fl || maxAp || filterThread || oqRange || priceRange);
 
   function clearFilters(): void {
@@ -109,7 +111,17 @@ function LensExplorer({ lenses }: LensExplorerProps) {
       {sorted.length === 0 ? (
         <p className={styles.emptyState}>No lenses match the current filters.</p>
       ) : (
-        <LensResults sorted={sorted} slugMap={slugMap} sortKey={sortKey} sortDirection={sortDirection} toggleSort={toggleSort} />
+        <>
+          <LensResults
+            sorted={showAll || hasFilters ? sorted : sorted.slice(0, INITIAL_PAGE_SIZE)}
+            slugMap={slugMap} sortKey={sortKey} sortDirection={sortDirection} toggleSort={toggleSort}
+          />
+          {!showAll && !hasFilters && sorted.length > INITIAL_PAGE_SIZE && (
+            <button type="button" className={styles.showAllButton} onClick={() => setShowAll(true)}>
+              Show all {sorted.length} lenses
+            </button>
+          )}
+        </>
       )}
 
       <p className={styles.footnote}>

--- a/src/components/interactive/LensExplorer/constants.ts
+++ b/src/components/interactive/LensExplorer/constants.ts
@@ -29,6 +29,8 @@ const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
   { key: "price", label: "Price", align: "right" },
 ];
 
+const INITIAL_PAGE_SIZE = 50;
+
 const APERTURE_OPTIONS = ["0.95", "1.0", "1.2", "1.4", "1.8", "2.0", "2.8", "3.5", "4.0", "4.5", "5.6", "6.3", "8.0"];
 const FILTER_THREAD_OPTIONS = ["39", "43", "46", "49", "52", "55", "58", "62", "67", "72", "77", "82", "95", "none"];
 
@@ -47,4 +49,4 @@ const PRICE_RANGES: Record<string, [number, number]> = {
 };
 
 export type { ExplorerLens, LensExplorerProps, LensSortKey };
-export { COLUMNS, APERTURE_OPTIONS, FILTER_THREAD_OPTIONS, FL_RANGES, OQ_RANGES, PRICE_RANGES };
+export { COLUMNS, INITIAL_PAGE_SIZE, APERTURE_OPTIONS, FILTER_THREAD_OPTIONS, FL_RANGES, OQ_RANGES, PRICE_RANGES };


### PR DESCRIPTION
## Summary
- Limit initial render to 50 lenses (down from 241) when no filters are active
- Add "Show all N lenses" button to expand the full list
- When filters are active, all matching results are shown immediately

Closes #350

## Test plan
- [ ] Load /lenses — only 50 lenses visible, "Show all" button appears
- [ ] Click "Show all" — full list renders
- [ ] Apply any filter — all matching results shown, no "Show all" button
- [ ] Run Lighthouse on /lenses — LCP should improve significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)