### PR TITLE
docs: ADRs for performance spikes #380 and #381

### DIFF
--- a/docs/decisions/016-reject-data-externalization.md
+++ b/docs/decisions/016-reject-data-externalization.md
@@ -1,0 +1,64 @@
+# ADR-016: Reject data externalization to static JSON endpoints
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+Spike #380. The lens, camera, and genre data is serialized inline into
+`<astro-island props="">` attributes in the HTML. After session 19 data
+trimming, gzipped sizes are /lenses 17 KB, /cameras 10 KB, /genre 19 KB.
+Real-world LCP on /lenses is 2.0 s (PageSpeed Insights field data).
+
+The question: would moving this data to static JSON files fetched
+client-side after hydration improve LCP?
+
+## Decision
+
+Reject. Keep data inline in Astro island props.
+
+## Alternatives considered
+
+### Static JSON endpoints fetched client-side
+
+The island would render a loading state, hydrate, fetch `/api/lenses.json`,
+then render the data.
+
+**Rejected because:**
+
+1. **Fetch waterfall.** HTML load -> JS hydrate -> fetch JSON -> render.
+   Currently: HTML load -> render (data already present). Adding a network
+   round-trip after hydration increases time-to-content, not decreases it.
+
+2. **Already tried and reverted.** Session 16 reverted "Approach B
+   (AppShell)" for exactly this reason: first-load regression from fetch
+   waterfall and JS bundle increase.
+
+3. **SEO regression.** With `output: "static"` and no SSR, data fetched
+   client-side is invisible to crawlers. The current inline approach
+   produces fully crawlable HTML.
+
+4. **Diminishing returns.** 17-19 KB gzip is smaller than a single hero
+   image. Further optimization of this payload cannot produce a
+   perceptible improvement.
+
+5. **Complexity cost.** Adds API endpoint files, fetch logic, loading
+   states, and error handling for zero user-visible benefit.
+
+### Static JSON with `<script type="application/json">`
+
+Embed JSON in a script tag instead of island props, read it on hydration.
+
+**Rejected because:** Astro's built-in binary serialization format already
+compresses better than raw JSON (~40-50% smaller) through reference
+deduplication. Switching to plain JSON would increase payload size.
+
+## Consequences
+
+- Data remains inline in Astro island props (current architecture unchanged)
+- No `src/pages/api/` directory needed
+- Future data growth (more lenses/cameras) may revisit this if gzipped
+  HTML exceeds ~50 KB, but current trajectory (256 lenses = 17 KB gzip)
+  suggests this is far off
+- Performance improvements should focus on other vectors (View Transitions,
+  bundle splitting, image optimization)

--- a/docs/decisions/017-adopt-view-transitions.md
+++ b/docs/decisions/017-adopt-view-transitions.md
@@ -1,0 +1,79 @@
+# ADR-017: Adopt Astro View Transitions for navigation speed
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+Spike #381. Each navigation between explorer pages (/lenses, /cameras,
+/genre, /accessories) triggers a full page reload and React re-hydration.
+Prefetch is already enabled (hover strategy, all links), so the HTML is
+pre-fetched but the browser still does a full document swap.
+
+Astro 6.1.5 ships `<ClientRouter />` (from `astro:transitions`) which
+enables client-side DOM morphing with the View Transitions API. The
+question: does this improve perceived navigation speed with acceptable
+risk?
+
+## Decision
+
+Adopt View Transitions by adding `<ClientRouter />` to `Base.astro`.
+
+## Implementation
+
+1. Import and add `<ClientRouter />` in `Base.astro` `<head>`
+2. Update the hamburger menu inline script to use `astro:page-load`
+   event instead of top-level execution (scripts in `<head>` only run
+   once with client-side routing)
+3. Verify React island hydration works correctly after DOM swap
+4. Test navigation between all explorer pages on mobile and desktop
+5. Measure perceived navigation time before and after
+
+### What NOT to do
+
+- Do not add `transition:persist` on React islands - each page has a
+  different island component (LensExplorer, CameraExplorer, etc.),
+  so persist would not match across pages
+- Do not add custom transition animations - the default crossfade is
+  sufficient and avoids jank on low-end devices
+- Do not persist filter state across pages - this is not expected
+  behavior (each explorer is independent)
+
+## Alternatives considered
+
+### Keep full page reloads with prefetch only
+
+The current approach. Prefetch warms the cache but the browser still
+parses and renders the full document from scratch.
+
+**Rejected because:** View Transitions is a one-component addition that
+eliminates the full-page flash. The prefetched HTML is already in cache;
+View Transitions simply swaps the DOM instead of discarding it.
+
+### SPA framework (Next.js, Remix)
+
+Full client-side routing with shared React tree.
+
+**Rejected because:** Massive migration cost, ships far more JS, and
+breaks the zero-JS-by-default architecture. Astro View Transitions
+achieves the same perceived speed with a fraction of the complexity.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Hamburger menu breaks after transition | High | Use `astro:page-load` event listener |
+| React hydration timing issues | Medium | Test all islands; fallback is `transition:animate="none"` |
+| Inline scripts run twice or not at all | Medium | Audit all inline scripts in Base.astro |
+| Browser without View Transitions API | Low | Graceful degradation to full reload (built-in) |
+
+## Consequences
+
+- Navigation between pages feels instant (DOM morph instead of reload)
+- Header/footer do not flash or re-render during navigation
+- Inline scripts in Base.astro must use `astro:page-load` lifecycle
+  event for re-initialization
+- Future islands can use `transition:persist` if the same component
+  appears on multiple pages (not applicable today)
+- Lighthouse navigation-based audits may need adjustment since
+  client-side routing changes how page loads are measured


### PR DESCRIPTION
## Summary
- ADR-016: reject data externalization — inline props already 17-19KB gzipped, externalizing adds fetch waterfall with no gain
- ADR-017: adopt View Transitions — `<ClientRouter />` for instant navigation between explorer pages

Closes #380, closes #381

## Test plan
- [ ] Docs-only change, no code impact
- [ ] ADR numbering follows sequence (016, 017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)