### PR TITLE
fix: resolve Lighthouse accessibility failures on /genre/ page (#581)

### DIFF
--- a/src/components/interactive/GenreGuide/FilterSelect.tsx
+++ b/src/components/interactive/GenreGuide/FilterSelect.tsx
@@ -22,6 +22,7 @@ function FilterSelect({
         className={styles.controlSelect}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
       >
         <option value="">{allLabel}</option>
         {options.map((opt) => (

--- a/src/components/interactive/GenreGuide/GenreGuide.module.css
+++ b/src/components/interactive/GenreGuide/GenreGuide.module.css
@@ -493,7 +493,7 @@
 
 .matrixOver {
   background-color: #180e0e;
-  color: #905030;
+  color: #bc7454;
 }
 
 .matrixLegend {
@@ -512,7 +512,7 @@
 }
 
 .matrixOverText {
-  color: #905030;
+  color: #bc7454;
 }
 
 .matrixExplain {

--- a/src/components/interactive/shared/MarkPips.module.css
+++ b/src/components/interactive/shared/MarkPips.module.css
@@ -42,7 +42,7 @@
 }
 
 .fieldOver {
-  color: #905030; /* red — poor */
+  color: #bc7454; /* red — poor */
 }
 
 .fieldMono {

--- a/src/components/interactive/shared/MarkPips.tsx
+++ b/src/components/interactive/shared/MarkPips.tsx
@@ -41,7 +41,11 @@ function MarkPips({ mark }: { mark: number | null }) {
     pips.push(<span key={`empty-${i}`} className={styles.pip} />);
   }
   return (
-    <span className={styles.markDots} aria-label={`Mark ${mark} of 5`}>
+    <span
+      className={styles.markDots}
+      role="img"
+      aria-label={`Mark ${mark} of 5`}
+    >
       {pips}
     </span>
   );

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -286,6 +286,10 @@ const navLinks = [
     color: var(--color-text-muted);
   }
 
+  .footer-text a {
+    text-decoration: underline;
+  }
+
   .footer-feedback {
     margin-top: var(--space-xs);
     font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary
- Fix `aria-prohibited-attr` — add `role="img"` to MarkPips `<span>` with `aria-label` (17 violations)
- Fix `color-contrast` — raise "over/poor" indicator color from `#905030` to `#bc7454` (passes 4.5:1 on both page bg `#1a1d27` and matrix cell bg `#180e0e`)
- Fix `link-in-text-block` — add underline to footer text links so they are distinguishable without color
- Fix `select-name` — add `aria-label` to FilterSelect `<select>` elements (8 violations)

Lighthouse accessibility score: **0.85 → 1.0**

Closes #581

## Test plan
- [x] `npm run validate` passes (lint, format, check, 176 tests, build, links)
- [x] Lighthouse accessibility score >= 0.90 on `/genre/`
- [x] Lighthouse accessibility score >= 0.90 on `/genre/landscape/`
- [x] All contrast ratios verified computationally (>= 4.5:1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)