### PR TITLE
chore: remove duplicate score scale, bump submodule

### DIFF
--- a/docs/360-audit.md
+++ b/docs/360-audit.md
@@ -1,17 +1,8 @@
 # 360-Degree Audit History
 
 Score history from periodic 360-degree audits. Each audit evaluates four
-dimensions: Value, Quality, Viability, and Discovery.
-
-## Score scale
-
-| Grade  | Meaning                            |
-| ------ | ---------------------------------- |
-| A / A- | Strong — minor polish only         |
-| B+ / B | Solid — some gaps to address       |
-| C+ / C | Adequate — clear improvement areas |
-| D+ / D | Weak — significant gaps            |
-| F      | Failing — blocking issues          |
+dimensions: Value, Quality, Viability, and Discovery. See
+`docs/solid-ai-templates/base/360.md` for methodology and grading scale.
 
 ## Audit history
 


### PR DESCRIPTION
## Summary
- Remove local Score scale table from `docs/360-audit.md` — upstream `base/360.md` is the single source
- Bump `solid-ai-templates` submodule to pick up #141 (Tracking section) and #142 (grading scale)

## Test plan
- [x] `npm run validate` passes (172 tests, 458 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)