### PR TITLE
docs: add upstream candidates to session 31 journal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,10 +274,10 @@ execution prevents missed steps.
 [ ] 3. Update epic checklists if relevant
 [ ] 4. Dev journal entry (### heading, --- separator, PRs, issues, key changes, key decisions with ADR refs)
 [ ] 5. ADRs — record any architectural decisions in docs/decisions/
-[ ] 6. CLAUDE.md — update if conventions or architecture changed
-[ ] 7. README.md — update if public-facing info changed
-[ ] 8. ONBOARDING.md — update if prerequisites or setup changed
-[ ] 9. PLAYBOOK.md — update if commands, workflows, or release process changed
+[ ] 6. CLAUDE.md — for each new convention/rule introduced, does it belong here? Name the section.
+[ ] 7. README.md — for each new command, dependency, or structural change, is it reflected? Name the section.
+[ ] 8. ONBOARDING.md — for each new tool, prerequisite, or setup step, is it documented? Name the section.
+[ ] 9. PLAYBOOK.md — for each new command/script/workflow added, is it documented? Name the section.
 [ ] 10. Submodules — check if upstream needs update
 [ ] 11. Flag conventions for solid-ai-templates upstream — for each new pattern/convention introduced, explicitly state whether it's project-specific or reusable; if reusable, name the upstream template file it would go in
 [ ] 12. Summarize what was done and what's next

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,6 @@ execution prevents missed steps.
 [ ] 8. ONBOARDING.md — update if prerequisites or setup changed
 [ ] 9. PLAYBOOK.md — update if commands, workflows, or release process changed
 [ ] 10. Submodules — check if upstream needs update
-[ ] 11. Flag conventions for solid-ai-templates upstream
+[ ] 11. Flag conventions for solid-ai-templates upstream — for each new pattern/convention introduced, explicitly state whether it's project-specific or reusable; if reusable, name the upstream template file it would go in
 [ ] 12. Summarize what was done and what's next
 ```

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1092,3 +1092,9 @@ Key decisions:
 - Coverage only tracks `src/utils/` and `src/hooks/` (component test coverage not enforced by thresholds)
 - Lighthouse reports go to `reports/lighthouse/` (filesystem upload target in lighthouserc.json)
 - lychee and gitleaks are optional local tools (not npm packages, need system install)
+
+Upstream candidates for solid-ai-templates:
+
+- `test:report` as a MAY command in stack templates (HTML coverage + test results)
+- `it.fails` pattern for known data gaps (expected failures that auto-flag when fixed)
+- Local report generation convention for CI-only tools (Lighthouse, lychee, gitleaks)


### PR DESCRIPTION
## Summary
- Add 3 upstream candidates for solid-ai-templates identified during session 31 wrap-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)