### PR TITLE
feat: ADR-026 lens detail page content strategy + nav rename (#684)

### DIFF
--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -1,4 +1,4 @@
-# ADR-026: Generate lens page prose from data at build time
+# ADR-026: Lens detail page content strategy
 
 **Status:** Accepted
 **Date:** 2026-05-17

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -26,7 +26,9 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
    - Distortion (distortion)
 4. **Genre Fit** — 9 genre sub-sections, each explaining why the lens is
    or isn't suited (pros AND cons derived from formula primary/secondary fields)
-5. **User Consensus** — review source links
+5. **Reviews** — professional review source links (from `reviewSources`)
+6. **Community** — user opinions as bullet points (from `communityNotes: string[]`,
+   populated during scoring research, section hidden when empty)
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -14,8 +14,18 @@ are a discovery liability. The site needs unique, keyword-rich text per page.
 
 Generate deterministic prose at build time using score-to-phrase mapping tables.
 Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
-The content spine has 5 sections: Summary, Strengths, Weaknesses, Genre Fit,
-Build (includes sweet spot aperture).
+
+### Page structure
+
+1. **Summary** — one-line verdict + strengths/weaknesses bullets
+2. **Specifications** — lens configuration, MTF charts, specs table
+3. **Optical Quality** — prose interpretation grouped into 4 clusters:
+   - Sharpness (centerWideOpen, cornerWideOpen, centerStopped, cornerStopped)
+   - Aberrations (longitudinalCA, lateralCA, coma, astigmatism, sphericalAberration)
+   - Rendering (bokeh, vignettingWideOpen, vignettingStopped, flareResistance)
+   - Distortion (distortion)
+4. **User Consensus** — review source links
+5. **Genre Fit** — top/weak genres from genre marks
 
 ## Alternatives considered
 
@@ -44,7 +54,9 @@ the content signal that pure data tables lack.
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`
-- Phrase tables: score → natural-language string (LensTip-inspired wording)
+- Phrase tables: score → natural-language string (review-style wording)
 - Focal length context: equivalent mm → descriptive phrase
-- Rendered as semantic HTML sections above spec tables
-- Spec stored in: #572 comments / `temp/lens-content-spine.md`
+- Optical Quality uses 4 clusters (not 14 sub-headings) for UX scannability
+  and SEO substance — individual field names appear in prose, not headings
+- MTF charts from `docs/mtf-charts/` served as images within Specifications
+- Spec stored in: `temp/lens-content-spine.md`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -59,6 +59,24 @@ Indexed page count increases from ~106 (23%) to 300+ as scored lens pages
 cross Google's quality threshold for indexing. Unique prose per page provides
 the content signal that pure data tables lack.
 
+## Missing data handling
+
+When optical scores or genre marks are absent, explain why using
+`scoringStatus?: "niche" | "new" | "discontinued" | "specialty" | "pending"`
+on the Lens interface.
+
+| Status         | Generated phrase                                             |
+| -------------- | ------------------------------------------------------------ |
+| `niche`        | Limited professional review coverage for this lens.          |
+| `new`          | Recently released — professional reviews pending.            |
+| `discontinued` | Discontinued before comprehensive optical testing.           |
+| `specialty`    | Standard optical bench tests do not apply to this lens type. |
+| `pending`      | Scoring in progress.                                         |
+
+Applied to Optical Quality, Genre Fit, and any section that depends on scored data.
+Field is set during data entry. Absent `scoringStatus` on an unscored lens defaults
+to `niche`.
+
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -29,6 +29,8 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
 5. **Reviews** — professional review source links (from `reviewSources`)
 6. **Community** — user opinions as bullet points (from `communityNotes: string[]`,
    populated during scoring research, section hidden when empty)
+7. **Alternatives** — direct competitor lenses (same FL range + mount),
+   computed at build time, creates internal cross-links and "vs" keyword clusters
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -35,6 +35,12 @@ Build, Sweet Spot.
 - Content quality is bounded by data quality — garbage scores produce garbage prose
 - Page word count: ~100 words (scored) / ~30 words (unscored)
 
+## Expected outcome
+
+Indexed page count increases from ~106 (23%) to 300+ as scored lens pages
+cross Google's quality threshold for indexing. Unique prose per page provides
+the content signal that pure data tables lack.
+
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -1,0 +1,44 @@
+# ADR-026: Generate lens page prose from data at build time
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Issue:** #572
+
+## Context
+
+Lens detail pages (`/lenses/[slug]/`) contain only data tables and structured
+specs. Search engines index thin pages poorly — 461 pages with no prose content
+are a discovery liability. The site needs unique, keyword-rich text per page.
+
+## Decision
+
+Generate deterministic prose at build time using score-to-phrase mapping tables.
+Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
+The content spine has 6 sections: Summary, Strengths, Weaknesses, Genre Fit,
+Build, Sweet Spot.
+
+## Alternatives considered
+
+| Alternative                              | Rejected because                                                              |
+| ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Manual descriptions per lens             | Does not scale to 244 lenses; maintenance burden                              |
+| LLM-generated content                    | Non-deterministic; can't be validated in CI; requires API calls at build time |
+| No prose (status quo)                    | Pages remain thin; Discovery score stays at C                                 |
+| Template sentences without score mapping | Produces identical text across lenses; no uniqueness                          |
+
+## Consequences
+
+- Optical score changes automatically update user-facing prose
+- Phrase tables must be maintained — adding a new optical field requires new phrases
+- Unscored lenses get minimal content ("Not yet scored")
+- Generated text is a competitive advantage: unique per lens, no manual effort
+- Content quality is bounded by data quality — garbage scores produce garbage prose
+- Page word count: ~100 words (scored) / ~30 words (unscored)
+
+## Implementation
+
+- Utility function: `generateLensContent(lens) → ContentSpine`
+- Phrase tables: score → natural-language string (LensTip-inspired wording)
+- Focal length context: equivalent mm → descriptive phrase
+- Rendered as semantic HTML sections above spec tables
+- Spec stored in: #572 comments / `temp/lens-content-spine.md`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -14,8 +14,8 @@ are a discovery liability. The site needs unique, keyword-rich text per page.
 
 Generate deterministic prose at build time using score-to-phrase mapping tables.
 Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
-The content spine has 6 sections: Summary, Strengths, Weaknesses, Genre Fit,
-Build, Sweet Spot.
+The content spine has 5 sections: Summary, Strengths, Weaknesses, Genre Fit,
+Build (includes sweet spot aperture).
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -24,8 +24,9 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
    - Aberrations (longitudinalCA, lateralCA, coma, astigmatism, sphericalAberration)
    - Rendering (bokeh, vignettingWideOpen, vignettingStopped, flareResistance)
    - Distortion (distortion)
-4. **User Consensus** — review source links
-5. **Genre Fit** — top/weak genres from genre marks
+4. **Genre Fit** — 9 genre sub-sections, each explaining why the lens is
+   or isn't suited (pros AND cons derived from formula primary/secondary fields)
+5. **User Consensus** — review source links
 
 ## Alternatives considered
 
@@ -43,7 +44,10 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
 - Unscored lenses get minimal content ("Not yet scored")
 - Generated text is a competitive advantage: unique per lens, no manual effort
 - Content quality is bounded by data quality — garbage scores produce garbage prose
-- Page word count: ~100 words (scored) / ~30 words (unscored)
+- Page word count: ~400 words (scored) / ~30 words (unscored)
+- Genre Fit alone generates ~270 words (9 genres × ~30 words each)
+- 9 genre sub-headings per lens create 2,196 unique keyword-rich sections across the site
+- Each genre explanation directly answers "is [lens] good for [genre]?" — featured snippet ready
 
 ## Expected outcome
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1813,3 +1813,27 @@ GSC data: 106/461 pages indexed (23%), ranking only for wiki content ("golden ra
   - Subagents don't read CLAUDE.md or PLAYBOOK — must include relevant rules in agent prompts
   - Always read PLAYBOOK 2.8 before launching spec research agents — LensTip and Radojuva are priority sources for maxMagnification
   - 17 lenses have genuinely unpublished maxMagnification — confirmed across all playbook sources, web search, and PDF catalogs
+
+---
+
+### Session 57 — Content Strategy and SEO Spike
+
+- Tool: Claude Code (Opus 4.6)
+- PRs: #696
+- Issues closed: #572 (spike), #611 (epic), #622, #623, #684
+- Issues created: #684, #693, #694, #695
+- Milestones: created v0.7.0; trimmed v0.6.0 from 29 → 3 issues
+- Key changes:
+  - ADR-026: Lens detail page content strategy (7-section page structure)
+  - Nav button renamed "Genre Guide" → "Genres"
+  - Spike: maxMagnification fallback — concluded no action needed (all missing lenses score bucket 0)
+  - Spike: isInternalFocusing field — researched, prototyped, discarded (needs per-lens verification, deferred to video genre)
+  - Spike #572: content generation feasibility — recommended IMPLEMENT
+- Key decisions:
+  - ADR-026: deterministic prose from optical scores at build time (ref: `docs/decisions/026-lens-page-content-generation.md`)
+  - 4 optical quality clusters (sharpness, aberrations, rendering, distortion) — not 14 sub-headings
+  - 9 per-genre explanations with pros AND cons derived from formula fields
+  - `scoringStatus` enum for missing data transparency
+  - `communityNotes: string[]` for user opinions (deferred population)
+  - Focus on 120 scored lenses first — usable pages over data completeness
+  - v0.7.0 milestone: content depth, implementing ADR-026

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -17,7 +17,7 @@ const navLinks = [
   { href: "/lenses/", label: "Lenses" },
   { href: "/cameras/", label: "Cameras" },
   { href: "/accessories/", label: "Accessories" },
-  { href: "/genre/", label: "Genre Guide" },
+  { href: "/genre/", label: "Genres" },
   { href: "/wiki/", label: "Wiki" },
 ];
 ---


### PR DESCRIPTION
## Summary

- Rename nav button "Genre Guide" to "Genres" (closes #684)
- ADR-026: Lens detail page content strategy — full page redesign spec for SEO and UX

## ADR-026 defines

- 7-section page structure (Summary, Specifications, Optical Quality, Genre Fit, Reviews, Community, Alternatives)
- Deterministic prose generation from optical scores using phrase tables
- 4 optical quality clusters (sharpness, aberrations, rendering, distortion)
- 9 per-genre explanations with pros AND cons
- `scoringStatus` enum for missing data explanation
- `communityNotes` field (deferred population)
- Alternatives section with computed cross-links

## Test plan

- [x] `npm run validate` passes
- [ ] ADR reviewed for completeness
- [ ] Verify nav button renders "Genres" on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)