### PR TITLE
fix: preserve Astro history state in URL filter sync

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.test.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.test.tsx
@@ -151,6 +151,56 @@ describe("LensExplorer", () => {
     expect(screen.queryByText("XF 50mm f/2 R WR")).not.toBeInTheDocument();
   });
 
+  it("OIS column sort toggles between asc and desc", async () => {
+    const user = userEvent.setup();
+    const testLenses = [
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 16mm f/1.4 R WR",
+        hasOis: false,
+        price: 1000,
+      }),
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 18-120mm f/4 LM PZ WR",
+        type: "zoom",
+        focalLengthMin: 18,
+        focalLengthMax: 120,
+        hasOis: true,
+        price: 900,
+      }),
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 50mm f/2 R WR",
+        hasOis: false,
+        price: 450,
+      }),
+    ];
+    render(<LensExplorer lenses={testLenses} />);
+
+    const table = screen.getAllByRole("table")[0];
+    const oisButton = within(table).getByRole("button", { name: /OIS/i });
+
+    // First click → ascending (false before true)
+    await user.click(oisButton);
+    const rowsAsc = within(table).getAllByRole("row").slice(1);
+    const modelsAsc = rowsAsc.map(
+      (row) => within(row).getByRole("link").textContent,
+    );
+
+    // Second click → descending (true before false)
+    await user.click(oisButton);
+    const rowsDesc = within(table).getAllByRole("row").slice(1);
+    const modelsDesc = rowsDesc.map(
+      (row) => within(row).getByRole("link").textContent,
+    );
+
+    // The OIS lens should be in different positions
+    expect(modelsAsc).not.toEqual(modelsDesc);
+    // Descending: the OIS=true lens should be first
+    expect(modelsDesc[0]).toBe("XF 18-120mm f/4 LM PZ WR");
+  });
+
   it("sorts by price when Price header is clicked", async () => {
     const user = userEvent.setup();
     render(<LensExplorer lenses={lenses} />);

--- a/src/components/interactive/LensExplorer/LensExplorer.test.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.test.tsx
@@ -104,6 +104,53 @@ describe("LensExplorer", () => {
     ).toBeInTheDocument();
   });
 
+  it("OIS filter works after sorting", async () => {
+    const user = userEvent.setup();
+    const testLenses = [
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 16mm f/1.4 R WR",
+        hasOis: false,
+        isWeatherSealed: true,
+        price: 1000,
+      }),
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 18-120mm f/4 LM PZ WR",
+        type: "zoom",
+        focalLengthMin: 18,
+        focalLengthMax: 120,
+        hasOis: true,
+        isWeatherSealed: true,
+        price: 900,
+      }),
+      makeLens({
+        brand: "Fujifilm",
+        model: "XF 50mm f/2 R WR",
+        hasOis: false,
+        isWeatherSealed: true,
+        price: 450,
+      }),
+    ];
+    render(<LensExplorer lenses={testLenses} />);
+
+    // Sort by price first
+    const table = screen.getAllByRole("table")[0];
+    const priceButton = within(table).getByRole("button", { name: /price/i });
+    await user.click(priceButton);
+
+    // Now filter by OIS — first "Yes" button is OIS (before WR in markup)
+    const yesButtons = screen.getAllByRole("button", { name: "Yes" });
+    await user.click(yesButtons[0]);
+
+    // Only the OIS lens should remain
+    expect(
+      screen.getAllByText("XF 18-120mm f/4 LM PZ WR").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("XF 16mm f/1.4 R WR")).not.toBeInTheDocument();
+    expect(screen.queryByText("XF 50mm f/2 R WR")).not.toBeInTheDocument();
+  });
+
   it("sorts by price when Price header is clicked", async () => {
     const user = userEvent.setup();
     render(<LensExplorer lenses={lenses} />);

--- a/src/hooks/useUrlFilters.ts
+++ b/src/hooks/useUrlFilters.ts
@@ -32,7 +32,7 @@ function useUrlFilters(keys: FilterConfig): {
     const url = search
       ? `${window.location.pathname}?${search}`
       : window.location.pathname;
-    history.replaceState(null, "", url);
+    history.replaceState(history.state, "", url);
   }, [state, keys]);
 
   const set = useCallback((key: string, value: string) => {


### PR DESCRIPTION
## Summary
- `useUrlFilters` was calling `history.replaceState(null, ...)` which clobbered Astro's `ClientRouter` internal state (`index`, `scrollX`, `scrollY`)
- After state corruption, subsequent interactions (sort, filter changes) could cause unpredictable behavior — OIS and WR chip filters appeared to stop working after sorting
- Fix: pass `history.state` through to preserve Astro's router state
- Added test for filter-after-sort interaction

## Test plan
- [x] New test: OIS filter works after sorting by price
- [x] `npm run validate` passes (136 tests, 458 pages)
- [ ] Manual: on /lenses, sort by any column, then toggle OIS/WR chips — verify filter updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)