### PR TITLE
fix: sort nulls last and guard range filters against invalid URL params

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -71,7 +71,9 @@ interface AccessoryFilterValues {
 
 function passesRangeFilter(value: number, filter: string): boolean {
   if (!filter) return true;
-  const [min, max] = PRICE_RANGES[filter];
+  const range = PRICE_RANGES[filter];
+  if (!range) return true;
+  const [min, max] = range;
   return value >= min && value <= max;
 }
 

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -36,7 +36,9 @@ function passesRangeFilter(
   ranges: Record<string, [number, number]>,
 ): boolean {
   if (!filter) return true;
-  const [min, max] = ranges[filter];
+  const range = ranges[filter];
+  if (!range) return true;
+  const [min, max] = range;
   return value >= min && value <= max;
 }
 

--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -33,7 +33,9 @@ function passesStatusFilter(
 
 function passesFlFilter(lens: ExplorerLens, fl: string): boolean {
   if (!fl) return true;
-  const [min, max] = FL_RANGES[fl];
+  const range = FL_RANGES[fl];
+  if (!range) return true;
+  const [min, max] = range;
   return lens.focalLengthMax >= min && lens.focalLengthMin <= max;
 }
 
@@ -52,7 +54,9 @@ function passesOqFilter(
 ): boolean {
   if (!filter) return true;
   if (filter === "not-scored") return oq == null;
-  const [min, max] = OQ_RANGES[filter];
+  const range = OQ_RANGES[filter];
+  if (!range) return true;
+  const [min, max] = range;
   return oq != null && oq >= min && oq <= max;
 }
 
@@ -62,7 +66,9 @@ function passesRangeFilter(
   ranges: Record<string, [number, number]>,
 ): boolean {
   if (!filter) return true;
-  const [min, max] = ranges[filter];
+  const range = ranges[filter];
+  if (!range) return true;
+  const [min, max] = range;
   return value >= min && value <= max;
 }
 

--- a/src/hooks/useSort.test.ts
+++ b/src/hooks/useSort.test.ts
@@ -83,12 +83,22 @@ describe("useSort", () => {
     expect(result.current.sorted.map((i) => i.name)).toEqual(["B", "A", "C"]);
   });
 
-  it("handles null values by sorting them last", () => {
+  it("handles null values by sorting them last ascending", () => {
     const withNulls = [
       { name: "A", price: null as unknown as number, year: 2020 },
       { name: "B", price: 100, year: 2021 },
     ];
     const { result } = renderHook(() => useSort(withNulls, "price"));
     expect(result.current.sorted.map((i) => i.name)).toEqual(["B", "A"]);
+  });
+
+  it("handles null values by sorting them last descending", () => {
+    const withNulls = [
+      { name: "A", price: null as unknown as number, year: 2020 },
+      { name: "B", price: 300, year: 2021 },
+      { name: "C", price: 100, year: 2022 },
+    ];
+    const { result } = renderHook(() => useSort(withNulls, "price", "desc"));
+    expect(result.current.sorted.map((i) => i.name)).toEqual(["B", "C", "A"]);
   });
 });

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -50,7 +50,15 @@ function useSort<T, K extends string & keyof T>(
         if (pre !== 0) return pre;
       }
 
-      const cmp = compareValues(a[sort.key as keyof T], b[sort.key as keyof T]);
+      const aVal = a[sort.key as keyof T];
+      const bVal = b[sort.key as keyof T];
+
+      // Nulls always last, regardless of direction
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+
+      const cmp = compareValues(aVal, bVal);
       return sort.direction === "asc" ? cmp : -cmp;
     });
     return copy;


### PR DESCRIPTION
## Summary
- Null OQ values floated to top when sorting descending — now always sort last
- Range filter lookups (OQ, FL, price) crash on invalid URL params — now guarded
- Fix applied to all three explorers (Lens, Camera, Accessories)

## Test plan
- [x] New test: nulls sort last in descending order
- [x] `npm run validate` passes (135 tests, 458 pages)
- [ ] Manual: click OQ column header — highest scores appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)