### PR TITLE
fix: standardize focus-visible on all interactive elements (#400)

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -55,6 +55,11 @@
   color: var(--color-text);
 }
 
+.genreTab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .genreTabActive {
   background-color: var(--color-accent);
   border-color: var(--color-accent);
@@ -129,6 +134,11 @@
 .learnMoreBtn:hover {
   border-color: var(--color-accent);
   background-color: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+
+.learnMoreBtn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .main {
@@ -213,9 +223,9 @@
   max-width: 160px;
 }
 
-.controlSelect:focus {
+.controlSelect:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 /* ==========================================================================
@@ -246,6 +256,11 @@
 
 .sceneItem:hover {
   background-color: var(--color-bg-hover);
+}
+
+.sceneItem:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
 }
 
 .sceneItemActive {
@@ -349,6 +364,11 @@
 
 .clearBtn:hover {
   color: var(--color-text);
+}
+
+.clearBtn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .emptyState {
@@ -628,7 +648,7 @@
 
 .sortButton:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 .table .cellRight {

--- a/src/components/interactive/shared/shared.module.css
+++ b/src/components/interactive/shared/shared.module.css
@@ -70,9 +70,9 @@
   color: var(--color-text-muted);
 }
 
-.searchInput:focus {
+.searchInput:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 .filterSelect {
@@ -88,9 +88,9 @@
   width: 100%;
 }
 
-.filterSelect:focus {
+.filterSelect:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 .filterActive {
@@ -114,6 +114,11 @@
 .clearButton:hover {
   background-color: var(--color-accent);
   color: var(--color-bg);
+}
+
+.clearButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* ==========================================================================
@@ -177,6 +182,11 @@
 
 .chip:hover {
   color: var(--color-text);
+}
+
+.chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .chipOn {
@@ -248,7 +258,7 @@
 
 .sortButton:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 1px;
+  outline-offset: 2px;
 }
 
 .table th.cellRight,


### PR DESCRIPTION
## Summary
- Add `focus-visible` to all interactive elements that were missing it: chips, clear buttons, genre tabs, scene items, learn-more links
- Upgrade `:focus` to `:focus-visible` on search inputs, filter selects, and genre control selects
- Standardize `outline-offset: 2px` across all elements (scene items use `-2px` inset to avoid clipping in scrollable list)

## Test plan
- [ ] `npm run check:all` passes
- [ ] Tab through Lens Explorer — all chips, filters, sort headers, clear button show focus ring
- [ ] Tab through Genre Guide — tabs, scene items, learn-more links show focus ring
- [ ] Click with mouse — no focus ring appears on any element

🤖 Generated with [Claude Code](https://claude.com/claude-code)