### PR TITLE
fix: bump package.json version to 0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 - Do not commit `node_modules/`, `dist/`, `.env`, `.env.local`
 - Lock file (`package-lock.json`) is committed
 - Run `npm run validate` before committing
+- Releases MUST follow PLAYBOOK 5.1 — never tag without bumping `package.json` first
 - When creating GitHub issues, follow the formats in `docs/solid-ai-templates/templates/base/workflow/issues.md` — use the correct label (`epic`, `bug`, `incident`, `question`) and body structure for each type
 - Creating a new directory or moving content between documents is an architectural decision — write the ADR **at the moment of the decision**, before creating the files
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wuseria",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.4.0` to `0.5.0`
- The v0.5.0 release used the "no-build" tag flow (tag directly on main) instead of the "version manifest" flow from `base/git.md`, which requires bumping `package.json` before tagging

Closes #647

## Test plan
- [ ] CI passes
- [ ] `package.json` version matches the latest git tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)