### PR TITLE
fix: show all lenses when sort column changes

### DIFF
--- a/src/components/interactive/LensExplorer/LensExplorer.tsx
+++ b/src/components/interactive/LensExplorer/LensExplorer.tsx
@@ -226,7 +226,7 @@ function LensExplorer({ lenses }: LensExplorerProps) {
         <>
           <LensResults
             sorted={
-              showAll || hasFilters
+              showAll || hasFilters || sortKey !== "focalLengthMin"
                 ? sorted
                 : sorted.slice(0, INITIAL_PAGE_SIZE)
             }
@@ -235,15 +235,18 @@ function LensExplorer({ lenses }: LensExplorerProps) {
             sortDirection={sortDirection}
             toggleSort={toggleSort}
           />
-          {!showAll && !hasFilters && sorted.length > INITIAL_PAGE_SIZE && (
-            <button
-              type="button"
-              className={styles.showAllButton}
-              onClick={() => setShowAll(true)}
-            >
-              Show all {sorted.length} lenses
-            </button>
-          )}
+          {!showAll &&
+            !hasFilters &&
+            sortKey === "focalLengthMin" &&
+            sorted.length > INITIAL_PAGE_SIZE && (
+              <button
+                type="button"
+                className={styles.showAllButton}
+                onClick={() => setShowAll(true)}
+              >
+                Show all {sorted.length} lenses
+              </button>
+            )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Pagination (first 50 of 241) hid boolean column sort toggles
- OIS ascending: first 50 = all false (looks unchanged); descending: true first (visible)
- Toggling back to ascending looked like "nothing happened" because the visible slice was identical
- Fix: show all results when sort column differs from default (focalLengthMin)
- Cameras unaffected (no pagination — only 39 cameras)

## Test plan
- [x] `npm run validate` passes (137 tests, 458 pages)
- [ ] Manual: click OIS column header twice — verify toggle between true-first and false-first is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)