### PR TITLE
chore: add gate job for fast docs-only merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,6 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-      - run: npm run validate
-
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -42,6 +27,23 @@ jobs:
               - 'package-lock.json'
               - 'lighthouserc.json'
               - '.github/workflows/**'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run validate
 
   lighthouse:
     runs-on: ubuntu-latest
@@ -65,3 +67,15 @@ jobs:
         with:
           configPath: lighthouserc.json
           uploadArtifacts: true
+
+  gate:
+    runs-on: ubuntu-latest
+    needs: [build, lighthouse]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" ]]; then
+            echo "CI failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Make `build` job conditional on code changes (same path filter as lighthouse)
- Add `gate` job as the single required check — always runs, checks results
- Docs-only PRs skip build/lighthouse and merge as soon as gate passes (~10s)
- Code PRs run the full pipeline as before

## Test plan
- [x] `npm run validate` passes locally
- [ ] Verify this docs-touching PR skips build and merges via gate
- [ ] Verify a code-touching PR still runs full build

🤖 Generated with [Claude Code](https://claude.com/claude-code)