### PR TITLE
fix: add global focus-visible styles for links and nav

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -113,6 +113,12 @@ a:hover {
   color: var(--color-link-hover);
 }
 
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 img {
   max-width: 100%;
   display: block;


### PR DESCRIPTION
## Summary
- Add `:focus-visible` outline on all `<a>` elements in `global.css`
- Ensures keyboard users can track focus on links and nav items
- Consistent with existing focus styles (2px solid accent, offset)

Closes #330

## Test plan
- [ ] Tab through nav links — gold outline visible
- [ ] Tab through lens detail page links — same outline
- [ ] Mouse clicks do not trigger the outline (`:focus-visible` vs `:focus`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)