### PR TITLE
feat: show genre mark scale on lens detail page

### DIFF
--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -166,7 +166,7 @@ const jsonLd = {
           {genreEntries.map(([genre, mark]) => (
             <a href={`/genre/${genre}`} class="genre-card">
               <span class="genre-name">{genreConfigs[genre].name}</span>
-              <span class="genre-mark">{mark}</span>
+              <span class="genre-mark">{mark}/5</span>
             </a>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Display genre scores as "4/5" instead of "4" on lens detail pages
- Communicates the 1-5 scale at a glance without requiring prior knowledge

Closes #271

## Test plan
- [ ] Genre scores on lens detail page show "/5" suffix
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)