### PR TITLE
chore: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -28,7 +28,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -48,11 +48,11 @@ jobs:
     needs: [build, changes]
     if: needs.changes.outputs.code == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the repo, including the solid-ai-templates submodule
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
       # Set up Node.js with npm cache for faster installs
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -37,7 +37,7 @@ jobs:
       - run: npm run validate
 
       # Package dist/ as a GitHub Pages artifact for the deploy job
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist/
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       # Deploy the uploaded artifact to GitHub Pages
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

Supersedes #438, #439, #440, #441 (individual Dependabot PRs that couldn't auto-merge due to cascading rebase delays).

## Test plan
- [ ] CI passes (build + lighthouse)
- [ ] Deploy workflow succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)