### PR TITLE
chore: skip Lighthouse CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,30 @@ jobs:
       - run: npm ci
       - run: npm run check:all
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'public/**'
+              - 'astro.config.mjs'
+              - 'tsconfig.json'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'lighthouserc.json'
+              - '.github/workflows/**'
+
   lighthouse:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Lighthouse job now skipped on docs-only PRs using dorny/paths-filter
- Build job always runs (required by branch protection)
- Lighthouse triggers on: src/**, public/**, config files, workflows
- Docs-only PRs save ~90s of CI time

Closes #370

## Test plan
- [x] This PR changes a workflow file — Lighthouse should run
- [ ] A future docs-only PR should skip Lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)