### PR TITLE
feat: UI/UX quick wins — aria-sort, About page, workflow sections

### DIFF
--- a/src/components/interactive/GenreGuide/GenreTable.tsx
+++ b/src/components/interactive/GenreGuide/GenreTable.tsx
@@ -25,6 +25,7 @@ function GenreTable({ state, enrichedLenses }: GenreTableProps) {
               <th
                 key={`${key}-${label}`}
                 className={primary ? styles.primaryCol : ""}
+                aria-sort={sortBy === key ? (sortAsc ? "ascending" : "descending") : "none"}
               >
                 <button type="button" className={styles.sortButton} onClick={() => handleSort(key)}>
                   {label}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,115 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base
+  title="About — Wuseria"
+  description="Wuseria is a free Fujifilm lens and camera explorer with genre-based scoring. Built by Branimir Georgiev at Imbra."
+>
+  <article class="about-page">
+    <h1>About Wuseria</h1>
+
+    <section>
+      <h2>What it is</h2>
+      <p>
+        Wuseria is a free, independent Fujifilm lens and camera explorer.
+        Every lens is scored against photography genres — nightscape, portrait,
+        landscape, street, and more — using optical quality data from trusted
+        lab reviews, not marketing specs or manufacturer claims.
+      </p>
+    </section>
+
+    <section>
+      <h2>Why it exists</h2>
+      <p>
+        After spending countless hours compiling specs, reading reviews, and
+        building spreadsheets to find the best lenses on a budget, one gap kept
+        coming back: plenty of data, zero genre recommendations. Wuseria closes
+        that gap — document everything, share everything.
+      </p>
+    </section>
+
+    <section>
+      <h2>How scoring works</h2>
+      <p>
+        Each genre weights optical fields differently. Nightscape penalizes coma
+        and astigmatism. Portrait rewards bokeh and longitudinal CA control.
+        Architecture demands low distortion. Scores come from lab measurements
+        published by independent review sites — not from affiliate deals or
+        brand partnerships.
+      </p>
+      <p>
+        Scoring is opinionated and subjective by design. The methodology is
+        documented and open to scrutiny.
+        <a href="/wiki/optical-scoring">Read the full scoring methodology.</a>
+      </p>
+    </section>
+
+    <section>
+      <h2>Data sources</h2>
+      <p>
+        Optical quality data comes from trusted lab review sites including
+        LensTip, LensRentals, OpticalLimits, and DxOMark. Each source is
+        rated by methodology (lab vs. field) and trust level. Only sources
+        with reproducible, lab-based measurements receive the highest trust
+        rating.
+      </p>
+      <p>
+        All prices are approximate USD estimates.
+      </p>
+    </section>
+
+    <section>
+      <h2>Who built it</h2>
+      <p>
+        Built by <a href="https://braboj.me">Branimir Georgiev</a> at
+        <a href="https://imbra.io">Imbra</a> — an engineer who builds systems
+        for a living and photographs as a hobby.
+      </p>
+    </section>
+
+    <section>
+      <h2>License</h2>
+      <p>
+        Content and code are licensed under
+        <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank" rel="noopener noreferrer">CC BY-NC-ND 4.0</a>.
+      </p>
+    </section>
+  </article>
+</Base>
+
+<style>
+  .about-page {
+    max-width: 40rem;
+    margin: 0 auto;
+  }
+
+  .about-page h1 {
+    font-size: var(--font-size-2xl);
+    font-weight: 700;
+    color: var(--color-text);
+    margin-bottom: var(--space-xl);
+  }
+
+  .about-page h2 {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-sm);
+  }
+
+  .about-page p {
+    color: var(--color-text-muted);
+    line-height: var(--line-height);
+    margin-bottom: var(--space-md);
+  }
+
+  .about-page a {
+    color: var(--color-link);
+  }
+
+  .about-page a:hover {
+    color: var(--color-link-hover);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,6 +52,53 @@ const wikiCount = wikiEntries.length;
     </a>
   </section>
 
+  <div class="content-column">
+  <section class="workflows">
+    <h2 class="section-title">Find your gear</h2>
+    <div class="workflow-cards">
+      <a href="/lenses" class="workflow-card">
+        <span class="workflow-card-title">Lenses</span>
+        <span class="workflow-card-desc">
+          Browse and filter by mount, focal length, aperture, price, and
+          optical quality scores.
+        </span>
+      </a>
+      <a href="/cameras" class="workflow-card">
+        <span class="workflow-card-title">Cameras</span>
+        <span class="workflow-card-desc">
+          Compare Fujifilm bodies by sensor, resolution, video specs, and
+          price.
+        </span>
+      </a>
+      <a href="/accessories" class="workflow-card">
+        <span class="workflow-card-title">Accessories</span>
+        <span class="workflow-card-desc">
+          Find filters, adapters, flash units, and other gear for your
+          setup.
+        </span>
+      </a>
+    </div>
+  </section>
+
+  <section class="workflows">
+    <h2 class="section-title">Plan your shoot</h2>
+    <ol class="workflow-steps">
+      <li>
+        <a href="/genre">Pick a genre</a> — nightscape, landscape, portrait,
+        street, or architecture
+      </li>
+      <li>
+        Select the scene you want to shoot and check the conditions
+      </li>
+      <li>
+        See which lenses score best and decide what to rent or buy
+      </li>
+      <li>
+        On location, use the EV matrix to dial in the right shutter speed
+      </li>
+    </ol>
+  </section>
+
   <section class="methodology">
     <h2 class="section-title">How scoring works</h2>
     <p class="section-desc">
@@ -75,6 +122,7 @@ const wikiCount = wikiEntries.length;
       <a href="/about">Learn more.</a>
     </p>
   </section>
+  </div>
 </Base>
 
 <style>
@@ -139,11 +187,84 @@ const wikiCount = wikiEntries.length;
     margin-top: var(--space-xs);
   }
 
+  .content-column {
+    max-width: 40rem;
+    margin: 0 auto;
+  }
+
+  .workflows {
+    padding: var(--space-xl) 0;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .workflow-cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-md);
+    margin-top: var(--space-lg);
+  }
+
+  .workflow-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    text-decoration: none;
+    transition: border-color 0.15s;
+  }
+
+  .workflow-card:hover {
+    border-color: var(--color-accent);
+  }
+
+  .workflow-card-title {
+    font-weight: 600;
+    color: var(--color-text);
+    font-size: var(--font-size-lg);
+  }
+
+  .workflow-card:hover .workflow-card-title {
+    color: var(--color-accent);
+  }
+
+  .workflow-card-desc {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    line-height: var(--line-height);
+  }
+
+  .workflow-steps {
+    margin-top: var(--space-lg);
+    list-style-position: outside;
+    padding-left: var(--space-lg);
+    color: var(--color-text-muted);
+    line-height: var(--line-height);
+  }
+
+  .workflow-steps li {
+    margin-bottom: var(--space-sm);
+  }
+
+  .workflow-steps a {
+    color: var(--color-link);
+  }
+
+  .workflow-steps a:hover {
+    color: var(--color-link-hover);
+  }
+
+  @media (max-width: 640px) {
+    .workflow-cards {
+      grid-template-columns: 1fr;
+    }
+  }
+
   .methodology,
   .about {
     padding: var(--space-xl) 0;
     border-top: 1px solid var(--color-border);
-    text-align: center;
   }
 
   .about {
@@ -157,8 +278,7 @@ const wikiCount = wikiEntries.length;
   }
 
   .section-desc {
-    max-width: 40rem;
-    margin: var(--space-md) auto 0;
+    margin-top: var(--space-md);
     font-size: var(--font-size-base);
     color: var(--color-text-muted);
     line-height: var(--line-height);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,6 +72,7 @@ const wikiCount = wikiEntries.length;
       spreadsheets to find the best lenses on a budget, one gap kept
       coming back: plenty of data, zero genre recommendations. Wuseria
       closes that gap — document everything, share everything.
+      <a href="/about">Learn more.</a>
     </p>
   </section>
 </Base>


### PR DESCRIPTION
## Summary
- Add `aria-sort` attribute to GenreTable column headers for accessibility (#320)
- Create About page with scoring methodology, data sources, and license info (#270)
- Add "Find your gear" and "Plan your shoot" workflow sections to homepage (#394)
- Narrow centered content column on homepage for focused reading layout

## Test plan
- [ ] `npm run check:all` passes (lint, types, 134 tests, build)
- [ ] About page renders at `/about` with all sections
- [ ] Homepage workflow cards link to correct pages
- [ ] Genre table headers announce sort direction to screen readers
- [ ] Mobile layout: workflow cards stack to single column below 640px

🤖 Generated with [Claude Code](https://claude.com/claude-code)