### PR TITLE
UI & UX polish: mobile sort, OQ colors, feedback, cleanup

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.module.css
@@ -35,6 +35,10 @@
 .lensLink { composes: lensLink from '../shared/shared.module.css'; }
 
 .chipRow { composes: chipRow from '../shared/shared.module.css'; }
+.mobileSort { composes: mobileSort from '../shared/shared.module.css'; }
+.mobileSortLabel { composes: mobileSortLabel from '../shared/shared.module.css'; }
+.mobileSortSelect { composes: mobileSortSelect from '../shared/shared.module.css'; }
+.mobileSortDirection { composes: mobileSortDirection from '../shared/shared.module.css'; }
 
 /* ==========================================================================
    Accessories-specific styles

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -4,6 +4,7 @@ import { useSort } from "../../../hooks/useSort";
 import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
+import { MobileSort } from "../shared/MobileSort";
 import type { ColumnAlign } from "../shared/table";
 import { makeAlignClasses } from "../shared/table";
 import styles from "./AccessoriesExplorer.module.css";
@@ -170,6 +171,14 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
             { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
           ]} />
         </div>
+
+        <MobileSort
+          columns={COLUMNS}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          toggleSort={toggleSort}
+          styles={styles}
+        />
       </div>
 
       {sorted.length === 0 ? (
@@ -255,9 +264,6 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
         </>
       )}
 
-      <p className={styles.footnote}>
-        All prices are approximate USD estimates.
-      </p>
     </div>
   );
 }

--- a/src/components/interactive/CameraExplorer/CameraExplorer.module.css
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.module.css
@@ -36,3 +36,7 @@
 .cardBadges { composes: cardBadges from '../shared/shared.module.css'; }
 .badge { composes: badge from '../shared/shared.module.css'; }
 .footnote { composes: footnote from '../shared/shared.module.css'; }
+.mobileSort { composes: mobileSort from '../shared/shared.module.css'; }
+.mobileSortLabel { composes: mobileSortLabel from '../shared/shared.module.css'; }
+.mobileSortSelect { composes: mobileSortSelect from '../shared/shared.module.css'; }
+.mobileSortDirection { composes: mobileSortDirection from '../shared/shared.module.css'; }

--- a/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
@@ -47,11 +47,6 @@ describe("CameraExplorer", () => {
     expect(screen.getByText("No cameras match the current filters.")).toBeInTheDocument();
   });
 
-  it("shows price footnote", () => {
-    render(<CameraExplorer cameras={cameras} />);
-    expect(screen.getByText(/approximate USD estimates/)).toBeInTheDocument();
-  });
-
   it("sorts by price when Price header is clicked", async () => {
     const user = userEvent.setup();
     render(<CameraExplorer cameras={cameras} />);

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -96,6 +96,7 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
         videoSpec={videoSpec} setVideoSpec={setVideoSpec} priceRange={priceRange} setPriceRange={setPriceRange}
         seriesOptions={seriesOptions} sensorOptions={sensorOptions}
         hasFilters={hasFilters} clearFilters={clearFilters}
+        sortKey={sortKey} sortDirection={sortDirection} toggleSort={toggleSort}
       />
 
       {sorted.length === 0 ? (
@@ -104,9 +105,6 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
         <CameraResults sorted={sorted} sortKey={sortKey} sortDirection={sortDirection} toggleSort={toggleSort} />
       )}
 
-      <p className={styles.footnote}>
-        All prices are approximate USD estimates.
-      </p>
     </div>
   );
 }

--- a/src/components/interactive/CameraExplorer/CameraFilters.tsx
+++ b/src/components/interactive/CameraExplorer/CameraFilters.tsx
@@ -1,6 +1,8 @@
 import { ChipGroup } from "../shared/ChipGroup";
+import { MobileSort } from "../shared/MobileSort";
 import { RESET_VALUE, resetValue } from "../shared/constants";
-import { YEAR_RANGES, VIDEO_OPTIONS } from "./constants";
+import type { CameraSortKey } from "./constants";
+import { COLUMNS, YEAR_RANGES, VIDEO_OPTIONS } from "./constants";
 import styles from "./CameraExplorer.module.css";
 
 interface CameraFiltersProps {
@@ -19,6 +21,9 @@ interface CameraFiltersProps {
   sensorOptions: string[];
   hasFilters: boolean;
   clearFilters: () => void;
+  sortKey: CameraSortKey;
+  sortDirection: "asc" | "desc";
+  toggleSort: (key: CameraSortKey) => void;
 }
 
 function CameraFilters(props: CameraFiltersProps) {
@@ -29,6 +34,7 @@ function CameraFilters(props: CameraFiltersProps) {
     discontinued, setDiscontinued, videoSpec, setVideoSpec,
     priceRange, setPriceRange, seriesOptions, sensorOptions,
     hasFilters, clearFilters,
+    sortKey, sortDirection, toggleSort,
   } = props;
 
   return (
@@ -97,6 +103,14 @@ function CameraFilters(props: CameraFiltersProps) {
           { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
         ]} />
       </div>
+
+      <MobileSort
+        columns={COLUMNS}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        toggleSort={toggleSort}
+        styles={styles}
+      />
     </div>
   );
 }

--- a/src/components/interactive/LensExplorer/LensExplorer.module.css
+++ b/src/components/interactive/LensExplorer/LensExplorer.module.css
@@ -38,6 +38,14 @@
 .showAllButton { composes: showAllButton from '../shared/shared.module.css'; }
 .footnote { composes: footnote from '../shared/shared.module.css'; }
 
+.mobileSort { composes: mobileSort from '../shared/shared.module.css'; }
+.mobileSortLabel { composes: mobileSortLabel from '../shared/shared.module.css'; }
+.mobileSortSelect { composes: mobileSortSelect from '../shared/shared.module.css'; }
+.mobileSortDirection { composes: mobileSortDirection from '../shared/shared.module.css'; }
+.oqHigh { composes: oqHigh from '../shared/shared.module.css'; }
+.oqMid { composes: oqMid from '../shared/shared.module.css'; }
+.oqLow { composes: oqLow from '../shared/shared.module.css'; }
+
 /* ==========================================================================
    Lens-specific styles
    ========================================================================== */

--- a/src/components/interactive/LensExplorer/LensExplorer.test.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.test.tsx
@@ -59,11 +59,6 @@ describe("LensExplorer", () => {
     expect(screen.getByText("No lenses match the current filters.")).toBeInTheDocument();
   });
 
-  it("shows price footnote", () => {
-    render(<LensExplorer lenses={lenses} />);
-    expect(screen.getByText(/approximate USD estimates/)).toBeInTheDocument();
-  });
-
   it("sorts by price when Price header is clicked", async () => {
     const user = userEvent.setup();
     render(<LensExplorer lenses={lenses} />);

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -92,6 +92,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
         filterThread={f.thread} setFilterThread={(v) => set("thread", v)}
         oqRange={f.oq} setOqRange={(v) => set("oq", v)} priceRange={f.price} setPriceRange={(v) => set("price", v)}
         brands={brands} hasFilters={hasFilters} clearFilters={clearFilters}
+        sortKey={sortKey} sortDirection={sortDirection} toggleSort={toggleSort}
       />
 
       {sorted.length === 0 ? (
@@ -110,9 +111,6 @@ function LensExplorer({ lenses }: LensExplorerProps) {
         </>
       )}
 
-      <p className={styles.footnote}>
-        All prices are approximate USD estimates.
-      </p>
     </div>
   );
 }

--- a/src/components/interactive/LensExplorer/LensFilters.tsx
+++ b/src/components/interactive/LensExplorer/LensFilters.tsx
@@ -1,6 +1,8 @@
 import { ChipGroup } from "../shared/ChipGroup";
+import { MobileSort } from "../shared/MobileSort";
 import { RESET_VALUE, resetValue } from "../shared/constants";
-import { APERTURE_OPTIONS, FILTER_THREAD_OPTIONS } from "./constants";
+import type { LensSortKey } from "./constants";
+import { APERTURE_OPTIONS, COLUMNS, FILTER_THREAD_OPTIONS } from "./constants";
 import styles from "./LensExplorer.module.css";
 
 interface LensFiltersProps {
@@ -20,6 +22,9 @@ interface LensFiltersProps {
   brands: string[];
   hasFilters: boolean;
   clearFilters: () => void;
+  sortKey: LensSortKey;
+  sortDirection: "asc" | "desc";
+  toggleSort: (key: LensSortKey) => void;
 }
 
 function LensFilters(props: LensFiltersProps) {
@@ -29,6 +34,7 @@ function LensFilters(props: LensFiltersProps) {
     discontinued, setDiscontinued, fl, setFl, maxAp, setMaxAp,
     filterThread, setFilterThread, oqRange, setOqRange,
     priceRange, setPriceRange, brands, hasFilters, clearFilters,
+    sortKey, sortDirection, toggleSort,
   } = props;
 
   return (
@@ -74,10 +80,10 @@ function LensFilters(props: LensFiltersProps) {
         <select autoComplete="off" className={`${styles.filterSelect} ${oqRange ? styles.filterActive : ""}`} value={oqRange} onChange={(e) => setOqRange(resetValue(e.target.value))} aria-label="Filter by optical quality">
           <option value="" hidden>Optical Quality</option>
           <option value={RESET_VALUE}>All</option>
-          <option value="8+">8+ (Excellent)</option>
-          <option value="6-7.9">6 – 7.9 (Good)</option>
-          <option value="4-5.9">4 – 5.9 (Average)</option>
-          <option value="0-3.9">0 – 3.9 (Below avg)</option>
+          <option value="1.5+">1.5+ (Excellent)</option>
+          <option value="1.0-1.4">1.0 – 1.4 (Good)</option>
+          <option value="0.5-0.9">0.5 – 0.9 (Average)</option>
+          <option value="0-0.4">0 – 0.4 (Below avg)</option>
           <option value="not-scored">Not scored</option>
         </select>
 
@@ -112,6 +118,14 @@ function LensFilters(props: LensFiltersProps) {
           { label: "All", value: "" }, { label: "Available", value: "available" }, { label: "Discontinued", value: "discontinued" },
         ]} />
       </div>
+
+      <MobileSort
+        columns={COLUMNS}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        toggleSort={toggleSort}
+        styles={styles}
+      />
     </div>
   );
 }

--- a/src/components/interactive/LensExplorer/LensResults.tsx
+++ b/src/components/interactive/LensExplorer/LensResults.tsx
@@ -6,6 +6,13 @@ import styles from "./LensExplorer.module.css";
 
 const ALIGN_CLASSES = makeAlignClasses(styles);
 
+function oqClass(oq: number | null | undefined): string {
+  if (oq == null) return "";
+  if (oq >= 1.5) return styles.oqHigh;
+  if (oq >= 1.0) return styles.oqMid;
+  return styles.oqLow;
+}
+
 interface LensResultsProps {
   sorted: ExplorerLens[];
   slugMap: Map<string, string>;
@@ -47,7 +54,7 @@ function LensResults({ sorted, slugMap, sortKey, sortDirection, toggleSort }: Le
                 <td className={styles.cellCenter}><span className={lens.isWeatherSealed ? styles.dotOn : styles.dotOff} /></td>
                 <td className={styles.cellCenter}>{lens.afMotor ?? "MF"}</td>
                 <td className={styles.cellRight}>{lens.weight}g</td>
-                <td className={styles.cellRight}>{lens.opticalQuality != null ? lens.opticalQuality.toFixed(1) : "\u2013"}</td>
+                <td className={`${styles.cellRight} ${oqClass(lens.opticalQuality)}`}>{lens.opticalQuality != null ? lens.opticalQuality.toFixed(1) : "\u2013"}</td>
                 <td className={styles.cellRight}>~${lens.price}</td>
               </tr>
             ))}
@@ -65,7 +72,7 @@ function LensResults({ sorted, slugMap, sortKey, sortDirection, toggleSort }: Le
             <div className={styles.cardSpecs}>
               {lens.year && <span>{lens.year}</span>}
               <span>{lens.weight}g</span>
-              {lens.opticalQuality != null && <span>OQ {lens.opticalQuality.toFixed(1)}</span>}
+              {lens.opticalQuality != null && <span className={oqClass(lens.opticalQuality)}>OQ {lens.opticalQuality.toFixed(1)}</span>}
               {lens.filterThread && <span>{"\u03A6"}{lens.filterThread}mm</span>}
             </div>
             <div className={styles.cardBadges}>

--- a/src/components/interactive/LensExplorer/constants.ts
+++ b/src/components/interactive/LensExplorer/constants.ts
@@ -54,7 +54,7 @@ const FL_RANGES: Record<string, [number, number]> = {
 };
 
 const OQ_RANGES: Record<string, [number, number]> = {
-  "8+": [8, 10], "6-7.9": [6, 7.9], "4-5.9": [4, 5.9], "0-3.9": [0, 3.9],
+  "1.5+": [1.5, 2], "1.0-1.4": [1.0, 1.4], "0.5-0.9": [0.5, 0.9], "0-0.4": [0, 0.4],
 };
 
 const PRICE_RANGES: Record<string, [number, number]> = {

--- a/src/components/interactive/shared/MobileSort.tsx
+++ b/src/components/interactive/shared/MobileSort.tsx
@@ -1,0 +1,40 @@
+interface MobileSortColumn<K extends string> {
+  key: K;
+  label: string;
+}
+
+interface MobileSortProps<K extends string> {
+  columns: MobileSortColumn<K>[];
+  sortKey: K;
+  sortDirection: "asc" | "desc";
+  toggleSort: (key: K) => void;
+  styles: Record<string, string>;
+}
+
+function MobileSort<K extends string>({ columns, sortKey, sortDirection, toggleSort, styles }: MobileSortProps<K>) {
+  return (
+    <div className={styles.mobileSort}>
+      <label className={styles.mobileSortLabel} htmlFor="mobile-sort">Sort</label>
+      <select
+        id="mobile-sort"
+        className={styles.mobileSortSelect}
+        value={sortKey}
+        onChange={(e) => toggleSort(e.target.value as K)}
+      >
+        {columns.map((col) => (
+          <option key={col.key} value={col.key}>{col.label}</option>
+        ))}
+      </select>
+      <button
+        type="button"
+        className={styles.mobileSortDirection}
+        onClick={() => toggleSort(sortKey)}
+        aria-label={`Sort ${sortDirection === "asc" ? "ascending" : "descending"}`}
+      >
+        {sortDirection === "asc" ? "\u2191" : "\u2193"}
+      </button>
+    </div>
+  );
+}
+
+export { MobileSort };

--- a/src/components/interactive/shared/shared.module.css
+++ b/src/components/interactive/shared/shared.module.css
@@ -364,6 +364,70 @@
 }
 
 /* ==========================================================================
+   Mobile sort control
+   ========================================================================== */
+
+.mobileSort {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding-top: var(--space-sm);
+}
+
+@media (min-width: 640px) {
+  .mobileSort {
+    display: none;
+  }
+}
+
+.mobileSortLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.mobileSortSelect {
+  flex: 1;
+  background-color: var(--color-bg-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  min-width: 0;
+}
+
+.mobileSortSelect:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.mobileSortDirection {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  line-height: 1;
+  min-height: 32px;
+}
+
+.mobileSortDirection:hover {
+  color: var(--color-text);
+  background-color: var(--color-bg-hover);
+}
+
+.mobileSortDirection:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* ==========================================================================
    Cards (mobile — default)
    ========================================================================== */
 
@@ -420,6 +484,23 @@
   background-color: var(--color-bg-hover);
   color: var(--color-text-muted);
   letter-spacing: 0.03em;
+}
+
+/* ==========================================================================
+   Optical quality — traffic-light color scale (0-10)
+   ========================================================================== */
+
+.oqHigh {
+  color: #6aaa70;
+  font-weight: 600;
+}
+
+.oqMid {
+  color: #b09040;
+}
+
+.oqLow {
+  color: #905030;
 }
 
 /* ==========================================================================

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -100,6 +100,9 @@ const navLinks = [
       <p class="footer-text">
         Wuseria — Fujifilm lens &amp; camera explorer by <a href="https://braboj.me">braboj.me</a>
       </p>
+      <p class="footer-feedback">
+        <a href="mailto:contact@imbra.io?subject=Wuseria Feedback">Feedback</a>
+      </p>
     </footer>
   </body>
 </html>
@@ -208,6 +211,19 @@ const navLinks = [
   .footer-text {
     font-size: var(--font-size-sm);
     color: var(--color-text-muted);
+  }
+
+  .footer-feedback {
+    margin-top: var(--space-xs);
+    font-size: var(--font-size-sm);
+  }
+
+  .footer-feedback a {
+    color: var(--color-text-muted);
+  }
+
+  .footer-feedback a:hover {
+    color: var(--color-accent);
   }
 
   /* Mobile: hamburger menu */

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -320,9 +320,9 @@ function computeOpticalQuality(lens: Lens): number | null {
 
   if (sumW === 0) return null;
 
-  // Weighted average is 0–2, scale to 0–10
+  // Weighted average on 0–2 scale, one decimal
   const avg = sumWV / sumW;
-  return Math.round(avg * 5 * 10) / 10;
+  return Math.round(avg * 10) / 10;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- **Mobile sort controls** (#412): shared `MobileSort` component in all 3 explorers, inside filter box, hidden on desktop
- **OQ color coding** (#413): traffic-light colors on OQ scores (green 1.5+, amber 1.0+, red <1.0) in Lens Explorer table and cards
- **OQ scale change**: 0-2 raw scale replaces 0-10 display scale — consistent with individual optical field scores site-wide
- **Feedback link** (#265): mailto in footer (contact@imbra.io)
- **Remove price footnote** (#418): `~` prefix is sufficient

## Test plan
- [ ] Mobile: sort dropdown visible inside filter box, changes card order
- [ ] Desktop: sort dropdown hidden, table sort headers work as before
- [ ] OQ scores show green/amber/red colors in table and cards
- [ ] OQ filter options show 0-2 scale ranges
- [ ] Feedback link in footer opens email client
- [ ] No price footnote on any explorer page
- [ ] 132 tests pass, 0 errors, 458 pages build

Closes #412, #413, #265, #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)