### PR TITLE
docs: ADR-019 OQ display scale, fix session 23 journal format

### DIFF
--- a/docs/decisions/019-oq-display-scale.md
+++ b/docs/decisions/019-oq-display-scale.md
@@ -1,0 +1,45 @@
+# ADR-019: Display optical quality on native 0-2 scale
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+The `computeOpticalQuality` function computes a weighted average of optical
+fields, each on a 0-2 scale. The result was multiplied by 5 to produce a
+0-10 display value. This created two problems:
+
+1. The explorer showed OQ on a 0-10 scale while genre screener field
+   scores used 0-2 — users had to mentally convert between them.
+2. Color-coding OQ required back-converting to 0-2 thresholds, adding
+   complexity for no user benefit.
+
+## Decision
+
+Display OQ on the native 0-2 scale. Remove the x5 multiplier from
+`computeOpticalQuality`. Apply the same traffic-light color thresholds
+used by `FieldVal` for individual optical fields:
+
+- Green: 1.5+ (good)
+- Amber: 1.0-1.4 (acceptable)
+- Red: < 1.0 (poor)
+
+OQ filter ranges in the Lens Explorer updated to match (1.5+, 1.0-1.4,
+0.5-0.9, 0-0.4).
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep 0-10 with color thresholds | Two scales on one site; thresholds require back-conversion |
+| Switch everything to 0-5 | Arbitrary multiplier, no alignment with source data |
+| Switch everything to 0-10 | Would require changing all optical field displays site-wide |
+
+## Consequences
+
+- One scale (0-2) across all pages: field scores, OQ aggregate, genre screener
+- Color language is consistent — green/amber/red means the same everywhere
+- If we later rescale (0-5 or 0-10), it is a single multiplier change that
+  propagates to all pages
+- Users familiar with the old 0-10 OQ values will see lower numbers — no
+  migration path needed since the site is pre-launch

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -773,16 +773,18 @@ Key decisions:
 - Keep genre chip sizing compact (content-width) vs explorer chips (equal-width grid) — different interaction contexts
 - URL param names kept short: q, mount, type, brand, ois, wr, af, status, fl, aperture, thread, oq, price
 
-## Session 23 — 2026-05-01 — UI & UX Milestone Closure
+---
 
-Tool: Claude Code (Opus 4.6)
-Theme: UI & UX — final polish and milestone closure
-Branch: feat/ui-ux-polish
-PR: #419 (merged)
+### Session 23 — UI & UX Milestone Closure
+
+PRs merged:
+- #419 — Mobile sort, OQ color coding, feedback link, remove price footnote
+
 Issues closed: #320 (already done), #412, #413, #265, #418, #246 (wontdo), #46 (epic)
+Issues created: #418 (price footnote removal)
 Milestone closed: Phase 2 — UI & UX (27/27)
 
-Triage: moved 8 issues to other milestones (#394, #270, #410 → Wiki & Content; #269 → Revenue; #251, #266, #272, #300 → Phase 4), moved #336 (light theme) to Phase 4, closed #246 (Material Design spike) as wontdo.
+Triage: moved #394, #270, #410 to Wiki & Content; #269 to Revenue; #251, #266, #272, #300, #336 to Phase 4; closed #246 as wontdo.
 
 Key changes:
 - Mobile sort controls: new shared MobileSort component (generic, reusable), integrated in all 3 explorers inside the filter box
@@ -791,9 +793,10 @@ Key changes:
 - OQ filter ranges updated to 0-2 scale
 - Feedback mailto link added to footer (contact@imbra.io)
 - Price footnote removed from all explorers (~ prefix is sufficient)
+- CLAUDE.md updated: removed price footnote rule
 
 Key decisions:
-- OQ uses 0-2 raw scale for consistency with individual optical field scores; future rescaling (0-5 or 0-10) is a single multiplier change
+- ADR-019: Display OQ on native 0-2 scale for consistency with optical field scores
 - Feedback in footer, not nav — nav reserved for content pages
 - Mobile sort inside filter box, not floating — visually grouped with other controls
 - Light theme deferred to Phase 4 — dark-only is a brand choice, dual-theme adds maintenance overhead


### PR DESCRIPTION
## Summary
- ADR-019: document decision to display OQ on native 0-2 scale
- Fix session 23 journal entry to match established format (### heading, --- separator, ADR reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)