### PR TITLE
fix: add sponsored to rel attribute on review source links

### DIFF
--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -183,7 +183,7 @@ const jsonLd = {
           <a href={lens.officialUrl} target="_blank" rel="noopener noreferrer" class="link-button">Official product page</a>
         )}
         {lens.reviewSources && Object.entries(lens.reviewSources).map(([source, url]) => (
-          <a href={url} target="_blank" rel="nofollow" class="link-button">{source}</a>
+          <a href={url} target="_blank" rel="nofollow sponsored" class="link-button">{source}</a>
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add `sponsored` to `rel` attribute on review source links in lens detail pages
- Changes `rel="nofollow"` to `rel="nofollow sponsored"` per CLAUDE.md convention

Closes #321

## Test plan
- [ ] Inspect review source links on any lens detail page — verify `rel="nofollow sponsored"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)