### PR TITLE
refactor: extract shared utils and MarkPips styles

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -273,6 +273,56 @@ Open either in a browser. The `reports/` directory is gitignored.
 | `src/components/interactive/GenreGuide/GenreGuide.test.tsx`         | Genre tabs, filters, matrices                  |
 | `src/components/interactive/GenreGuide/exposure.test.ts`            | Exposure calculations                          |
 
+### 2.11 Analytics verification (Umami)
+
+Umami Cloud tracks page views with zero cookies and no consent banner.
+The script loads from `cloud.umami.is` via the base layout. Run this
+manual check after changes to navigation, View Transitions, or the
+analytics integration.
+
+**Prerequisites:**
+
+- Access to https://cloud.umami.is/ (login credentials)
+- Chrome DevTools (or equivalent)
+
+**Step 1 — Script loads:**
+
+1. Open https://wuseria.com
+2. DevTools → Network → filter `script.js`
+3. Refresh the page
+
+Expected: `cloud.umami.is/script.js` returns **200 OK**, ~5-6 KB.
+No console errors.
+
+**Step 2 — Page views register:**
+
+1. Open the Umami dashboard → select wuseria.com → Realtime view
+2. Navigate through several pages: Lenses → Cameras → Genre → Wiki →
+   any individual lens detail page
+3. Check the dashboard
+
+Expected: each page path appears (`/lenses/`, `/cameras/`, `/genre/`,
+`/wiki/`, `/lenses/[slug]`). Count matches pages visited.
+
+**Step 3 — No duplicate events:**
+
+1. DevTools → Network → clear the log
+2. Click one navigation link (e.g. Cameras)
+3. Filter by `cloud.umami.is`
+
+Expected: exactly **1 `send`** request per navigation. If 2+ fire
+for a single click, that's a duplicate event bug.
+
+**Step 4 — Fresh page load:**
+
+1. Clear the Network log
+2. Type `wuseria.com` in the address bar and press Enter (full load)
+3. Filter by `cloud.umami.is`
+
+Expected: `script.js` + exactly **1 `send`** request.
+
+**Last verified:** 2026-05-03 — all checks pass.
+
 ## 3. Maintenance
 
 ### 3.1 Update quality conventions

--- a/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
+++ b/src/components/interactive/AccessoriesExplorer/AccessoriesExplorer.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useCallback } from "react";
-import type { Accessory, AccessoryCategory } from "../../../types/accessory";
+import type { Accessory } from "../../../types/accessory";
 import { useSort } from "../../../hooks/useSort";
 import { useUrlFilters } from "../../../hooks/useUrlFilters";
 import { toSlug } from "../../../utils/slug";
+import { formatCategory } from "../../../utils/formatting";
 import { ChipGroup } from "../shared/ChipGroup";
 import { RESET_VALUE, resetValue } from "../shared/constants";
 import { MobileSort } from "../shared/MobileSort";
@@ -34,24 +35,6 @@ const COLUMNS: ColumnDef<AccessorySortKey>[] = [
 ];
 
 const ALIGN_CLASSES = makeAlignClasses(styles);
-
-const CATEGORY_LABELS: Record<string, string> = {
-  flash: "Flash",
-  "battery-grip": "Battery Grip",
-  "hand-grip": "Hand Grip",
-  battery: "Battery",
-  charger: "Charger",
-  "lens-accessory": "Lens Accessory",
-  adapter: "Adapter",
-  remote: "Remote",
-  audio: "Audio",
-  cooling: "Cooling",
-  "body-accessory": "Body Accessory",
-};
-
-function formatCategory(category: AccessoryCategory): string {
-  return CATEGORY_LABELS[category] ?? category;
-}
 
 const PRICE_RANGES: Record<string, [number, number]> = {
   "0-250": [0, 250],

--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -568,69 +568,7 @@
   line-height: 1.5;
 }
 
-/* ==========================================================================
-   Mark pips
-   ========================================================================== */
-
-.markDots {
-  display: inline-flex;
-  gap: 3px;
-  align-items: center;
-}
-
-.pip {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  border: 1.5px solid var(--color-text-muted);
-}
-
-.pipFull {
-  background-color: var(--color-accent);
-  border-color: var(--color-accent);
-}
-
-.pipHalf {
-  background: linear-gradient(
-    to right,
-    var(--color-accent) 50%,
-    transparent 50%
-  );
-  border-color: var(--color-accent);
-}
-
-.markDash {
-  color: #8a8070;
-}
-
-/* Field value colors — traffic-light scale for optical scores (0-2) */
-.fieldViable {
-  color: #6aaa70; /* green — good optical performance */
-}
-
-.fieldMarginal {
-  color: #b09040; /* amber — acceptable */
-}
-
-.fieldOver {
-  color: #905030; /* red — poor */
-}
-
-.fieldMono {
-  font-family: var(--font-mono);
-}
-
-.topStar {
-  color: var(--color-accent);
-  font-size: var(--font-size-sm);
-}
-
-.sweetSpot {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-  margin-left: var(--space-xs);
-}
+/* Mark pips, field values, and pick star styles are in shared/MarkPips.module.css */
 
 .dotOn,
 .dotOff {

--- a/src/components/interactive/shared/MarkPips.module.css
+++ b/src/components/interactive/shared/MarkPips.module.css
@@ -1,0 +1,55 @@
+/* Mark pips, field values, and editorial pick styles */
+
+.markDots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.pip {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-text-muted);
+}
+
+.pipFull {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.pipHalf {
+  background: linear-gradient(
+    to right,
+    var(--color-accent) 50%,
+    transparent 50%
+  );
+  border-color: var(--color-accent);
+}
+
+.markDash {
+  color: #8a8070;
+}
+
+/* Field value colors — traffic-light scale for optical scores (0-2) */
+.fieldViable {
+  color: #6aaa70; /* green — good optical performance */
+}
+
+.fieldMarginal {
+  color: #b09040; /* amber — acceptable */
+}
+
+.fieldOver {
+  color: #905030; /* red — poor */
+}
+
+.fieldMono {
+  font-family: var(--font-mono);
+}
+
+.topStar {
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+}

--- a/src/components/interactive/shared/MarkPips.tsx
+++ b/src/components/interactive/shared/MarkPips.tsx
@@ -1,4 +1,4 @@
-import styles from "../GenreGuide/GenreGuide.module.css";
+import styles from "./MarkPips.module.css";
 
 // =============================================================================
 // FIELD VALUE — 0-2 scale with traffic-light color

--- a/src/pages/accessories/[slug].astro
+++ b/src/pages/accessories/[slug].astro
@@ -3,6 +3,7 @@ import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 import Base from "../../layouts/Base.astro";
 import accessories from "../../data/accessories";
 import { toSlug } from "../../utils/slug";
+import { formatCategory } from "../../utils/formatting";
 
 export const getStaticPaths = (() => {
   return accessories.map((accessory) => ({
@@ -18,23 +19,6 @@ const canonicalUrl = new URL(
   `/accessories/${toSlug(`${accessory.brand} ${accessory.model}`)}`,
   Astro.site,
 );
-
-function formatCategory(cat: string): string {
-  const labels: Record<string, string> = {
-    flash: "Flash",
-    "battery-grip": "Battery Grip",
-    "hand-grip": "Hand Grip",
-    battery: "Battery",
-    charger: "Charger",
-    "lens-accessory": "Lens Accessory",
-    adapter: "Adapter",
-    remote: "Remote",
-    audio: "Audio",
-    cooling: "Cooling",
-    "body-accessory": "Body Accessory",
-  };
-  return labels[cat] ?? cat;
-}
 
 const jsonLd = {
   "@context": "https://schema.org",

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatShutter, formatFL } from "./formatting";
+import { formatShutter, formatFL, formatCategory } from "./formatting";
 
 describe("formatShutter", () => {
   it("formats hours", () => {
@@ -40,5 +40,18 @@ describe("formatFL", () => {
 
   it("formats zoom (min !== max)", () => {
     expect(formatFL(18, 55)).toBe("18-55mm");
+  });
+});
+
+describe("formatCategory", () => {
+  it("formats known categories", () => {
+    expect(formatCategory("battery-grip")).toBe("Battery Grip");
+    expect(formatCategory("lens-accessory")).toBe("Lens Accessory");
+    expect(formatCategory("body-accessory")).toBe("Body Accessory");
+    expect(formatCategory("flash")).toBe("Flash");
+  });
+
+  it("returns unknown categories as-is", () => {
+    expect(formatCategory("unknown")).toBe("unknown");
   });
 });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -21,4 +21,22 @@ function formatFL(focalLengthMin: number, focalLengthMax: number): string {
   return `${focalLengthMin}-${focalLengthMax}mm`;
 }
 
-export { formatShutter, formatFL };
+const CATEGORY_LABELS: Record<string, string> = {
+  flash: "Flash",
+  "battery-grip": "Battery Grip",
+  "hand-grip": "Hand Grip",
+  battery: "Battery",
+  charger: "Charger",
+  "lens-accessory": "Lens Accessory",
+  adapter: "Adapter",
+  remote: "Remote",
+  audio: "Audio",
+  cooling: "Cooling",
+  "body-accessory": "Body Accessory",
+};
+
+function formatCategory(category: string): string {
+  return CATEGORY_LABELS[category] ?? category;
+}
+
+export { formatShutter, formatFL, formatCategory };


### PR DESCRIPTION
## Summary
- Extract duplicated `formatCategory` + `CATEGORY_LABELS` to `src/utils/formatting.ts` — both `AccessoriesExplorer` and `[slug].astro` now import from the shared location (closes #318)
- Move MarkPips styles from `GenreGuide.module.css` to `shared/MarkPips.module.css` — MarkPips no longer imports a sibling's CSS module directly (closes #319)
- Remove dead `.sweetSpot` CSS class
- Add `formatCategory` tests

## Test plan
- [x] `npm run validate` passes (lint, format, check, 175 tests, 458 pages built)
- [x] No visual changes — styles are identical, just moved to their own module
- [x] formatCategory tested with known categories and fallback

Generated with [Claude Code](https://claude.com/claude-code)