### PR TITLE
chore: add Lighthouse CI to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,25 @@ jobs:
 
       - run: npm ci
       - run: npm run check:all
+
+  lighthouse:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: lighthouserc.json
+          uploadArtifacts: true

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -613,3 +613,49 @@ Key decisions:
 - CC-BY-NC-ND-4.0 over proprietary — legal protection + allows public repo on free tier
 - Stay public — scoring data is derived from public sources, niche risk is low, portfolio value is high
 - Meta descriptions as pitches per solid-ai-templates/frontend/static-site.md SEO rules
+
+---
+
+### Session 19 — SEO Closure & Performance
+
+**Date:** 2026-05-01
+**Tool:** Claude Code (Opus 4.6)
+
+Docs:
+- Fixed phase numbering in dev journal — milestones were renumbered in session 14 but overview never updated (PR #369)
+- Phase 2 is now "Polish & Foundation" (6 workstreams), Phase 3 "Revenue", Phase 4 "Multi-system"
+
+SEO & Discovery (epic #48 closed):
+- #281 — Heading hierarchy audit: all pages pass, genre screener had zero H1 (PR #371)
+- Genre H1 initially dynamic per tab, caused CLS — changed to static "Genre Screener"
+- Epic fully complete, all 11 tasks checked off
+
+Release:
+- Tagged v0.2.0 — bumped package.json from 0.0.0 (Astro scaffold default)
+- Discovered release process gap: base/git.md doesn't mention package version bump
+
+Performance (#229, PR #373):
+- Trimmed serialized data across all explorers:
+  - LensExplorer: 40+ → 16 fields, gzip 26KB → 17KB (-35%)
+  - CameraExplorer: 46 → 15 fields, raw 125KB → 88KB (-30%)
+  - GenreGuide: 40+ → 25 fields, gzip 24KB → 16KB (-33%)
+- Inlined all CSS via `build.inlineStylesheets: "always"` — zero render-blocking requests
+- Attempted hero extraction (H1 from React to static Astro) — reverted, worse perceived perf
+- Moved misassigned issues: #309 → UI & UX, #228 → Equipment Database
+- Updated epic with current baseline and concrete remaining tasks
+- Created ExplorerCamera and GenreLens lean interfaces
+- Created pickGenreFields utility
+
+Upstream issues created:
+- solid-ai-templates #108 — Keep dev journal phases in sync with milestones
+- solid-ai-templates #109 — Add package version bump to release process
+
+Issues created:
+- #370 — Skip CI on docs-only changes
+
+Key decisions:
+- Don't sacrifice perceived performance for Lighthouse scores — hero extraction caused visible flash
+- Static H1 with variable-length text causes CLS on tab switch — use fixed text
+- Data trimming is invisible to users — pure win
+- CSS inlining trades 2KB gzip for eliminating render-blocking round-trip
+- Real-world LCP (2.0s on PageSpeed) matters more than simulated 3G (3.5s)

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,23 @@
+
+
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "dist",
+      "url": [
+        "/",
+        "/lenses/",
+        "/cameras/",
+        "/genre/"
+      ]
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.8 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Lighthouse CI as a separate job in the PR workflow
- Runs on 4 key pages: `/`, `/lenses/`, `/cameras/`, `/genre/`
- Thresholds: Performance >= 80 (error), Accessibility/SEO/Best Practices >= 90 (warn)
- Results uploaded as GitHub Actions artifacts

Closes #382

## Test plan
- [x] Local build passes
- [ ] CI runs Lighthouse successfully on this PR
- [ ] Artifacts visible in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)