### PR TITLE
feat: score Voigtlander lenses (#553)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 - Scoring log format and field completeness rules are defined in `docs/decisions/022-scoring-log-and-mtf-charts.md` — every entry must list all 14 optical fields with explicit undefined markers
 - When scoring lenses, always save official MTF charts to `docs/mtf-charts/` with companion `.md` analysis files per ADR-022
 - Samyang lenses are sold under multiple brand aliases (Rokinon, Bower, Walimex Pro, Vivitar) — search all aliases when looking for reviews
+- optyczne.pl and lenstip.com are the same company (CO-NET Robert Olech) — never count as separate sources for trust-2 aggregation
 - Verify lens mount availability before adding to the database — check official manufacturer pages and third-party lens lists; do not assume a lens exists in X-mount or GFX just because it exists in other mounts
 
 ## 3. Quality

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1483,3 +1483,27 @@ Key decisions:
 - 12-24mm f/5.6 Zoom Shift CF left unscored: too new (2024), only proxy data from C-Dreamer (different optical formula)
 - GFX third-party lenses are a data desert: zero trust-3 quantitative reviews across all 8 lenses
 - Verified complete Laowa X-mount lineup against multiple sources; corrected database accordingly
+
+---
+
+### Session 43 — Voigtlander Scoring and Global Source Scan
+
+Tool: Claude Code. PR [#571](https://github.com/Imbra-Ltd/wuseria/pull/571).
+
+- Scored 2 Voigtlander lenses from LensTip: Ultron 27mm f/2, Nokton 35mm f/0.9 Aspherical
+- Added scoring log entries for all 7 Voigtlander lenses (including existing Nokton 35mm f/1.2)
+- Documented 4 lenses as unscorable: Nokton 23mm f/1.2, Nokton 50mm f/1.2, Color-Skopar 18mm f/2.8, Macro APO-Ultron 35mm f/2
+- Fixed Nokton 50mm f/1.2 X-mount specs: discovered it's an exclusive APS-C Sonnar design (290g, 9 elem/8 groups), not a rehoused SE. Weight 492→290g, filter 52→58mm, MFD 450→390mm
+- Deep scan of 40+ review sources across 10+ languages (German, French, Italian, Japanese, Chinese, Korean, Russian, Nordic, Dutch, Czech)
+- Added 8 new review sources: digitalkamera.de, fotoMAGAZIN, Focus Review, Fotografi Digitali (lab trust-2); Asobinet, Fujiya Camera, Map Camera KASYAPA, Radojuva (field trust-2). Total: 40 sources (10 trust-3, 30 trust-2)
+- Confirmed optyczne.pl = lenstip.com (same company, must never count as separate sources)
+- Epic #554 completed — all 6 brand scoring tasks done
+- Scoring coverage: 119/243 (49%)
+
+Issues created: #572 (lens page SEO spike), #573 (evaluate new sources), #574 (in-house testing spike), #575 (composite trust-2 scoring rule spike)
+
+Key decisions:
+
+- Lab-quality lens testing is concentrated in ~15 sites globally (Europe + USA). No Chinese, Korean, or Russian lab sites exist. Japanese sites are qualitative only despite Cosina being Japanese
+- Nokton 50mm f/1.2 X-mount is a completely different optical design from VM/SE versions — data from other mounts does not apply
+- Macro APO-Ultron 35mm f/2 reached 6 of 7 fields from trust-2 aggregation (Fujiya + KASYAPA) but falls 1 short of MIN_OPTICAL_FIELDS; composite scoring rule (#575) could unlock it

--- a/docs/scoring-log.md
+++ b/docs/scoring-log.md
@@ -1114,3 +1114,97 @@ OpticalLimits (lab, trust 3, Fuji X-mount).
 
 Note: Mk II shares identical optical design with PFU RBMH (10 elements,
 7 groups, 1 ELD). Mk II is lighter (340g vs 490g) with improved AF.
+
+---
+
+## Voigtlander
+
+### Color-Skopar 18mm f/2.8
+
+Not scored — no trust-3 reviews available. Released January 2024. LensTip has
+specs page only, no lab review. No coverage from OpticalLimits, DxOMark,
+LensRentals, The Digital Picture, Dustin Abbott, DPReview (editorial),
+Phillip Reeve, Lloyd Chambers, or Lonely Speck.
+
+### Nokton 23mm f/1.2
+
+Not scored — no trust-3 reviews available. LensTip has specs page only, no lab
+review. No coverage from any other trust-3 source. Community data
+(DPReview forums, Digital Camera World Z-mount proxy) is qualitative only,
+insufficient for rubric scoring.
+
+### Nokton 35mm f/0.9 Aspherical
+
+Sources: LensTip (lab, trust 3). Sensor: X-Trans III (X-T2), max ~85 lpmm.
+
+| Field               | Score | Source data                                                                  | Rubric rule         |
+| ------------------- | ----- | ---------------------------------------------------------------------------- | ------------------- |
+| centerStopped       | 2.0   | 82-83 lpmm at f/2.8-f/4. "Excellent."                                        | 82/85 = 96%, >= 90% |
+| cornerStopped       | 1.0   | ~55 lpmm at f/5.6. "Medium results."                                         | 55/85 = 65%, 60-74% |
+| centerWideOpen      | 0.0   | ~40 lpmm at f/0.9. "Just slightly exceeding 40 lpmm."                        | 40/85 = 47%, < 50%  |
+| cornerWideOpen      | 0.0   | "Weak" up to f/2.0.                                                          | < 50%               |
+| astigmatism         | 0.5   | 22.5%. "A significant value."                                                | 18-25%              |
+| coma                | 0.0   | "Seriously deformed", "huge wings." Summary: "very high coma."               | "severe"            |
+| sphericalAberration | 0.5   | Summary: "weak correction of spherical aberration." Focus shift f/0.9-f/1.4. | "poor"              |
+| longitudinalCA      | 2.0   | "Almost imperceptible." Summary: "imperceptible."                            | "negligible"        |
+| lateralCA           | 1.5   | 0.08%. "Borderline between low and medium."                                  | 0.04-0.08%          |
+| distortion          | 1.0   | RAW -1.27% barrel. "Lack of any serious problems."                           | 1.0-2.0%            |
+| vignettingWideOpen  | 0.5   | -2.10 EV RAW at f/0.9. "Distinct vignetting."                                | 1.5-2.5 EV          |
+| vignettingStopped   | 2.0   | -0.41 EV RAW at f/5.6.                                                       | < 0.5 EV            |
+| bokeh               | 0.5   | Diode: "noticeable onion ring bokeh", angular polygons stopped down.         | "problematic"       |
+| flareResistance     | 1.0   | "Manages to avoid serious slip-ups", "acceptable but unremarkable."          | "acceptable"        |
+
+### Nokton 35mm f/1.2
+
+Sources: LensTip (lab, trust 3). Sensor: X-Trans III (X-T2), max ~85 lpmm.
+
+| Field               | Score | Source data                                                              | Rubric rule         |
+| ------------------- | ----- | ------------------------------------------------------------------------ | ------------------- |
+| centerStopped       | 2.0   | >80 lpmm at f/4. "Exceeds 80 lpmm."                                      | 80/85 = 94%, >= 90% |
+| cornerStopped       | 0.0   | "Decent quality only at f/8-f/11." ~44 lpmm at best.                     | 44/85 = 52%, ~50%   |
+| centerWideOpen      | 0.0   | "Images are of weak quality" at f/1.2-f/1.4.                             | < 50%               |
+| cornerWideOpen      | 0.0   | Worse than center wide open.                                             | < 50%               |
+| astigmatism         | 1.0   | 12.8%. "Borderline between medium and high level."                       | 10-18%              |
+| coma                | 0.0   | "Really huge." "Long wings." Summary: con.                               | "severe"            |
+| sphericalAberration | 0.0   | "Some problems", "characteristic mist", "badly corrected."               | "very poor"         |
+| longitudinalCA      | 2.0   | "Rather doesn't experience any problems."                                | "negligible"        |
+| lateralCA           | 1.5   | 0.05-0.07%. "Low."                                                       | 0.04-0.08%          |
+| distortion          | 1.0   | RAW -1.53% barrel. "Not a serious flaw."                                 | 1.0-2.0%            |
+| vignettingWideOpen  | 0.0   | -2.67 EV RAW at f/1.2. "Very high."                                      | > 2.5 EV            |
+| vignettingStopped   | 1.5   | -0.56 EV at f/5.6.                                                       | 0.5-1.0 EV          |
+| bokeh               | 2.0   | Diode: "very even, without any local extremes or onion ring bokeh."      | "excellent"         |
+| flareResistance     | 0.5   | "Failed completely", "really hopeless", "big intensive light artifacts." | "poor"              |
+
+### Nokton 50mm f/1.2
+
+Not scored — X-mount SE design (8 elements/6 groups) differs from reviewed VM
+Aspherical (9 elements/6 groups). LensTip reviewed only the VM on full frame.
+Phillip Reeve reviewed the SE on full frame (E-mount) but vignetting and
+resolution data does not transfer to APS-C.
+
+### Macro APO-Ultron 35mm f/2
+
+Not scored — no trust-3 reviews available. LensTip has specs page only.
+Not reviewed by any of the 10 trust-3 sources. Only community impressions
+(DPReview forum mini-review, FujiFanBoys) with no quantitative data.
+
+### Ultron 27mm f/2
+
+Sources: LensTip (lab, trust 3). Sensor: X-Trans III (X-T2), max ~85 lpmm.
+
+| Field               | Score | Source data                                                                                 | Rubric rule          |
+| ------------------- | ----- | ------------------------------------------------------------------------------------------- | -------------------- |
+| centerStopped       | 2.0   | >80 lpmm at f/4. "Excellent."                                                               | 80/85 = 94%, >= 90%  |
+| cornerStopped       | 0.5   | ~50 lpmm at f/4-f/8. "Medium results."                                                      | 50/85 = 59%, 50-59%  |
+| centerWideOpen      | 1.5   | >64 lpmm at f/2. "Excellent image quality in the frame centre."                             | 64/85 = 75%, 75-89%  |
+| cornerWideOpen      | 0.0   | 36.6 lpmm at f/2. "Simply blurry."                                                          | 36.6/85 = 43%, < 50% |
+| astigmatism         | 1.5   | 6%. "Borderline between low and very low level." Summary: "slight."                         | 5-10%                |
+| coma                | 0.0   | "Very high" at f/2. "First big slip-up." Summary: con.                                      | "severe"             |
+| sphericalAberration | 1.5   | "Not a huge problem." "No noticeable focus shift." Summary: "lack of any serious problems." | "well corrected"     |
+| longitudinalCA      | 2.0   | "Performed here very well, no issues." Summary: "imperceptible."                            | "negligible"         |
+| lateralCA           | 2.0   | ~0.01%. "Negligible value." Summary: "slight."                                              | < 0.04%              |
+| distortion          | 2.0   | +0.18% RAW. "Brushing against zero." Summary: "practically zero."                           | < 0.3%               |
+| vignettingWideOpen  | 0.5   | -2.16 EV RAW at f/2. "Distinct." Summary: con.                                              | 1.5-2.5 EV           |
+| vignettingStopped   | 1.5   | -0.79 EV RAW at f/4.                                                                        | 0.5-1.0 EV           |
+| bokeh               | 1.5   | "Even light distribution", "no onion-ring effect." Summary: "sensibly-looking."             | "very good"          |
+| flareResistance     | 1.5   | "Pretty well", "few and far between." Summary: "decent performance."                        | "very good"          |

--- a/docs/scoring-log.md
+++ b/docs/scoring-log.md
@@ -1177,10 +1177,12 @@ Sources: LensTip (lab, trust 3). Sensor: X-Trans III (X-T2), max ~85 lpmm.
 
 ### Nokton 50mm f/1.2
 
-Not scored — X-mount SE design (8 elements/6 groups) differs from reviewed VM
-Aspherical (9 elements/6 groups). LensTip reviewed only the VM on full frame.
-Phillip Reeve reviewed the SE on full frame (E-mount) but vignetting and
-resolution data does not transfer to APS-C.
+Not scored — X-mount version is an exclusive APS-C Sonnar design (290g, 58mm
+filter), different from both the VM Aspherical (8 elem/6 groups, 347g) and the
+SE E-mount (8 elem/6 groups, 434g). No trust-3 or trust-2 reviews exist for
+the X-mount design. DCFever (trust-2) has a brief X-mount article in Chinese
+with qualitative impressions only. Database specs corrected: 492g→290g,
+filterThread 52→58, MFD 450→390mm.
 
 ### Macro APO-Ultron 35mm f/2
 

--- a/src/data/lenses.ts
+++ b/src/data/lenses.ts
@@ -5886,11 +5886,11 @@ const lenses: Lens[] = [
     apertureBlades: 12,
     hasApertureRing: true,
     isFocusByWire: false,
-    weight: 492,
-    filterThread: 52,
+    weight: 290,
+    filterThread: 58,
     price: 1000,
-    minFocusDistance: 450,
-    // Not scored — SE design (8 elem) differs from reviewed VM (9 elem); no APS-C lab data
+    minFocusDistance: 390,
+    // Not scored — X-mount exclusive Sonnar design; no trust-3 reviews
     officialUrl:
       "https://www.voigtlaender.de/lenses/x-mount/50mm-11-2-nokton/?lang=en",
   },

--- a/src/data/lenses.ts
+++ b/src/data/lenses.ts
@@ -5822,6 +5822,7 @@ const lenses: Lens[] = [
     filterThread: 46,
     price: 750,
     minFocusDistance: 200,
+    // Not scored — no trust-3 reviews available
     officialUrl:
       "https://www.voigtlaender.de/lenses/x-mount/23-mm-11-2-nokton/?lang=en",
   },
@@ -5889,6 +5890,7 @@ const lenses: Lens[] = [
     filterThread: 52,
     price: 1000,
     minFocusDistance: 450,
+    // Not scored — SE design (8 elem) differs from reviewed VM (9 elem); no APS-C lab data
     officialUrl:
       "https://www.voigtlaender.de/lenses/x-mount/50mm-11-2-nokton/?lang=en",
   },
@@ -5908,11 +5910,41 @@ const lenses: Lens[] = [
     filterThread: 39,
     price: 750,
     minFocusDistance: 250,
+    sweetSpotAperture: 4,
+    centerStopped: 2.0,
+    cornerStopped: 0.5,
+    centerWideOpen: 1.5,
+    cornerWideOpen: 0.0,
+    astigmatism: 1.5,
+    coma: 0.0,
+    sphericalAberration: 1.5,
+    longitudinalCA: 2.0,
+    lateralCA: 2.0,
+    distortion: 2.0,
+    vignettingWideOpen: 0.5,
+    vignettingStopped: 1.5,
+    bokeh: 1.5,
+    flareResistance: 1.5,
+    genreMarks: {
+      nightscape: 1,
+      landscape: 2,
+      architecture: 2,
+      portrait: 4,
+      street: 4,
+      travel: 5,
+      sport: 4,
+      wildlife: 4,
+    },
+    reviewSources: {
+      lenstip:
+        "https://www.lenstip.com/660.1-Lens_review-Voigtlander_Ultron_27_mm_f_2.html",
+    },
     officialUrl:
       "https://www.voigtlaender.de/lenses/x-mount/27-mm-12-0-nokton/?lang=en",
   },
   // Additional Voigtlander
   {
+    // Not scored — no trust-3 reviews available (released Jan 2024)
     brand: "Voigtlander",
     model: "Color-Skopar 18mm f/2.8",
     type: "prime",
@@ -5947,9 +5979,39 @@ const lenses: Lens[] = [
     filterThread: 52,
     price: 1000,
     minFocusDistance: 300,
+    sweetSpotAperture: 4,
+    centerStopped: 2.0,
+    cornerStopped: 1.0,
+    centerWideOpen: 0.0,
+    cornerWideOpen: 0.0,
+    astigmatism: 0.5,
+    coma: 0.0,
+    sphericalAberration: 0.5,
+    longitudinalCA: 2.0,
+    lateralCA: 1.5,
+    distortion: 1.0,
+    vignettingWideOpen: 0.5,
+    vignettingStopped: 2.0,
+    bokeh: 0.5,
+    flareResistance: 1.0,
+    genreMarks: {
+      nightscape: 1,
+      landscape: 3,
+      architecture: 3,
+      portrait: 1,
+      street: 4,
+      travel: 3,
+      sport: 1,
+      wildlife: 1,
+    },
+    reviewSources: {
+      lenstip:
+        "https://www.lenstip.com/663.1-Lens_review-Voigtlander_Nokton_35_mm_f_0.9_Aspherical.html",
+    },
     officialUrl: "https://www.voigtlaender.de/lenses/x-mount/",
   },
   {
+    // Not scored — no trust-3 reviews available
     brand: "Voigtlander",
     model: "Macro APO-Ultron 35mm f/2",
     type: "prime",

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -211,6 +211,58 @@ const reviewSourceDirectory: Record<ReviewSource, ReviewSourceInfo> = {
     name: "ProVideo Coalition",
     site: "provideocoalition.com",
   },
+
+  // --- lab, trust 2 (multilingual) ---
+  "digitalkamera-de": {
+    methodology: "lab",
+    trust: 2,
+    name: "digitalkamera.de",
+    site: "digitalkamera.de",
+  },
+  fotomagazin: {
+    methodology: "lab",
+    trust: 2,
+    name: "fotoMAGAZIN",
+    site: "fotomagazin.de",
+  },
+  "focus-review": {
+    methodology: "lab",
+    trust: 2,
+    name: "Focus Review",
+    site: "focus-review.com",
+  },
+  fotografidigitali: {
+    methodology: "lab",
+    trust: 2,
+    name: "Fotografi Digitali",
+    site: "fotografidigitali.it",
+  },
+
+  // --- field, trust 2 (multilingual) ---
+  asobinet: {
+    methodology: "field",
+    trust: 2,
+    name: "Asobinet (とるなら)",
+    site: "asobinet.com",
+  },
+  fujiyacamera: {
+    methodology: "field",
+    trust: 2,
+    name: "Fujiya Camera",
+    site: "fujiya-camera.co.jp",
+  },
+  mapcamera: {
+    methodology: "field",
+    trust: 2,
+    name: "Map Camera KASYAPA",
+    site: "news.mapcamera.com",
+  },
+  radojuva: {
+    methodology: "field",
+    trust: 2,
+    name: "Radojuva",
+    site: "radojuva.com",
+  },
 };
 
 export { reviewSourceDirectory };

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -35,7 +35,15 @@ type ReviewSource =
   | "provideocoalition"
   | "diglloyd"
   | "lonelyspeck"
-  | "nightscapephotographer";
+  | "nightscapephotographer"
+  | "digitalkamera-de"
+  | "fotomagazin"
+  | "focus-review"
+  | "fotografidigitali"
+  | "asobinet"
+  | "fujiyacamera"
+  | "mapcamera"
+  | "radojuva";
 
 // =============================================================================
 // METHODOLOGY & TRUST


### PR DESCRIPTION
## Summary
- Score 2 Voigtlander lenses from LensTip lab reviews: Ultron 27mm f/2 and Nokton 35mm f/0.9 Aspherical
- Add scoring log entries for all 7 Voigtlander lenses (including existing Nokton 35mm f/1.2)
- Document 4 lenses as unscorable: Nokton 23mm f/1.2, Nokton 50mm f/1.2 (SE design differs from reviewed VM), Color-Skopar 18mm f/2.8, Macro APO-Ultron 35mm f/2

Scoring coverage: 119/243 lenses (49%), up from 117/243 (48%).

Closes #553

## Test plan
- [x] `npm run validate` passes (lint + format + check + test + build)
- [x] Genre marks computed from scoring engine match stored values
- [x] All 14 optical fields documented in scoring log per ADR-022
- [x] 460 pages built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)