### PR TITLE
feat: add trailing slash CI check and fix twitter:image meta

### DIFF
--- a/docs/seo-test-plan.md
+++ b/docs/seo-test-plan.md
@@ -1,0 +1,170 @@
+# SEO Manual Test Plan
+
+Periodic checklist for monitoring indexing, discoverability, and technical SEO health.
+
+## 1. Google Search Console (GSC)
+
+### 1.1 Sitemap
+
+- [ ] Sitemap submitted at `sitemap-index.xml`
+- [ ] Status shows "Success" (no errors)
+- [ ] Discovered URLs match expected page count (~458)
+- [ ] No sitemap warnings or errors
+
+### 1.2 Coverage / Indexing
+
+- [ ] Check **Pages > Indexed** count — trending upward
+- [ ] Review **Pages > Not indexed** — check reasons:
+  - "Discovered - currently not indexed" — crawl budget issue
+  - "Crawled - currently not indexed" — thin content signal
+  - "Excluded by noindex tag" — should be zero
+  - "Blocked by robots.txt" — should be zero
+  - "Redirect" — check for unexpected redirects
+  - "Duplicate without user-selected canonical" — investigate
+- [ ] No pages stuck in "Discovered" for >2 weeks
+
+### 1.3 Enhancements
+
+- [ ] **Structured data** — no errors on Product or Article types
+- [ ] No "unparsable structured data" warnings
+- [ ] Check rich result eligibility for Product pages
+
+### 1.4 Experience
+
+- [ ] Core Web Vitals — no "Poor" URLs
+- [ ] Mobile usability — no errors
+- [ ] HTTPS — all pages served over HTTPS
+
+### 1.5 Links
+
+- [ ] Review **Links > Top linked pages** — confirm section hubs rank high
+- [ ] Review **Links > External links** — track backlink growth
+
+### 1.6 Search performance
+
+- [ ] Check **Performance > Search results** for impressions trend
+- [ ] Note top queries and pages — identify content gaps
+- [ ] Compare impressions vs clicks — low CTR pages may need better titles/descriptions
+
+## 2. Umami Analytics
+
+### 2.1 Traffic
+
+- [ ] Verify tracking script fires on page load (check network tab)
+- [ ] Compare Umami pageviews with GSC impressions — large discrepancy means tracking gaps
+- [ ] Check bounce rate on key landing pages (homepage, /lenses/, /genre/)
+
+### 2.2 Navigation patterns
+
+- [ ] Review top pages — do users reach individual lens/camera pages?
+- [ ] Check referrers — any organic search traffic appearing?
+- [ ] Review device split — confirm mobile vs desktop ratio
+
+### 2.3 Engagement
+
+- [ ] Average visit duration — is it increasing?
+- [ ] Pages per visit — are users exploring beyond landing page?
+- [ ] Check exit pages — identify where users leave
+
+## 3. Technical SEO (manual spot checks)
+
+### 3.1 Meta tags
+
+Pick 1 page from each section (homepage, lens, camera, accessory, genre, wiki):
+
+- [ ] `<title>` is unique and descriptive (50-60 chars)
+- [ ] `<meta name="description">` is unique (120-160 chars)
+- [ ] `<link rel="canonical">` points to correct URL with trailing slash
+- [ ] `og:title`, `og:description`, `og:url`, `og:image` present
+- [ ] `twitter:card`, `twitter:title`, `twitter:description` present
+- [ ] `twitter:image` present (currently missing — see #507)
+
+### 3.2 Structured data
+
+Validate with [Google Rich Results Test](https://search.google.com/test/rich-results):
+
+- [ ] `/lenses/fujifilm-xf-23mm-f1-4-r-lm-wr/` — valid Product schema
+- [ ] `/cameras/x-t5/` — valid Product schema
+- [ ] `/accessories/fujifilm-np-w235/` — valid Product schema
+- [ ] `/wiki/aperture/` — valid Article schema
+- [ ] No errors or warnings
+
+### 3.3 Trailing slashes
+
+- [ ] `https://wuseria.com/lenses` redirects to `/lenses/` (301, not 302)
+- [ ] No double-slash URLs (e.g., `/lenses//xf-23mm/`)
+- [ ] Internal links in HTML output all end with `/`
+
+### 3.4 Canonical consistency
+
+- [ ] Canonical URL matches the actual page URL
+- [ ] No `www` vs non-`www` conflicts
+- [ ] HTTP requests redirect to HTTPS
+
+### 3.5 robots.txt and sitemap
+
+- [ ] `https://wuseria.com/robots.txt` is accessible
+- [ ] `https://wuseria.com/sitemap-index.xml` is accessible
+- [ ] `https://wuseria.com/sitemap-0.xml` is accessible
+- [ ] Sitemap URL count matches build output
+- [ ] All sitemap URLs use trailing slashes
+- [ ] All sitemap URLs use HTTPS
+
+### 3.6 404 handling
+
+- [ ] Non-existent URL (e.g., `/lenses/does-not-exist/`) returns 404 status
+- [ ] Custom 404 page renders with back-to-home link
+
+## 4. Lighthouse
+
+Run against production (`https://wuseria.com`):
+
+```bash
+npx @lhci/cli@latest autorun
+```
+
+- [ ] Performance >= 80
+- [ ] Accessibility >= 90
+- [ ] SEO >= 90
+- [ ] Best Practices >= 90
+
+Spot-check these pages:
+
+| Page            | URL                                      |
+| --------------- | ---------------------------------------- |
+| Homepage        | `/`                                      |
+| Lenses index    | `/lenses/`                               |
+| Individual lens | `/lenses/fujifilm-xf-23mm-f1-4-r-lm-wr/` |
+| Cameras index   | `/cameras/`                              |
+| Genre index     | `/genre/`                                |
+| Genre page      | `/genre/landscape/`                      |
+| Wiki index      | `/wiki/`                                 |
+| Wiki article    | `/wiki/aperture/`                        |
+
+## 5. External tools (periodic)
+
+### 5.1 Google "site:" search
+
+- [ ] Search `site:wuseria.com` — count matches expected indexed pages
+- [ ] Search `site:wuseria.com/lenses/` — lens pages appearing
+- [ ] Search `site:wuseria.com/wiki/` — wiki pages appearing
+
+### 5.2 Social card preview
+
+Test with [OpenGraph.xyz](https://www.opengraph.xyz/):
+
+- [ ] Homepage renders card correctly
+- [ ] Individual lens page renders card correctly
+- [ ] OG image loads (not broken)
+
+## 6. Frequency
+
+| Check                       | Frequency                               |
+| --------------------------- | --------------------------------------- |
+| GSC coverage & indexing     | Weekly until 400+ indexed, then monthly |
+| GSC search performance      | Weekly                                  |
+| Umami traffic review        | Weekly                                  |
+| Lighthouse scores           | After each deploy                       |
+| Structured data validation  | After schema changes                    |
+| Technical spot checks (3.x) | After deploy or SEO-related changes     |
+| External tools (5.x)        | Monthly                                 |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "test:report": "vitest run --coverage --reporter=default --reporter=html --outputFile=reports/tests/index.html",
     "lighthouse": "npm run build && npx @lhci/cli autorun --config lighthouserc.json",
-    "validate": "npm run lint && npm run format && npm run check && npm run test && npm run build",
+    "check:links": "npx tsx scripts/check-trailing-slashes.ts",
+    "validate": "npm run lint && npm run format && npm run check && npm run test && npm run build && npm run check:links",
     "release": "bash scripts/release.sh",
     "prepare": "husky"
   },

--- a/scripts/check-trailing-slashes.ts
+++ b/scripts/check-trailing-slashes.ts
@@ -1,0 +1,50 @@
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const DIST = resolve(import.meta.dirname, "..", "dist");
+
+if (!existsSync(DIST)) {
+  console.error("dist/ not found — run `npm run build` first.");
+  process.exit(1);
+}
+
+const files = readdirSync(DIST, { recursive: true })
+  .map(String)
+  .filter((f) => f.endsWith(".html"));
+
+const hrefPattern = /href="(\/[^"]*?)"/g;
+const IGNORED_EXTENSIONS =
+  /\.(xml|css|js|json|svg|png|jpg|jpeg|webp|ico|txt|pdf|woff2?)$/i;
+
+let violations = 0;
+
+for (const file of files) {
+  const html = readFileSync(join(DIST, file), "utf-8");
+  let match: RegExpExecArray | null;
+
+  while ((match = hrefPattern.exec(html)) !== null) {
+    const href = match[1];
+
+    if (
+      href.includes("#") ||
+      href.includes("?") ||
+      IGNORED_EXTENSIONS.test(href)
+    ) {
+      continue;
+    }
+
+    if (!href.endsWith("/")) {
+      console.error(`${file}: href="${href}" missing trailing slash`);
+      violations++;
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(`\n${violations} internal link(s) missing trailing slash.`);
+  process.exit(1);
+} else {
+  console.log(
+    `Checked ${files.length} HTML files — all internal links have trailing slashes.`,
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -40,9 +40,15 @@ const navLinks = [
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:site_name" content="Wuseria" />
     <meta property="og:image" content="https://wuseria.com/og-image-dark.png" />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="640" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
+    <meta
+      name="twitter:image"
+      content="https://wuseria.com/og-image-dark.png"
+    />
     <ClientRouter />
     <slot name="head" />
     <!-- Privacy-friendly analytics by Umami -->


### PR DESCRIPTION
## Summary
- Add `scripts/check-trailing-slashes.ts` — scans `dist/**/*.html` for internal hrefs missing trailing slashes
- Integrate as `npm run check:links` into the `validate` pipeline
- Add missing `twitter:image` meta tag to base layout
- Add `og:image:width` and `og:image:height` for faster social card rendering
- Add `docs/seo-test-plan.md` — manual SEO test plan covering GSC, Umami, Lighthouse, and technical checks

## Test plan
- [x] `npm run check:links` passes (458 files, zero violations)
- [x] `npm run validate` passes
- [ ] Verify `twitter:image` in page source after deploy
- [ ] Test social card preview with OpenGraph.xyz

Closes #538, closes #507

Generated with [Claude Code](https://claude.com/claude-code)