### PR TITLE
feat: show sunstar points on lens detail page

### DIFF
--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -92,6 +92,7 @@ const jsonLd = {
             <tr><td>Max aperture</td><td>f/{lens.maxAperture}</td></tr>
             {lens.sweetSpotAperture && <tr><td>Sweet spot</td><td>f/{lens.sweetSpotAperture}</td></tr>}
             {lens.apertureBlades && <tr><td>Aperture blades</td><td>{lens.apertureBlades}{lens.hasCircularAperture ? " (circular)" : ""}</td></tr>}
+            {lens.apertureBlades && <tr><td>Sunstar points</td><td>{lens.apertureBlades % 2 === 0 ? lens.apertureBlades : lens.apertureBlades * 2}{lens.hasCircularAperture ? " (soft — circular blades)" : " (sharp — straight blades)"}</td></tr>}
             {lens.maxMagnification && <tr><td>Max magnification</td><td>{lens.maxMagnification}x</td></tr>}
             {lens.minFocusDistance && <tr><td>Min focus distance</td><td>{lens.minFocusDistance}mm</td></tr>}
             <tr><td>AF motor</td><td>{lens.afMotor ?? "Manual focus"}</td></tr>


### PR DESCRIPTION
## Summary
- Display computed sunstar point count on lens detail pages
- Formula: odd blades x2, even blades = same count
- Indicates sharp (straight blades) vs soft (circular blades) quality
- One line change, zero JS

Closes #37

## Test plan
- [ ] Lens with 7 blades shows "14 (sharp — straight blades)"
- [ ] Lens with 9 circular blades shows "18 (soft — circular blades)"
- [ ] Row only appears when `apertureBlades` is defined
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)