### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wuseria",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.0.0` to `0.2.0`
- Marks completion of Phase 2 — SEO & Discovery milestone (epic #48)

## Test plan
- [x] `package.json` version matches intended tag
- [ ] After merge: `git tag v0.2.0 && git push origin v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)