### PR TITLE
fix: bump package.json version to match v0.4.0 tag

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -229,13 +229,15 @@ only. Do not commit the copied files.
 ### 4.1 Release
 
 ```bash
-git checkout -b chore/release-vA.B.C
-# Bump version in package.json to A.B.C
-git add package.json
-git commit -m "chore: release vA.B.C"
-git push -u origin chore/release-vA.B.C
-gh pr create --title "chore: release vA.B.C" --body "Release vA.B.C"
-gh pr merge --merge
+# From main, with clean working directory:
+npm run release -- A.B.C
+```
+
+The script validates preconditions (on main, clean tree, valid semver),
+bumps `package.json`, commits, pushes, and creates a PR. After the PR
+merges:
+
+```bash
 git checkout main && git pull
 git tag vA.B.C && git push origin vA.B.C
 git branch -d chore/release-vA.B.C

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wuseria",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "validate": "npm run lint && npm run format && npm run check && npm run test && npm run build",
+    "release": "bash scripts/release.sh",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: npm run release -- 0.5.0
+# Bumps package.json, commits, pushes, creates PR, and prints next steps.
+
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: npm run release -- <version>"
+  echo "Example: npm run release -- 0.5.0"
+  exit 1
+fi
+
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: version must be semver (e.g. 1.2.3), got: $VERSION"
+  exit 1
+fi
+
+CURRENT=$(node -p "require('./package.json').version")
+if [ "$CURRENT" = "$VERSION" ]; then
+  echo "Error: package.json is already at $VERSION"
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  echo "Error: must be on main branch, currently on: $BRANCH"
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working directory is not clean"
+  exit 1
+fi
+
+echo "Releasing v$VERSION (current: $CURRENT)"
+
+git checkout -b "chore/release-v$VERSION"
+npm version "$VERSION" --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore: release v$VERSION"
+git push -u origin "chore/release-v$VERSION"
+gh pr create --title "chore: release v$VERSION" --body "Release v$VERSION"
+
+echo ""
+echo "PR created. After merge, run:"
+echo "  git checkout main && git pull"
+echo "  git tag v$VERSION && git push origin v$VERSION"
+echo "  git branch -d chore/release-v$VERSION"
+echo "  git push origin --delete chore/release-v$VERSION"


### PR DESCRIPTION
## Summary
- Bumps `package.json` from `0.3.0` to `0.4.0` to match the existing git tag
- Adds `npm run release -- X.Y.Z` script to prevent this from happening again
- Updates PLAYBOOK release section to use the new script

## Root cause
The v0.4.0 release commit (`99b7331`) was empty — `package.json` was never edited. The release process had 6 manual steps; step 2 (bump version) was skipped.

## Fix
The release script validates preconditions before proceeding:
- Must be on `main` with clean working directory
- Version must be valid semver and different from current
- Bumps `package.json` via `npm version --no-git-tag-version`
- Commits, pushes, and creates PR automatically

## Test plan
- [x] `npm run validate` passes
- [x] `package.json` version matches latest git tag
- [x] PLAYBOOK updated with new release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)