### PR TITLE
feat: add beta version indicator under the Wuseria logo

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -55,7 +55,9 @@ const navLinks = [
   <body>
     <header class="site-header">
       <nav class="nav" aria-label="Main navigation">
-        <a href="/" class="nav-brand">Wuseria</a>
+        <a href="/" class="nav-brand"
+          >Wuseria<span class="beta-badge">beta</span></a
+        >
         <button
           class="nav-toggle"
           type="button"
@@ -184,6 +186,21 @@ const navLinks = [
 
   .nav-brand:hover {
     color: var(--color-accent);
+  }
+
+  .beta-badge {
+    display: inline-block;
+    margin-left: var(--space-xs);
+    padding: 0.0625rem var(--space-xs);
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    vertical-align: super;
+    line-height: 1;
   }
 
   /* Hamburger toggle — mobile only */


### PR DESCRIPTION
## Summary
- Add subtle "beta" pill badge next to the Wuseria brand name in the nav header
- Muted text, border color, uppercase, superscript position
- Visible on all pages, does not interfere with mobile layout

## Test plan
- [x] `npm run validate` passes
- [ ] Visual check: badge visible on desktop and mobile
- [ ] Badge does not shift nav layout or overlap hamburger menu

Closes #534

Generated with [Claude Code](https://claude.com/claude-code)