### PR TITLE
fix: show empty pips to indicate max mark scale

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -583,7 +583,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  border: 1.5px solid var(--color-border);
+  border: 1.5px solid var(--color-text-muted);
 }
 
 .pipFull {

--- a/src/components/interactive/shared/MarkPips.tsx
+++ b/src/components/interactive/shared/MarkPips.tsx
@@ -23,6 +23,7 @@ function MarkPips({ mark }: { mark: number | null }) {
   if (mark == null) return <span className={styles.markDash}>&ndash;</span>;
   const full = Math.floor(mark);
   const half = mark % 1 >= 0.5;
+  const filled = full + (half ? 1 : 0);
   const pips: React.ReactNode[] = [];
   for (let i = 0; i < full; i++) {
     pips.push(<span key={i} className={`${styles.pip} ${styles.pipFull}`} />);
@@ -31,6 +32,9 @@ function MarkPips({ mark }: { mark: number | null }) {
     pips.push(
       <span key="half" className={`${styles.pip} ${styles.pipHalf}`} />,
     );
+  }
+  for (let i = filled; i < 5; i++) {
+    pips.push(<span key={`empty-${i}`} className={styles.pip} />);
   }
   return (
     <span className={styles.markDots} aria-label={`Mark ${mark} of 5`}>

--- a/src/components/static/GenreScoreBadge.astro
+++ b/src/components/static/GenreScoreBadge.astro
@@ -13,7 +13,8 @@ const palette = [
   "var(--color-mark-5)",
 ];
 const color = palette[mark] || "var(--color-mark-fallback)";
-const dots = "●".repeat(mark);
+const filled = "●".repeat(mark);
+const empty = "○".repeat(5 - mark);
 ---
 
 <span
@@ -21,7 +22,7 @@ const dots = "●".repeat(mark);
   style={`color: ${color};`}
   aria-label={`Mark ${mark} of 5`}
 >
-  {dots}
+  {filled}<span class="mark-empty">{empty}</span>
 </span>
 
 <style>
@@ -29,5 +30,9 @@ const dots = "●".repeat(mark);
     font-family: var(--font-mono);
     font-size: 10px;
     letter-spacing: 0.1em;
+  }
+
+  .mark-empty {
+    opacity: 0.3;
   }
 </style>

--- a/src/components/static/GenreScoreBadge.astro
+++ b/src/components/static/GenreScoreBadge.astro
@@ -33,6 +33,6 @@ const empty = "○".repeat(5 - mark);
   }
 
   .mark-empty {
-    opacity: 0.3;
+    color: var(--color-text-muted);
   }
 </style>


### PR DESCRIPTION
## Summary
- MarkPips (React) now renders all 5 dots — filled/half for the score, empty for the remainder
- GenreScoreBadge (Astro) now renders empty circles with 0.3 opacity after filled ones
- Closes #434

## Test plan
- [x] `npm run validate` passes (132 tests, 458 pages)
- [ ] Visual check: genre screener shows 5 dots per mark
- [ ] Visual check: lens detail page genre marks unchanged (uses text `/5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)