### PR TITLE
fix: wiki chips + restyle learn-more buttons (#401, #405)

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -124,7 +124,7 @@
   padding: var(--space-xs) var(--space-sm);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  color: var(--color-accent);
+  color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
   text-decoration: none;
@@ -133,7 +133,7 @@
 
 .learnMoreBtn:hover {
   border-color: var(--color-accent);
-  background-color: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-text);
 }
 
 .learnMoreBtn:focus-visible {

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -43,7 +43,7 @@ const categories = [...new Set(entries.flatMap((e) => e.data.categories))].sort(
 </Base>
 
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
+  function initWikiFilter() {
     const chips = document.querySelectorAll<HTMLButtonElement>(".chip");
     const cards = document.querySelectorAll<HTMLAnchorElement>(".wiki-card");
     const search = document.getElementById("wiki-search") as HTMLInputElement | null;
@@ -76,7 +76,8 @@ const categories = [...new Set(entries.flatMap((e) => e.data.categories))].sort(
     });
 
     search?.addEventListener("input", filter);
-  });
+  }
+  document.addEventListener("astro:page-load", initWikiFilter);
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- **Fix #405:** Wiki category chips unresponsive after View Transition navigation — replace `DOMContentLoaded` with `astro:page-load`
- **Fix #401:** Restyle learn-more buttons below EV matrix — muted text instead of accent color, accent border on hover

## Test plan
- [ ] `npm run check:all` passes
- [ ] Navigate to /wiki via nav link, click category chips — filtering works
- [ ] Hard refresh /wiki — filtering still works
- [ ] Genre screener learn-more buttons appear muted, accent border on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)