### PR TITLE
docs: add 360-degree audit history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ files, type-checked at build time.
 
 - [Architecture decisions](docs/decisions/)
 - [Development journal](docs/dev-journal.md)
+- [360-degree audit history](docs/360-audit.md)
 - [Quality conventions](docs/solid-ai-templates/)
 - [GitHub Issues](https://github.com/Imbra-Ltd/wuseria/issues)
 

--- a/docs/360-audit.md
+++ b/docs/360-audit.md
@@ -1,0 +1,32 @@
+# 360-Degree Audit History
+
+Score history from periodic 360-degree audits. Each audit evaluates four
+dimensions: Value, Quality, Viability, and Discovery.
+
+## Score scale
+
+| Grade  | Meaning                            |
+| ------ | ---------------------------------- |
+| A / A- | Strong — minor polish only         |
+| B+ / B | Solid — some gaps to address       |
+| C+ / C | Adequate — clear improvement areas |
+| D+ / D | Weak — significant gaps            |
+| F      | Failing — blocking issues          |
+
+## Audit history
+
+| Date       | Value | Quality | Viability | Discovery | Issues created                                                                           |
+| ---------- | ----- | ------- | --------- | --------- | ---------------------------------------------------------------------------------------- |
+| 2026-04-29 | B+    | B+      | B+        | D+        | #313, #314, #315, #316, #317, #325, #326, #327, #328, #329, #330, #331, #332, #333, #335 |
+| 2026-05-03 | B+    | A-      | A-        | C         | #501, #502, #503, #505, #506, #507, #508, #509, #510, #511, #512, #513, #514             |
+
+## Current bottleneck
+
+**Discovery (C)** — the weakest dimension. Key gaps:
+
+- No community presence in photography forums or social media
+- No per-page OG images for social sharing (#506)
+- Missing twitter:image meta tag (#507)
+- No URL params for shareable filtered views (#505)
+- No defined success metrics (#509)
+- Wiki content too shallow for SEO value (#513)


### PR DESCRIPTION
## Summary
- Add `docs/360-audit.md` with score history table for both audits (2026-04-29, 2026-05-03)
- Add link to README Links section

Closes #517

## Test plan
- [x] `npm run validate` passes (172 tests, 458 pages)
- [ ] Verify audit dates and scores are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)