### PR TITLE
docs: fix stale homepage description in ONBOARDING

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -26,8 +26,9 @@ already cloned without it, run `git submodule update --init`.
 npm run dev
 ```
 
-Open [http://localhost:4321](http://localhost:4321). You should be redirected
-to the Lens Explorer page. Confirm the dev server starts without errors.
+Open [http://localhost:4321](http://localhost:4321). You should see the homepage
+with stats, workflow cards, and scoring overview. Confirm the dev server starts
+without errors.
 
 To verify linting:
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1059,3 +1059,4 @@ Key decisions:
 - Homepage changelog (#477) deferred — user wants a broader homepage redesign with three-column layout and feature voting (#485), changelog will be part of that
 - `table-layout: fixed` chosen over `min-width` approach — fully prevents width shifts vs only reducing them
 - Percentage-based colgroup widths — totals intentionally under 100% (90%) to let browser distribute remaining space as padding
+- ONBOARDING.md — fixed stale homepage description (was "redirected to Lens Explorer", now shows actual homepage)


### PR DESCRIPTION
## Summary
- ONBOARDING.md said homepage redirects to Lens Explorer — no longer true since homepage was added
- Updated journal entry with ONBOARDING fix note

🤖 Generated with [Claude Code](https://claude.com/claude-code)