### PR TITLE
feat: polish chip group design across explorers and genre guide

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
@@ -12,7 +12,10 @@
 .filterSelect { composes: filterSelect from '../shared/shared.module.css'; }
 .filterActive { composes: filterActive from '../shared/shared.module.css'; }
 .clearButton { composes: clearButton from '../shared/shared.module.css'; }
+.chipGroup { composes: chipGroup from '../shared/shared.module.css'; }
 .chipLabel { composes: chipLabel from '../shared/shared.module.css'; }
+.chip { composes: chip from '../shared/shared.module.css'; }
+.chipButtons { composes: chipButtons from '../shared/shared.module.css'; }
 .chipOn { composes: chipOn from '../shared/shared.module.css'; }
 .emptyState { composes: emptyState from '../shared/shared.module.css'; }
 .tableWrap { composes: tableWrap from '../shared/shared.module.css'; }
@@ -31,55 +34,7 @@
 .footnote { composes: footnote from '../shared/shared.module.css'; }
 .lensLink { composes: lensLink from '../shared/shared.module.css'; }
 
-/* ==========================================================================
-   Accessories-specific overrides — chipRow uses grid on mobile
-   ========================================================================== */
-
-.chipRow {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-xs);
-}
-
-@media (min-width: 640px) {
-  .chipRow {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-md);
-  }
-}
-
-.chipGroup {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.chip {
-  background: none;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  font-family: var(--font-sans);
-  padding: 2px var(--space-sm);
-  cursor: pointer;
-}
-
-.chip:first-of-type {
-  border-radius: var(--radius) 0 0 var(--radius);
-}
-
-.chip:last-child {
-  border-radius: 0 var(--radius) var(--radius) 0;
-}
-
-.chip:not(:first-of-type) {
-  border-left: none;
-}
-
-.chip:hover {
-  color: var(--color-text);
-}
+.chipRow { composes: chipRow from '../shared/shared.module.css'; }
 
 /* ==========================================================================
    Accessories-specific styles

--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -16,6 +16,7 @@
 .chipGroup { composes: chipGroup from '../shared/shared.module.css'; }
 .chipLabel { composes: chipLabel from '../shared/shared.module.css'; }
 .chip { composes: chip from '../shared/shared.module.css'; }
+.chipButtons { composes: chipButtons from '../shared/shared.module.css'; }
 .chipOn { composes: chipOn from '../shared/shared.module.css'; }
 .emptyState { composes: emptyState from '../shared/shared.module.css'; }
 .tableWrap { composes: tableWrap from '../shared/shared.module.css'; }

--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -192,22 +192,36 @@
 
 .controls {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: var(--space-sm);
-  align-items: center;
   margin-bottom: var(--space-sm);
+}
+
+@media (min-width: 640px) {
+  .controls {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
 }
 
 .controlGroup {
   display: flex;
-  align-items: center;
-  gap: var(--space-sm);
+  flex-direction: column;
+  gap: var(--space-xs);
 }
 
+@media (min-width: 640px) {
+  .controlGroup {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+}
 
 .controlLabel {
   font-size: var(--font-size-sm);
-  color: var(--color-text);
+  color: var(--color-text-muted);
   font-weight: 600;
 }
 
@@ -291,15 +305,27 @@
 
 .chipGroup {
   display: flex;
-  align-items: center;
-  gap: 2px;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .chipGroup {
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+  }
+}
+
+.chipButtons {
+  display: flex;
 }
 
 .chipLabel {
   font-size: var(--font-size-sm);
-  color: var(--color-text);
+  color: var(--color-text-muted);
   font-weight: 600;
-  margin-right: var(--space-xs);
+  margin-right: var(--space-sm);
   white-space: nowrap;
 }
 
@@ -309,22 +335,40 @@
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
-  padding: 2px var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
+  min-height: 32px;
   cursor: pointer;
   border-radius: var(--radius);
+  transition: background-color 0.1s, color 0.1s, border-color 0.1s;
+}
+
+@media (max-width: 639px) {
+  .chip {
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-sm);
+  }
 }
 
 .chip:hover {
   color: var(--color-text);
+  background-color: var(--color-bg-hover);
+}
+
+.chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  z-index: 1;
 }
 
 .chipOn {
   background-color: var(--color-accent);
   border-color: var(--color-accent);
   color: var(--color-bg);
+  font-weight: 600;
 }
 
 .chipOn:hover {
+  background-color: var(--color-accent-hover);
   color: var(--color-bg);
 }
 

--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -16,6 +16,7 @@
 .chipGroup { composes: chipGroup from '../shared/shared.module.css'; }
 .chipLabel { composes: chipLabel from '../shared/shared.module.css'; }
 .chip { composes: chip from '../shared/shared.module.css'; }
+.chipButtons { composes: chipButtons from '../shared/shared.module.css'; }
 .chipOn { composes: chipOn from '../shared/shared.module.css'; }
 .emptyState { composes: emptyState from '../shared/shared.module.css'; }
 .tableWrap { composes: tableWrap from '../shared/shared.module.css'; }

--- a/src/components/interactive/shared/ChipGroup.tsx
+++ b/src/components/interactive/shared/ChipGroup.tsx
@@ -10,16 +10,18 @@ function ChipGroup({ label, value, options, onChange, styles }: ChipGroupProps) 
   return (
     <div className={styles.chipGroup}>
       <span className={styles.chipLabel}>{label}</span>
-      {options.map((opt) => (
-        <button
-          key={opt.value}
-          type="button"
-          className={`${styles.chip} ${value === opt.value ? styles.chipOn : ""}`}
-          onClick={() => onChange(opt.value)}
-        >
-          {opt.label}
-        </button>
-      ))}
+      <div className={styles.chipButtons}>
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            className={`${styles.chip} ${value === opt.value ? styles.chipOn : ""}`}
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/interactive/shared/shared.module.css
+++ b/src/components/interactive/shared/shared.module.css
@@ -126,30 +126,56 @@
    ========================================================================== */
 
 .chipRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-sm);
 }
 
 @media (min-width: 640px) {
   .chipRow {
+    display: flex;
+    flex-wrap: wrap;
     gap: var(--space-md);
   }
 }
 
 .chipGroup {
   display: flex;
-  align-items: center;
-  gap: 2px;
-  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+@media (min-width: 640px) {
+  .chipGroup {
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+  }
 }
 
 .chipLabel {
   font-size: var(--font-size-sm);
-  color: var(--color-text);
+  color: var(--color-text-muted);
   font-weight: 600;
-  margin-right: var(--space-xs);
   white-space: nowrap;
+}
+
+@media (min-width: 640px) {
+  .chipLabel {
+    margin-right: var(--space-sm);
+  }
+}
+
+.chipButtons {
+  display: flex;
+}
+
+.chipButtons .chip {
+  flex: 1 1 0%;
+}
+
+.chipButtons .chip:first-child {
+  flex: 0 0 auto;
 }
 
 .chip {
@@ -158,14 +184,19 @@
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   font-family: var(--font-sans);
-  padding: 2px var(--space-sm);
+  padding: var(--space-xs) var(--space-sm);
+  min-height: 32px;
   cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
-  min-width: 0;
-  flex: 1 1 auto;
   text-align: center;
+  transition: background-color 0.1s, color 0.1s, border-color 0.1s;
+}
+
+@media (max-width: 639px) {
+  .chip {
+    min-height: 44px;
+    padding: var(--space-sm) var(--space-sm);
+  }
 }
 
 .chip:first-of-type {
@@ -182,20 +213,28 @@
 
 .chip:hover {
   color: var(--color-text);
+  background-color: var(--color-bg-hover);
 }
 
 .chip:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .chipOn {
   background-color: var(--color-accent);
   border-color: var(--color-accent);
   color: var(--color-bg);
+  font-weight: 600;
+}
+
+.chipOn + .chip {
+  border-left: 1px solid var(--color-border);
 }
 
 .chipOn:hover {
+  background-color: var(--color-accent-hover);
   color: var(--color-bg);
 }
 


### PR DESCRIPTION
## Summary
- Increase chip touch targets (32px desktop, 44px mobile) for accessibility
- Add hover background, focus-visible z-index, active font-weight and accent-hover
- Label-above-buttons layout on mobile, inline on desktop
- 2-column grid for explorer chip rows on mobile; fixed-width "All" chip
- Remove ~50 lines of duplicated chip styles from AccessoriesExplorer
- Genre controls: same visual polish, column stack on mobile, focus-visible added

Closes #275

## Test plan
- [ ] Lens Explorer: 6 chip groups align in 3x2 grid on mobile, single row on desktop
- [ ] Camera Explorer: 4 chip groups in 2x2 grid on mobile
- [ ] Accessories Explorer: 2 chip groups, no truncation
- [ ] Genre screener: Mount/FL/ISO/ND chips — label above buttons on mobile, inline on desktop
- [ ] "All" chip is consistent width across all explorers
- [ ] Touch targets meet 44px minimum on mobile
- [ ] Keyboard navigation: focus-visible outline visible on all chips
- [ ] Active chip has clear visual distinction (accent bg + font-weight)
- [ ] `npm run check:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)