### PR TITLE
fix: 360-degree audit quick fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ npm run validate     # lint + format + check + test + build -- full CI suite
 
 Visit [wuseria.com](https://wuseria.com):
 
-- **Find a lens** -- open Lenses, filter by mount/aperture/price, sort by any column → filterable table of 241 lenses with specs, prices, and links to detail pages
-- **Pick a genre lens** -- open Genre Guide, select a genre tab, compare scored lenses → ranked list of lenses scored 0-10 for your chosen genre with EV matrix and FL recommendations
-- **Learn a concept** -- open Wiki, browse by category or search for a term → 115 photography articles organized by category (optics, exposure, composition, technique)
+- **Find a lens** -- open Lenses, filter by mount/aperture/price, sort by any column → filterable table with specs, prices, and links to detail pages
+- **Pick a genre lens** -- open Genre Guide, select a genre tab, compare scored lenses → ranked list scored 0-10 for your chosen genre with EV matrix and FL recommendations
+- **Learn a concept** -- open Wiki, browse by category or search for a term → photography articles organized by category (optics, exposure, composition, technique)
 
 For contributor workflows (adding lenses, cameras, wiki entries), see
 [docs/PLAYBOOK.md](docs/PLAYBOOK.md) section 2.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ src/
   utils/            # Scoring, formatting, slug utilities
   styles/           # Global CSS custom properties, dark theme
 docs/
-  decisions/        # Architecture Decision Records (ADR-001 to ADR-015)
+  decisions/        # Architecture Decision Records (ADRs)
   dev-journal.md    # Development history
   prototype/        # Original single-file prototype (reference only)
   solid-ai-templates/  # Quality convention templates (submodule)
@@ -86,9 +86,9 @@ npm run validate     # lint + format + check + test + build -- full CI suite
 
 Visit [wuseria.com](https://wuseria.com):
 
-- **Find a lens** -- open Lenses, filter by mount/aperture/price, sort by any column
-- **Pick a genre lens** -- open Genre Guide, select a genre tab, compare scored lenses
-- **Learn a concept** -- open Wiki, browse by category or search for a term
+- **Find a lens** -- open Lenses, filter by mount/aperture/price, sort by any column → filterable table of 241 lenses with specs, prices, and links to detail pages
+- **Pick a genre lens** -- open Genre Guide, select a genre tab, compare scored lenses → ranked list of lenses scored 0-10 for your chosen genre with EV matrix and FL recommendations
+- **Learn a concept** -- open Wiki, browse by category or search for a term → 115 photography articles organized by category (optics, exposure, composition, technique)
 
 For contributor workflows (adding lenses, cameras, wiki entries), see
 [docs/PLAYBOOK.md](docs/PLAYBOOK.md) section 2.

--- a/docs/decisions/008-seo-strategy.md
+++ b/docs/decisions/008-seo-strategy.md
@@ -11,6 +11,12 @@ Per-lens search queries ("fuji xf 23mm f1.4 review") are high-intent. Competitor
 
 Auto-generate one page per lens at build time via `getStaticPaths()`. Each page targets a specific high-intent search query.
 
+## Alternatives considered
+
+- **Single-page table only** — simple but cannot rank for per-lens queries
+- **Manual page authoring** — high effort, does not scale to 200+ lenses
+- **Client-side rendering** — bad for SEO; search engines may not index
+
 ## Approach
 
 - Astro native head management for per-page titles and descriptions

--- a/docs/decisions/011-deferred-items.md
+++ b/docs/decisions/011-deferred-items.md
@@ -7,6 +7,16 @@
 
 Several features and architectural options were considered during design but intentionally deferred. Recording the rationale prevents revisiting settled decisions.
 
+## Decision
+
+Defer all items listed below. The architecture stays fully static through all
+phases; each item can be reconsidered independently if demand signals change.
+
+## Alternatives considered
+
+No alternatives — this ADR records rationale for deferring features, not
+choosing between them. Each item stands alone.
+
 ## Deferred items
 
 | Item                            | Why deferred                                                 |

--- a/docs/decisions/012-domain-name-risk.md
+++ b/docs/decisions/012-domain-name-risk.md
@@ -29,7 +29,7 @@ and lawsuits.
 manner without the express prior written consent." Brand guidelines exist
 for the X Series.
 
-## Options
+## Alternatives considered
 
 1. **Keep fujime.app** — accept risk, add disclaimers, hope for no enforcement
 2. **Rename to a brand-neutral domain** — eliminates risk entirely

--- a/docs/decisions/020-code-quality-platform.md
+++ b/docs/decisions/020-code-quality-platform.md
@@ -1,8 +1,7 @@
 # ADR-020: Code Quality Platform
 
-## Status
-
-Decided — defer adoption until multi-contributor
+**Status:** Accepted (deferred until multi-contributor)
+**Date:** 2026-05-01
 
 ## Context
 
@@ -10,7 +9,7 @@ Decided — defer adoption until multi-contributor
 For solo development, `eslint-plugin-sonarjs` covers this. The question is whether
 a full platform (SonarCloud, Codacy, CodeClimate) is needed now or later.
 
-## Options Considered
+## Alternatives considered
 
 | Criteria                   | SonarCloud                        | Codacy              | CodeClimate       |
 | -------------------------- | --------------------------------- | ------------------- | ----------------- |

--- a/src/components/interactive/GenreGuide/types.ts
+++ b/src/components/interactive/GenreGuide/types.ts
@@ -1,34 +1,5 @@
 import type { Genre } from "../../../types/genre";
-import type { Brand, Mount } from "../../../types/common";
-
-interface GenreLens {
-  brand: Brand;
-  model: string;
-  mount: Mount;
-  type: "prime" | "zoom";
-  focalLengthMin: number;
-  focalLengthMax: number;
-  maxAperture: number;
-  sweetSpotAperture?: number;
-  maxMagnification?: number;
-  hasOis?: boolean;
-  isWeatherSealed?: boolean;
-  isDiscontinued?: boolean;
-  weight: number;
-  price: number;
-  genreMarks?: Partial<Record<Genre, number>>;
-  editorialPicks?: Genre[];
-  centerStopped?: number;
-  cornerStopped?: number;
-  centerWideOpen?: number;
-  astigmatism?: number;
-  coma?: number;
-  longitudinalCA?: number;
-  lateralCA?: number;
-  distortion?: number;
-  bokeh?: number;
-  flareResistance?: number;
-}
+import type { GenreLens } from "../../../types/genre-lens";
 
 interface GenreGuideProps {
   lenses: GenreLens[];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,7 @@ const wikiCount = wikiEntries.length;
       <ol class="workflow-steps">
         <li>
           <a href="/genre">Pick a genre</a> — nightscape, landscape, portrait, street,
-          or architecture
+          architecture, travel, sport, wildlife, or macro
         </li>
         <li>Select the scene you want to shoot and check the conditions</li>
         <li>See which lenses score best and decide what to rent or buy</li>

--- a/src/types/genre-lens.ts
+++ b/src/types/genre-lens.ts
@@ -1,0 +1,33 @@
+import type { Genre } from "./genre";
+import type { Brand, Mount } from "./common";
+
+interface GenreLens {
+  brand: Brand;
+  model: string;
+  mount: Mount;
+  type: "prime" | "zoom";
+  focalLengthMin: number;
+  focalLengthMax: number;
+  maxAperture: number;
+  sweetSpotAperture?: number;
+  maxMagnification?: number;
+  hasOis?: boolean;
+  isWeatherSealed?: boolean;
+  isDiscontinued?: boolean;
+  weight: number;
+  price: number;
+  genreMarks?: Partial<Record<Genre, number>>;
+  editorialPicks?: Genre[];
+  centerStopped?: number;
+  cornerStopped?: number;
+  centerWideOpen?: number;
+  astigmatism?: number;
+  coma?: number;
+  longitudinalCA?: number;
+  lateralCA?: number;
+  distortion?: number;
+  bokeh?: number;
+  flareResistance?: number;
+}
+
+export type { GenreLens };

--- a/src/utils/pickGenreFields.ts
+++ b/src/utils/pickGenreFields.ts
@@ -1,5 +1,5 @@
 import type { Lens } from "../types/lens";
-import type { GenreLens } from "../components/interactive/GenreGuide/types";
+import type { GenreLens } from "../types/genre-lens";
 
 function pickGenreFields(l: Lens): GenreLens {
   return {


### PR DESCRIPTION
## Summary
- Fix ADR format inconsistencies (008, 011, 012, 020) — standardize Status/Date, add missing sections
- Fix stale ADR count in README
- Add expected outcomes to README Usage section
- Fix homepage genre list (5 → all 9 genres)
- Move `GenreLens` type from component to `src/types/` (fixes utils → components dep direction)

Closes #501, #502, #503, #508, #512

## Test plan
- [x] `npm run validate` passes (lint, format, types, 172 tests, build)
- [ ] Review ADR changes for accuracy
- [ ] Verify homepage renders all 9 genres

🤖 Generated with [Claude Code](https://claude.com/claude-code)