### PR TITLE
fix: stabilize table columns and sync explorer filters to URL

### DIFF
--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -5,7 +5,7 @@ import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
 import { MobileSort } from "../shared/MobileSort";
-import type { ColumnAlign } from "../shared/table";
+import type { ColumnDef } from "../shared/table";
 import {
   makeAlignClasses,
   ariaSortValue,
@@ -24,14 +24,13 @@ type AccessorySortKey =
   | "description"
   | "price";
 
-const COLUMNS: { key: AccessorySortKey; label: string; align: ColumnAlign }[] =
-  [
-    { key: "category", label: "Category", align: "left" },
-    { key: "brand", label: "Brand", align: "left" },
-    { key: "model", label: "Model", align: "left" },
-    { key: "description", label: "Description", align: "left" },
-    { key: "price", label: "Price", align: "right" },
-  ];
+const COLUMNS: ColumnDef<AccessorySortKey>[] = [
+  { key: "category", label: "Category", align: "left", width: "14%" },
+  { key: "brand", label: "Brand", align: "left", width: "12%" },
+  { key: "model", label: "Model", align: "left", width: "24%" },
+  { key: "description", label: "Description", align: "left", width: "40%" },
+  { key: "price", label: "Price", align: "right", width: "10%" },
+];
 
 const ALIGN_CLASSES = makeAlignClasses(styles);
 
@@ -280,6 +279,11 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
           {/* Table — desktop */}
           <div className={styles.tableWrap}>
             <table className={styles.table}>
+              <colgroup>
+                {COLUMNS.map((col) => (
+                  <col key={col.key} style={{ width: col.width }} />
+                ))}
+              </colgroup>
               <thead>
                 <tr>
                   {COLUMNS.map((col) => (

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import type { Accessory, AccessoryCategory } from "../../../types/accessory";
 import { useSort } from "../../../hooks/useSort";
+import { useUrlFilters } from "../../../hooks/useUrlFilters";
 import { toSlug } from "../../../utils/slug";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
@@ -59,15 +60,6 @@ const PRICE_RANGES: Record<string, [number, number]> = {
   "1000+": [1000, Infinity],
 };
 
-interface AccessoryFilterValues {
-  search: string;
-  category: string;
-  mount: string;
-  compatible: string;
-  discontinued: string;
-  priceRange: string;
-}
-
 function passesRangeFilter(value: number, filter: string): boolean {
   if (!filter) return true;
   const range = PRICE_RANGES[filter];
@@ -85,7 +77,7 @@ function getCompatibleWith(acc: Accessory): string[] {
 
 function matchesAccessoryFilters(
   acc: Accessory,
-  f: AccessoryFilterValues,
+  f: Record<string, string>,
 ): boolean {
   if (f.category && acc.category !== f.category) return false;
   if (f.mount && (!("mount" in acc) || acc.mount !== f.mount)) return false;
@@ -94,10 +86,10 @@ function matchesAccessoryFilters(
     if (!getCompatibleWith(acc).some((c) => c.toLowerCase().includes(cq)))
       return false;
   }
-  if (f.discontinued === "available" && acc.isDiscontinued) return false;
-  if (f.discontinued === "discontinued" && !acc.isDiscontinued) return false;
-  if (!passesRangeFilter(acc.price, f.priceRange)) return false;
-  const q = f.search.toLowerCase();
+  if (f.status === "available" && acc.isDiscontinued) return false;
+  if (f.status === "discontinued" && !acc.isDiscontinued) return false;
+  if (!passesRangeFilter(acc.price, f.price)) return false;
+  const q = f.q.toLowerCase();
   if (
     q &&
     !`${acc.brand} ${acc.model} ${acc.description}`.toLowerCase().includes(q)
@@ -106,38 +98,32 @@ function matchesAccessoryFilters(
   return true;
 }
 
+const FILTER_KEYS = [
+  "q",
+  "category",
+  "mount",
+  "compatible",
+  "status",
+  "price",
+] as const;
+
 function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
-  const [search, setSearch] = useState("");
-  const [category, setCategory] = useState("");
-  const [mount, setMount] = useState("");
-  const [compatible, setCompatible] = useState("");
-  const [discontinued, setDiscontinued] = useState("");
-  const [priceRange, setPriceRange] = useState("");
+  const {
+    values: f,
+    set,
+    clear: clearFilters,
+    hasFilters,
+  } = useUrlFilters(FILTER_KEYS);
 
   const categories = useMemo(() => {
     const cats = [...new Set(accessories.map((a) => a.category))].sort();
     return cats;
   }, [accessories]);
 
-  const filtered = useMemo(() => {
-    const f: AccessoryFilterValues = {
-      search,
-      category,
-      mount,
-      compatible,
-      discontinued,
-      priceRange,
-    };
-    return accessories.filter((acc) => matchesAccessoryFilters(acc, f));
-  }, [
-    accessories,
-    search,
-    category,
-    mount,
-    compatible,
-    discontinued,
-    priceRange,
-  ]);
+  const filtered = useMemo(
+    () => accessories.filter((acc) => matchesAccessoryFilters(acc, f)),
+    [accessories, f],
+  );
 
   const availableFirst = useCallback(
     (a: Accessory, b: Accessory) =>
@@ -148,18 +134,6 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
     Accessory,
     AccessorySortKey
   >(filtered, "category", "asc", availableFirst);
-
-  const hasFilters =
-    search || category || mount || compatible || discontinued || priceRange;
-
-  function clearFilters(): void {
-    setSearch("");
-    setCategory("");
-    setMount("");
-    setCompatible("");
-    setDiscontinued("");
-    setPriceRange("");
-  }
 
   return (
     <div>
@@ -176,8 +150,8 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
             className={styles.searchInput}
             type="text"
             placeholder="Search accessories..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            value={f.q}
+            onChange={(e) => set("q", e.target.value)}
             aria-label="Search accessories"
           />
           {hasFilters && (
@@ -194,18 +168,18 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
 
         <div className={styles.filterRow}>
           <input
-            className={`${styles.searchInput} ${compatible ? styles.filterActive : ""}`}
+            className={`${styles.searchInput} ${f.compatible ? styles.filterActive : ""}`}
             type="text"
             placeholder="Compatible with... (e.g. X-T5)"
-            value={compatible}
-            onChange={(e) => setCompatible(e.target.value)}
+            value={f.compatible}
+            onChange={(e) => set("compatible", e.target.value)}
             aria-label="Filter by compatible model"
           />
 
           <select
-            className={`${styles.filterSelect} ${category ? styles.filterActive : ""}`}
-            value={category}
-            onChange={(e) => setCategory(resetValue(e.target.value))}
+            className={`${styles.filterSelect} ${f.category ? styles.filterActive : ""}`}
+            value={f.category}
+            onChange={(e) => set("category", resetValue(e.target.value))}
             aria-label="Filter by category"
           >
             <option value="" hidden>
@@ -220,9 +194,9 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
           </select>
 
           <select
-            className={`${styles.filterSelect} ${priceRange ? styles.filterActive : ""}`}
-            value={priceRange}
-            onChange={(e) => setPriceRange(resetValue(e.target.value))}
+            className={`${styles.filterSelect} ${f.price ? styles.filterActive : ""}`}
+            value={f.price}
+            onChange={(e) => set("price", resetValue(e.target.value))}
             aria-label="Filter by price"
           >
             <option value="" hidden>
@@ -239,8 +213,8 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
         <div className={styles.chipRow}>
           <ChipGroup
             label="Mount"
-            value={mount}
-            onChange={setMount}
+            value={f.mount}
+            onChange={(v) => set("mount", v)}
             styles={styles}
             options={[
               { label: "All", value: "" },
@@ -250,8 +224,8 @@ function AccessoriesExplorer({ accessories }: AccessoriesExplorerProps) {
           />
           <ChipGroup
             label="Status"
-            value={discontinued}
-            onChange={setDiscontinued}
+            value={f.status}
+            onChange={(v) => set("status", v)}
             styles={styles}
             options={[
               { label: "All", value: "" },

--- a/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CameraExplorer from "./CameraExplorer";
@@ -36,6 +36,10 @@ const cameras = [
 ];
 
 describe("CameraExplorer", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+
   it("renders all cameras", () => {
     render(<CameraExplorer cameras={cameras} />);
     expect(screen.getAllByText("X-T5").length).toBeGreaterThan(0);

--- a/src/components/interactive/CameraExplorer/CameraExplorer.tsx
+++ b/src/components/interactive/CameraExplorer/CameraExplorer.tsx
@@ -1,25 +1,12 @@
-import { useState, useMemo, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import { useSort } from "../../../hooks/useSort";
+import { useUrlFilters } from "../../../hooks/useUrlFilters";
 import type { CameraSortKey } from "./constants";
 import { YEAR_RANGES, PRICE_RANGES } from "./constants";
 import { CameraFilters } from "./CameraFilters";
 import { CameraResults } from "./CameraResults";
 import type { ExplorerCamera } from "./types";
 import styles from "./CameraExplorer.module.css";
-
-interface CameraFilterValues {
-  search: string;
-  mount: string;
-  series: string;
-  yearRange: string;
-  sensorType: string;
-  formFactor: string;
-  ibis: string;
-  wr: string;
-  discontinued: string;
-  videoSpec: string;
-  priceRange: string;
-}
 
 function passesBooleanFilter(
   filter: string,
@@ -57,20 +44,20 @@ function passesStatusFilter(
 
 function matchesCameraFilters(
   cam: ExplorerCamera,
-  f: CameraFilterValues,
+  f: Record<string, string>,
 ): boolean {
   return (
     passesExactFilter(cam.mount, f.mount) &&
     passesExactFilter(cam.series, f.series) &&
-    passesRangeFilter(cam.year, f.yearRange, YEAR_RANGES) &&
-    passesExactFilter(cam.sensor, f.sensorType) &&
-    passesExactFilter(cam.formFactor, f.formFactor) &&
+    passesRangeFilter(cam.year, f.year, YEAR_RANGES) &&
+    passesExactFilter(cam.sensor, f.sensor) &&
+    passesExactFilter(cam.formFactor, f.form) &&
     passesBooleanFilter(f.ibis, cam.hasIbis) &&
     passesBooleanFilter(f.wr, cam.isWeatherSealed) &&
-    passesStatusFilter(f.discontinued, cam.isDiscontinued) &&
-    passesExactFilter(cam.videoSpec, f.videoSpec) &&
-    passesRangeFilter(cam.price, f.priceRange, PRICE_RANGES) &&
-    (!f.search || cam.model.toLowerCase().includes(f.search.toLowerCase()))
+    passesStatusFilter(f.status, cam.isDiscontinued) &&
+    passesExactFilter(cam.videoSpec, f.video) &&
+    passesRangeFilter(cam.price, f.price, PRICE_RANGES) &&
+    (!f.q || cam.model.toLowerCase().includes(f.q.toLowerCase()))
   );
 }
 
@@ -78,58 +65,42 @@ interface CameraExplorerProps {
   cameras: ExplorerCamera[];
 }
 
+const FILTER_KEYS = [
+  "q",
+  "mount",
+  "series",
+  "year",
+  "sensor",
+  "form",
+  "ibis",
+  "wr",
+  "status",
+  "video",
+  "price",
+] as const;
+
 function CameraExplorer({ cameras }: CameraExplorerProps) {
-  const [search, setSearch] = useState("");
-  const [mount, setMount] = useState("");
-  const [series, setSeries] = useState("");
-  const [yearRange, setYearRange] = useState("");
-  const [sensorType, setSensorType] = useState("");
-  const [ibis, setIbis] = useState("");
-  const [wr, setWr] = useState("");
-  const [formFactor, setFormFactor] = useState("");
-  const [discontinued, setDiscontinued] = useState("");
-  const [videoSpec, setVideoSpec] = useState("");
-  const [priceRange, setPriceRange] = useState("");
+  const {
+    values: f,
+    set,
+    clear: clearFilters,
+    hasFilters,
+  } = useUrlFilters(FILTER_KEYS);
 
   const seriesOptions = useMemo(() => {
-    const pool = mount ? cameras.filter((c) => c.mount === mount) : cameras;
+    const pool = f.mount ? cameras.filter((c) => c.mount === f.mount) : cameras;
     return [...new Set(pool.map((c) => c.series))].sort();
-  }, [cameras, mount]);
+  }, [cameras, f.mount]);
 
   const sensorOptions = useMemo(() => {
-    const pool = mount ? cameras.filter((c) => c.mount === mount) : cameras;
+    const pool = f.mount ? cameras.filter((c) => c.mount === f.mount) : cameras;
     return [...new Set(pool.map((c) => c.sensor))].sort();
-  }, [cameras, mount]);
+  }, [cameras, f.mount]);
 
-  const filtered = useMemo(() => {
-    const f: CameraFilterValues = {
-      search,
-      mount,
-      series,
-      yearRange,
-      sensorType,
-      formFactor,
-      ibis,
-      wr,
-      discontinued,
-      videoSpec,
-      priceRange,
-    };
-    return cameras.filter((cam) => matchesCameraFilters(cam, f));
-  }, [
-    cameras,
-    search,
-    mount,
-    series,
-    yearRange,
-    sensorType,
-    formFactor,
-    discontinued,
-    ibis,
-    wr,
-    videoSpec,
-    priceRange,
-  ]);
+  const filtered = useMemo(
+    () => cameras.filter((cam) => matchesCameraFilters(cam, f)),
+    [cameras, f],
+  );
 
   const availableFirst = useCallback(
     (a: ExplorerCamera, b: ExplorerCamera) =>
@@ -146,41 +117,13 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
   >(filtered, "year", "asc", availableFirst, descFirst);
 
   function handleMountChange(value: string): void {
-    setMount(value);
-    if (series) {
+    set("mount", value);
+    if (f.series) {
       const seriesExistsInMount = cameras.some(
-        (c) => c.series === series && (!value || c.mount === value),
+        (c) => c.series === f.series && (!value || c.mount === value),
       );
-      if (!seriesExistsInMount) setSeries("");
+      if (!seriesExistsInMount) set("series", "");
     }
-  }
-
-  const hasFilters = !!(
-    search ||
-    mount ||
-    series ||
-    yearRange ||
-    sensorType ||
-    formFactor ||
-    discontinued ||
-    ibis ||
-    wr ||
-    videoSpec ||
-    priceRange
-  );
-
-  function clearFilters(): void {
-    setSearch("");
-    setMount("");
-    setSeries("");
-    setYearRange("");
-    setSensorType("");
-    setFormFactor("");
-    setDiscontinued("");
-    setIbis("");
-    setWr("");
-    setVideoSpec("");
-    setPriceRange("");
   }
 
   return (
@@ -193,28 +136,28 @@ function CameraExplorer({ cameras }: CameraExplorerProps) {
       </div>
 
       <CameraFilters
-        search={search}
-        setSearch={setSearch}
-        mount={mount}
+        search={f.q}
+        setSearch={(v) => set("q", v)}
+        mount={f.mount}
         onMountChange={handleMountChange}
-        series={series}
-        setSeries={setSeries}
-        yearRange={yearRange}
-        setYearRange={setYearRange}
-        sensorType={sensorType}
-        setSensorType={setSensorType}
-        ibis={ibis}
-        setIbis={setIbis}
-        wr={wr}
-        setWr={setWr}
-        formFactor={formFactor}
-        setFormFactor={setFormFactor}
-        discontinued={discontinued}
-        setDiscontinued={setDiscontinued}
-        videoSpec={videoSpec}
-        setVideoSpec={setVideoSpec}
-        priceRange={priceRange}
-        setPriceRange={setPriceRange}
+        series={f.series}
+        setSeries={(v) => set("series", v)}
+        yearRange={f.year}
+        setYearRange={(v) => set("year", v)}
+        sensorType={f.sensor}
+        setSensorType={(v) => set("sensor", v)}
+        ibis={f.ibis}
+        setIbis={(v) => set("ibis", v)}
+        wr={f.wr}
+        setWr={(v) => set("wr", v)}
+        formFactor={f.form}
+        setFormFactor={(v) => set("form", v)}
+        discontinued={f.status}
+        setDiscontinued={(v) => set("status", v)}
+        videoSpec={f.video}
+        setVideoSpec={(v) => set("video", v)}
+        priceRange={f.price}
+        setPriceRange={(v) => set("price", v)}
         seriesOptions={seriesOptions}
         sensorOptions={sensorOptions}
         hasFilters={hasFilters}

--- a/src/components/interactive/CameraExplorer/CameraResults.tsx
+++ b/src/components/interactive/CameraExplorer/CameraResults.tsx
@@ -28,6 +28,11 @@ function CameraResults({
     <>
       <div className={styles.tableWrap}>
         <table className={styles.table}>
+          <colgroup>
+            {COLUMNS.map((col) => (
+              <col key={col.key} style={{ width: col.width }} />
+            ))}
+          </colgroup>
           <thead>
             <tr>
               {COLUMNS.map((col) => (

--- a/src/components/interactive/CameraExplorer/constants.ts
+++ b/src/components/interactive/CameraExplorer/constants.ts
@@ -1,4 +1,4 @@
-import type { ColumnAlign } from "../shared/table";
+import type { ColumnDef } from "../shared/table";
 
 type CameraSortKey =
   | "model"
@@ -13,18 +13,18 @@ type CameraSortKey =
   | "weight"
   | "price";
 
-const COLUMNS: { key: CameraSortKey; label: string; align: ColumnAlign }[] = [
-  { key: "model", label: "Model", align: "left" },
-  { key: "year", label: "Year", align: "right" },
-  { key: "megapixels", label: "MP", align: "right" },
-  { key: "sensor", label: "Sensor", align: "left" },
-  { key: "hasIbis", label: "IBIS", align: "center" },
-  { key: "isWeatherSealed", label: "WR", align: "center" },
-  { key: "mechanicalBurstFps", label: "FPS", align: "right" },
-  { key: "videoSpec", label: "Video", align: "center" },
-  { key: "batteryLife", label: "Battery", align: "right" },
-  { key: "weight", label: "Weight", align: "right" },
-  { key: "price", label: "Price", align: "right" },
+const COLUMNS: ColumnDef<CameraSortKey>[] = [
+  { key: "model", label: "Model", align: "left", width: "22%" },
+  { key: "year", label: "Year", align: "right", width: "7%" },
+  { key: "megapixels", label: "MP", align: "right", width: "6%" },
+  { key: "sensor", label: "Sensor", align: "left", width: "12%" },
+  { key: "hasIbis", label: "IBIS", align: "center", width: "6%" },
+  { key: "isWeatherSealed", label: "WR", align: "center", width: "5%" },
+  { key: "mechanicalBurstFps", label: "FPS", align: "right", width: "6%" },
+  { key: "videoSpec", label: "Video", align: "center", width: "8%" },
+  { key: "batteryLife", label: "Battery", align: "right", width: "8%" },
+  { key: "weight", label: "Weight", align: "right", width: "8%" },
+  { key: "price", label: "Price", align: "right", width: "8%" },
 ];
 
 const YEAR_RANGES: Record<string, [number, number]> = {

--- a/src/components/interactive/LensExplorer/LensResults.tsx
+++ b/src/components/interactive/LensExplorer/LensResults.tsx
@@ -36,6 +36,11 @@ function LensResults({
     <>
       <div className={styles.tableWrap}>
         <table className={styles.table}>
+          <colgroup>
+            {COLUMNS.map((col) => (
+              <col key={col.key} style={{ width: col.width }} />
+            ))}
+          </colgroup>
           <thead>
             <tr>
               {COLUMNS.map((col) => (

--- a/src/components/interactive/LensExplorer/constants.ts
+++ b/src/components/interactive/LensExplorer/constants.ts
@@ -1,4 +1,4 @@
-import type { ColumnAlign } from "../shared/table";
+import type { ColumnDef } from "../shared/table";
 
 interface ExplorerLens {
   brand: string;
@@ -37,19 +37,19 @@ type LensSortKey =
   | "opticalQuality"
   | "price";
 
-const COLUMNS: { key: LensSortKey; label: string; align: ColumnAlign }[] = [
-  { key: "brand", label: "Brand", align: "left" },
-  { key: "model", label: "Model", align: "left" },
-  { key: "year", label: "Year", align: "left" },
-  { key: "focalLengthMin", label: "FL", align: "right" },
-  { key: "maxAperture", label: "f/", align: "right" },
-  { key: "filterThread", label: "\u03A6", align: "right" },
-  { key: "hasOis", label: "OIS", align: "center" },
-  { key: "isWeatherSealed", label: "WR", align: "center" },
-  { key: "afMotor", label: "AF", align: "center" },
-  { key: "weight", label: "Weight", align: "right" },
-  { key: "opticalQuality", label: "OQ", align: "right" },
-  { key: "price", label: "Price", align: "right" },
+const COLUMNS: ColumnDef<LensSortKey>[] = [
+  { key: "brand", label: "Brand", align: "left", width: "9%" },
+  { key: "model", label: "Model", align: "left", width: "20%" },
+  { key: "year", label: "Year", align: "left", width: "6%" },
+  { key: "focalLengthMin", label: "FL", align: "right", width: "7%" },
+  { key: "maxAperture", label: "f/", align: "right", width: "5%" },
+  { key: "filterThread", label: "\u03A6", align: "right", width: "5%" },
+  { key: "hasOis", label: "OIS", align: "center", width: "5%" },
+  { key: "isWeatherSealed", label: "WR", align: "center", width: "5%" },
+  { key: "afMotor", label: "AF", align: "center", width: "6%" },
+  { key: "weight", label: "Weight", align: "right", width: "8%" },
+  { key: "opticalQuality", label: "OQ", align: "right", width: "6%" },
+  { key: "price", label: "Price", align: "right", width: "8%" },
 ];
 
 const INITIAL_PAGE_SIZE = 50;

--- a/src/components/interactive/shared/shared.module.css
+++ b/src/components/interactive/shared/shared.module.css
@@ -262,6 +262,7 @@
 
 .table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   font-size: var(--font-size-sm);
 }

--- a/src/components/interactive/shared/table.ts
+++ b/src/components/interactive/shared/table.ts
@@ -1,5 +1,12 @@
 type ColumnAlign = "left" | "right" | "center";
 
+interface ColumnDef<K extends string> {
+  key: K;
+  label: string;
+  align: ColumnAlign;
+  width: string;
+}
+
 function makeAlignClasses(
   styles: Record<string, string>,
 ): Record<ColumnAlign, string | undefined> {
@@ -30,5 +37,5 @@ function sortIndicatorChar(
   return "\u2193";
 }
 
-export type { ColumnAlign };
+export type { ColumnAlign, ColumnDef };
 export { makeAlignClasses, ariaSortValue, sortIndicatorChar };


### PR DESCRIPTION
## Summary
- **#483**: Add `table-layout: fixed` with `<colgroup>` widths to all explorer tables — column widths no longer shift when sorting
- **#478**: Replace `useState` with `useUrlFilters` in Camera and Accessories explorers — filter state is now reflected in the URL for shareable links

Closes #483
Closes #478

## Test plan
- [ ] Lens explorer: sort by filter thread — columns stay stable
- [ ] Camera explorer: apply filters, copy URL, open in new tab — filters restored
- [ ] Accessories explorer: apply filters, copy URL, open in new tab — filters restored
- [ ] Clear filters works on all three explorers
- [ ] Mobile card layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)