### PR TITLE
chore: resolve all astro check hints and warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 
-export default tseslint.config(
+export default [
   { ignores: ["dist", ".astro"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
@@ -25,4 +25,4 @@ export default tseslint.config(
       ],
     },
   },
-);
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@astrojs/sitemap": "^3.7.2",
         "astro": "^6.1.5",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "zod": "^4.4.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -9499,9 +9500,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@astrojs/sitemap": "^3.7.2",
     "astro": "^6.1.5",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { z } from "zod";
 import { glob } from "astro/loaders";
 
 const wiki = defineCollection({

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -65,6 +65,7 @@ const compat =
   description={accessory.description}
 >
   <script
+    is:inline
     slot="head"
     type="application/ld+json"
     set:html={JSON.stringify(jsonLd)}

--- a/src/pages/cameras/[slug].astro
+++ b/src/pages/cameras/[slug].astro
@@ -49,6 +49,7 @@ const jsonLd = {
   description={`Everything you need to know about the Fujifilm ${camera.model}. Sensor, resolution, weight, and key features at a glance.`}
 >
   <script
+    is:inline
     slot="head"
     type="application/ld+json"
     set:html={JSON.stringify(jsonLd)}

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -79,6 +79,7 @@ const jsonLd = {
   description={`Is the ${lens.brand} ${lens.model} right for your genre? Optical quality scores, specs, and lab-tested performance data.`}
 >
   <script
+    is:inline
     slot="head"
     type="application/ld+json"
     set:html={JSON.stringify(jsonLd)}

--- a/src/pages/wiki/[slug].astro
+++ b/src/pages/wiki/[slug].astro
@@ -40,6 +40,7 @@ const jsonLd = {
   description={entry.data.summary}
 >
   <script
+    is:inline
     slot="head"
     type="application/ld+json"
     set:html={JSON.stringify(jsonLd)}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "exclude": ["coverage", "dist"]
+  "exclude": ["coverage", "dist", "docs/prototype"]
 }


### PR DESCRIPTION
## Summary
- Import `zod` directly instead of deprecated `astro:content` re-export (9 warnings)
- Use array literal in `eslint.config.js` instead of deprecated `tseslint.config()` overload (1 warning)
- Add `is:inline` to JSON-LD `<script>` tags on slug pages to suppress inline script warnings (4 warnings)
- Exclude `docs/prototype` from TypeScript compilation to eliminate dead code warnings (13 warnings)

Closes #427

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings, 0 hints
- [x] `npm run validate` — all 132 tests pass, build succeeds
- [x] JSON-LD still renders correctly in built pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)