### PR TITLE
docs: ADR-027 asset and spec storage strategy

### DIFF
--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -1,4 +1,4 @@
-# ADR-026: Generate lens page prose from data at build time
+# ADR-026: Lens detail page content strategy
 
 **Status:** Accepted
 **Date:** 2026-05-17

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -26,7 +26,9 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
    - Distortion (distortion)
 4. **Genre Fit** — 9 genre sub-sections, each explaining why the lens is
    or isn't suited (pros AND cons derived from formula primary/secondary fields)
-5. **User Consensus** — review source links
+5. **Reviews** — professional review source links (from `reviewSources`)
+6. **Community** — user opinions as bullet points (from `communityNotes: string[]`,
+   populated during scoring research, section hidden when empty)
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -14,8 +14,18 @@ are a discovery liability. The site needs unique, keyword-rich text per page.
 
 Generate deterministic prose at build time using score-to-phrase mapping tables.
 Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
-The content spine has 5 sections: Summary, Strengths, Weaknesses, Genre Fit,
-Build (includes sweet spot aperture).
+
+### Page structure
+
+1. **Summary** — one-line verdict + strengths/weaknesses bullets
+2. **Specifications** — lens configuration, MTF charts, specs table
+3. **Optical Quality** — prose interpretation grouped into 4 clusters:
+   - Sharpness (centerWideOpen, cornerWideOpen, centerStopped, cornerStopped)
+   - Aberrations (longitudinalCA, lateralCA, coma, astigmatism, sphericalAberration)
+   - Rendering (bokeh, vignettingWideOpen, vignettingStopped, flareResistance)
+   - Distortion (distortion)
+4. **User Consensus** — review source links
+5. **Genre Fit** — top/weak genres from genre marks
 
 ## Alternatives considered
 
@@ -44,7 +54,9 @@ the content signal that pure data tables lack.
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`
-- Phrase tables: score → natural-language string (LensTip-inspired wording)
+- Phrase tables: score → natural-language string (review-style wording)
 - Focal length context: equivalent mm → descriptive phrase
-- Rendered as semantic HTML sections above spec tables
-- Spec stored in: #572 comments / `temp/lens-content-spine.md`
+- Optical Quality uses 4 clusters (not 14 sub-headings) for UX scannability
+  and SEO substance — individual field names appear in prose, not headings
+- MTF charts from `docs/mtf-charts/` served as images within Specifications
+- Spec stored in: `temp/lens-content-spine.md`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -59,6 +59,24 @@ Indexed page count increases from ~106 (23%) to 300+ as scored lens pages
 cross Google's quality threshold for indexing. Unique prose per page provides
 the content signal that pure data tables lack.
 
+## Missing data handling
+
+When optical scores or genre marks are absent, explain why using
+`scoringStatus?: "niche" | "new" | "discontinued" | "specialty" | "pending"`
+on the Lens interface.
+
+| Status         | Generated phrase                                             |
+| -------------- | ------------------------------------------------------------ |
+| `niche`        | Limited professional review coverage for this lens.          |
+| `new`          | Recently released — professional reviews pending.            |
+| `discontinued` | Discontinued before comprehensive optical testing.           |
+| `specialty`    | Standard optical bench tests do not apply to this lens type. |
+| `pending`      | Scoring in progress.                                         |
+
+Applied to Optical Quality, Genre Fit, and any section that depends on scored data.
+Field is set during data entry. Absent `scoringStatus` on an unscored lens defaults
+to `niche`.
+
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -29,6 +29,8 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
 5. **Reviews** — professional review source links (from `reviewSources`)
 6. **Community** — user opinions as bullet points (from `communityNotes: string[]`,
    populated during scoring research, section hidden when empty)
+7. **Alternatives** — direct competitor lenses (same FL range + mount),
+   computed at build time, creates internal cross-links and "vs" keyword clusters
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -35,6 +35,12 @@ Build, Sweet Spot.
 - Content quality is bounded by data quality — garbage scores produce garbage prose
 - Page word count: ~100 words (scored) / ~30 words (unscored)
 
+## Expected outcome
+
+Indexed page count increases from ~106 (23%) to 300+ as scored lens pages
+cross Google's quality threshold for indexing. Unique prose per page provides
+the content signal that pure data tables lack.
+
 ## Implementation
 
 - Utility function: `generateLensContent(lens) → ContentSpine`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -1,0 +1,44 @@
+# ADR-026: Generate lens page prose from data at build time
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Issue:** #572
+
+## Context
+
+Lens detail pages (`/lenses/[slug]/`) contain only data tables and structured
+specs. Search engines index thin pages poorly — 461 pages with no prose content
+are a discovery liability. The site needs unique, keyword-rich text per page.
+
+## Decision
+
+Generate deterministic prose at build time using score-to-phrase mapping tables.
+Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
+The content spine has 6 sections: Summary, Strengths, Weaknesses, Genre Fit,
+Build, Sweet Spot.
+
+## Alternatives considered
+
+| Alternative                              | Rejected because                                                              |
+| ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Manual descriptions per lens             | Does not scale to 244 lenses; maintenance burden                              |
+| LLM-generated content                    | Non-deterministic; can't be validated in CI; requires API calls at build time |
+| No prose (status quo)                    | Pages remain thin; Discovery score stays at C                                 |
+| Template sentences without score mapping | Produces identical text across lenses; no uniqueness                          |
+
+## Consequences
+
+- Optical score changes automatically update user-facing prose
+- Phrase tables must be maintained — adding a new optical field requires new phrases
+- Unscored lenses get minimal content ("Not yet scored")
+- Generated text is a competitive advantage: unique per lens, no manual effort
+- Content quality is bounded by data quality — garbage scores produce garbage prose
+- Page word count: ~100 words (scored) / ~30 words (unscored)
+
+## Implementation
+
+- Utility function: `generateLensContent(lens) → ContentSpine`
+- Phrase tables: score → natural-language string (LensTip-inspired wording)
+- Focal length context: equivalent mm → descriptive phrase
+- Rendered as semantic HTML sections above spec tables
+- Spec stored in: #572 comments / `temp/lens-content-spine.md`

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -14,8 +14,8 @@ are a discovery liability. The site needs unique, keyword-rich text per page.
 
 Generate deterministic prose at build time using score-to-phrase mapping tables.
 Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
-The content spine has 6 sections: Summary, Strengths, Weaknesses, Genre Fit,
-Build, Sweet Spot.
+The content spine has 5 sections: Summary, Strengths, Weaknesses, Genre Fit,
+Build (includes sweet spot aperture).
 
 ## Alternatives considered
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -24,8 +24,9 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
    - Aberrations (longitudinalCA, lateralCA, coma, astigmatism, sphericalAberration)
    - Rendering (bokeh, vignettingWideOpen, vignettingStopped, flareResistance)
    - Distortion (distortion)
-4. **User Consensus** — review source links
-5. **Genre Fit** — top/weak genres from genre marks
+4. **Genre Fit** — 9 genre sub-sections, each explaining why the lens is
+   or isn't suited (pros AND cons derived from formula primary/secondary fields)
+5. **User Consensus** — review source links
 
 ## Alternatives considered
 
@@ -43,7 +44,10 @@ Each optical field score (0–2 scale) maps to a fixed natural-language phrase.
 - Unscored lenses get minimal content ("Not yet scored")
 - Generated text is a competitive advantage: unique per lens, no manual effort
 - Content quality is bounded by data quality — garbage scores produce garbage prose
-- Page word count: ~100 words (scored) / ~30 words (unscored)
+- Page word count: ~400 words (scored) / ~30 words (unscored)
+- Genre Fit alone generates ~270 words (9 genres × ~30 words each)
+- 9 genre sub-headings per lens create 2,196 unique keyword-rich sections across the site
+- Each genre explanation directly answers "is [lens] good for [genre]?" — featured snippet ready
 
 ## Expected outcome
 

--- a/docs/decisions/026-lens-page-content-generation.md
+++ b/docs/decisions/026-lens-page-content-generation.md
@@ -109,4 +109,4 @@ to `niche`.
 - Optical Quality uses 4 clusters (not 14 sub-headings) for UX scannability
   and SEO substance — individual field names appear in prose, not headings
 - MTF charts from `docs/mtf-charts/` served as images within Specifications
-- Spec stored in: `temp/lens-content-spine.md`
+- Spec stored in: `docs/specs/lens-content-spine.md`

--- a/docs/decisions/027-asset-and-spec-storage.md
+++ b/docs/decisions/027-asset-and-spec-storage.md
@@ -1,0 +1,65 @@
+# ADR-027: Asset and spec storage strategy
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Issue:** #693
+
+## Context
+
+MTF chart images (31 lenses) live in `docs/mtf-charts/` alongside companion
+`.md` analysis files. ADR-026 requires these images rendered on lens detail
+pages. The `docs/` directory is not processed by Astro's build pipeline, so
+images there cannot benefit from optimization (format conversion, responsive
+sizing, lazy loading). Implementation specs like the content spine were stored
+in untracked `temp/` and referenced by ADRs without being committed.
+
+## Decision
+
+### Web assets: `src/assets/mtf/`
+
+MTF chart images (.png) move to `src/assets/mtf/`. Astro's `<Image>` component
+processes files in `src/assets/`, providing:
+
+- Automatic format conversion (WebP/AVIF)
+- Width/height attributes (prevents CLS)
+- Lazy loading
+- Responsive `srcset` generation
+
+Naming convention: `{lens-slug}.png` — matches URL slugs already in use.
+
+When no image exists for a lens, omit the MTF chart sub-section entirely.
+
+Attribution: caption below each image — "Source: {brand} official specifications".
+
+### Analysis files: `docs/mtf-charts/`
+
+Companion `.md` files (chart readings, interpretation notes, source URLs) stay
+in `docs/mtf-charts/`. These are developer reference used during scoring. May
+optionally be rendered as page content during ADR-026 implementation.
+
+### Implementation specs: `docs/specs/`
+
+Implementation specifications referenced by ADRs live in `docs/specs/`.
+First file: `lens-content-spine.md` (referenced by ADR-026).
+
+### Optical diagrams: deferred
+
+No sourcing strategy yet. Will revisit when lens configuration data is added
+(see #565).
+
+## Alternatives considered
+
+| Alternative                           | Rejected because                                            |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Keep images in `docs/mtf-charts/`     | Not processed by Astro; no optimization                     |
+| Use `public/images/mtf/`              | Static copy only; no format conversion or responsive sizing |
+| Merge .md analysis into `src/assets/` | Mixes developer reference with web assets                   |
+| Keep specs in `temp/` (untracked)     | Not committed; disappears on clone                          |
+
+## Consequences
+
+- MTF chart images get automatic optimization (smaller payloads, modern formats)
+- `docs/mtf-charts/` shrinks to .md files only (analysis + source attribution)
+- `docs/specs/` provides a tracked home for implementation specs
+- Migration task needed: move 31 .png files from `docs/mtf-charts/` to `src/assets/mtf/`
+- Update .md analysis files to reference new image paths

--- a/docs/specs/lens-content-spine.md
+++ b/docs/specs/lens-content-spine.md
@@ -1,0 +1,326 @@
+# Lens Detail Page — Content Spine Specification
+
+## Page structure
+
+1. **Summary** — verdict + strengths/weaknesses
+2. **Specifications** — lens configuration, MTF charts, specs table
+3. **Optical Quality** — prose interpretation (4 clusters)
+4. **Genre Fit** — 9 sub-sections, each with pros AND cons
+5. **Reviews** — professional review source links
+6. **Community** — user opinions (populated gradually, hidden when empty)
+7. **Alternatives** — direct competitor lenses (internal cross-links)
+
+---
+
+## Section 1: Summary
+
+### Template
+
+```
+A {fl} f/{aperture} {type} for Fujifilm {mount}-mount ({equiv}mm equivalent) —
+{flContext}. {weight}g, ~${price}. {status}.
+```
+
+### Strengths (score ≥ 1.5)
+
+Bullet list using phrase table (see Section 3 wording tables).
+
+### Weaknesses (score ≤ 0.5)
+
+Bullet list using phrase table (see Section 3 wording tables).
+
+### Focal length context phrases
+
+| Equivalent | Phrase                                                           |
+| ---------- | ---------------------------------------------------------------- |
+| ≤ 18mm     | ultra-wide field of view for interiors and dramatic perspectives |
+| 19–28mm    | wide-angle suited for landscapes and architecture                |
+| 29–40mm    | moderate wide angle for street and environmental portraits       |
+| 41–60mm    | standard field of view close to human vision                     |
+| 61–90mm    | short telephoto ideal for portraits and subject isolation        |
+| 91–135mm   | telephoto compression for portraits and detail shots             |
+| 136–200mm  | telephoto reach for sports and candid photography                |
+| 201–400mm  | super-telephoto reach for wildlife and distant subjects          |
+| 401+mm     | extreme telephoto for birding and surveillance distances         |
+
+---
+
+## Section 2: Specifications
+
+Three sub-sections:
+
+### Lens configuration
+
+Optical design diagram or element/group description (future — requires new data field).
+
+### MTF charts
+
+Manufacturer MTF chart image from `docs/mtf-charts/`. Available for 31 lenses.
+Omit sub-section entirely when no chart exists.
+
+### Specs table
+
+Existing data tables (focal length, aperture, weight, dimensions, filter thread, etc.).
+Already implemented on current lens detail pages.
+
+---
+
+## Section 3: Optical Quality
+
+4 clusters. Each cluster contains prose sentences generated from scores using the
+wording tables below. Includes sweet spot aperture.
+
+### Cluster: Sharpness
+
+Fields: `centerWideOpen`, `cornerWideOpen`, `centerStopped`, `cornerStopped`
+
+| Field          | Score 2                                           | Score 1.5                                    | Score 0.5                                        | Score 0                                   |
+| -------------- | ------------------------------------------------- | -------------------------------------------- | ------------------------------------------------ | ----------------------------------------- |
+| centerStopped  | excellent center sharpness when stopped down      | very good center sharpness when stopped down | average center sharpness even stopped down       | poor center sharpness stopped down        |
+| cornerStopped  | excellent corner-to-corner sharpness stopped down | very good corner sharpness stopped down      | soft corners even stopped down                   | very weak corner performance stopped down |
+| centerWideOpen | sharp in the center wide open                     | good center performance wide open            | soft center wide open, improves on stopping down | weak center sharpness wide open           |
+| cornerWideOpen | impressive corner sharpness even wide open        | decent corner performance wide open          | soft corners wide open                           | very weak corner performance wide open    |
+
+Sweet spot: append "Sharpest at f/{sweetSpotAperture}." when defined.
+
+### Cluster: Aberrations
+
+Fields: `longitudinalCA`, `lateralCA`, `coma`, `astigmatism`, `sphericalAberration`
+
+| Field               | Score 2                                       | Score 1.5                              | Score 0.5                                    | Score 0                                              |
+| ------------------- | --------------------------------------------- | -------------------------------------- | -------------------------------------------- | ---------------------------------------------------- |
+| longitudinalCA      | negligible longitudinal chromatic aberration  | well-corrected longitudinal CA         | noticeable longitudinal chromatic aberration | pronounced longitudinal CA (color fringing in bokeh) |
+| lateralCA           | practically zero lateral chromatic aberration | low lateral chromatic aberration       | visible lateral chromatic aberration         | strong lateral CA on frame edges                     |
+| coma                | well-controlled coma                          | moderate coma control                  | noticeable coma in corners                   | strong coma (problematic for point light sources)    |
+| astigmatism         | minimal astigmatism                           | moderate astigmatism                   | noticeable astigmatism                       | strong astigmatism                                   |
+| sphericalAberration | well-controlled spherical aberration          | proper spherical aberration correction | noticeable spherical aberration              | poorly controlled spherical aberration               |
+
+### Cluster: Rendering
+
+Fields: `bokeh`, `vignettingWideOpen`, `vignettingStopped`, `flareResistance`
+
+| Field              | Score 2                              | Score 1.5                             | Score 0.5                                        | Score 0                                 |
+| ------------------ | ------------------------------------ | ------------------------------------- | ------------------------------------------------ | --------------------------------------- |
+| bokeh              | smooth, pleasing bokeh rendering     | good bokeh character                  | busy bokeh character                             | harsh, distracting bokeh                |
+| vignettingWideOpen | minimal light falloff wide open      | moderate vignetting wide open         | distinct vignetting wide open                    | heavy light falloff at maximum aperture |
+| vignettingStopped  | virtually no vignetting stopped down | negligible vignetting stopped down    | some vignetting persists stopped down            | notable vignetting even stopped down    |
+| flareResistance    | excellent flare resistance           | good performance against bright light | performance against bright light could be better | poor flare resistance                   |
+
+### Cluster: Distortion
+
+Fields: `distortion`
+
+| Field      | Score 2               | Score 1.5      | Score 0.5             | Score 0                                     |
+| ---------- | --------------------- | -------------- | --------------------- | ------------------------------------------- |
+| distortion | negligible distortion | low distortion | noticeable distortion | significant distortion requiring correction |
+
+---
+
+## Section 4: Genre Fit
+
+9 sub-sections — one per genre. Each explains why the lens IS or ISN'T suited,
+referencing the genre formula's primary and secondary fields.
+
+### Generation logic
+
+For each genre:
+
+1. Look up the genre formula (primary + secondary fields)
+2. For each field in the formula, get the lens's score
+3. Generate a sentence explaining:
+   - Fields that help (score ≥ 1.5 on a formula field)
+   - Fields that hurt (score ≤ 0.5 on a formula field)
+   - Derived fields (\_apertureScore, \_weightScore, \_magnificationScore) described naturally
+
+### Genre formula reference
+
+| Genre        | Primary fields                           | Secondary fields                                                                                  |
+| ------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| nightscape   | centerWideOpen                           | \_apertureScore, lateralCA, longitudinalCA, vignettingStopped, flareResistance, astigmatism, coma |
+| landscape    | centerStopped, cornerStopped             | lateralCA, longitudinalCA, vignettingStopped, flareResistance, astigmatism, coma                  |
+| architecture | cornerStopped, centerStopped, distortion | lateralCA, vignettingStopped, flareResistance                                                     |
+| portrait     | bokeh, centerWideOpen                    | longitudinalCA, sphericalAberration, vignettingWideOpen                                           |
+| street       | centerStopped, \_apertureScore           | centerWideOpen, flareResistance, longitudinalCA, coma                                             |
+| travel       | centerStopped, \_weightScore             | \_apertureScore, flareResistance, longitudinalCA                                                  |
+| sport        | centerWideOpen                           | \_apertureScore, longitudinalCA, lateralCA                                                        |
+| wildlife     | centerWideOpen, centerStopped            | \_apertureScore, longitudinalCA, lateralCA                                                        |
+| macro        | centerStopped, \_magnificationScore      | distortion, lateralCA, longitudinalCA, sphericalAberration, bokeh                                 |
+
+### Derived field descriptions
+
+| Derived field               | Natural language                           |
+| --------------------------- | ------------------------------------------ |
+| \_apertureScore (high)      | fast maximum aperture                      |
+| \_apertureScore (low)       | slow maximum aperture limits low-light use |
+| \_weightScore (high)        | lightweight and portable                   |
+| \_weightScore (low)         | heavy for travel use                       |
+| \_magnificationScore (high) | strong close-focus magnification           |
+| \_magnificationScore (low)  | low magnification limits close-up work     |
+
+### Template per genre
+
+```
+**{Genre} ({mark}/5):** {pros from formula fields}. {cons from formula fields}.
+```
+
+Omit entire section when `genreMarks` is null. Show "Not yet scored." fallback.
+
+---
+
+## Section 5: Reviews
+
+List professional review sources with links from `reviewSources` field.
+
+```
+Reviewed by: LensTip, Phillip Reeve, Radojuva
+```
+
+Each source linked via `rel="nofollow sponsored" target="_blank"`.
+Omit section when no review sources exist.
+
+---
+
+## Section 6: Community
+
+User opinions as bullet points from `communityNotes: string[]`.
+
+```
+- Known for slow, noisy AF
+- Beloved for rendering character wide open
+- Popular street lens in the Fuji community
+```
+
+Populated during scoring research. Section hidden when field is empty/absent.
+Data model: `communityNotes?: string[]` on Lens interface.
+
+---
+
+## Section 7: Alternatives
+
+Direct competitor lenses computed at build time. Links to other lens detail pages.
+
+### Matching logic
+
+Same mount + overlapping focal length range (±10mm equivalent):
+
+- For a 56mm prime → show all primes in 46–66mm range
+- For a 16-55mm zoom → show zooms that overlap that range
+
+### Sort order
+
+By genre similarity (highest overlap in top genres), then by price.
+
+### Limit
+
+Max 5 alternatives. Omit section when fewer than 2 exist.
+
+### Template
+
+```
+**Alternatives:**
+- [Sigma 56mm f/1.4 DC DN C](/lenses/sigma-56mm-f1-4-dc-dn-c/) — ~$500, 280g
+- [Viltrox AF 56mm f/1.4 STM](/lenses/viltrox-af-56mm-f1-4-stm/) — ~$250, 320g
+- [TTartisan AF 56mm f/1.8](/lenses/ttartisan-af-56mm-f1-8/) — ~$250, 260g
+```
+
+Each link is an internal cross-link (SEO internal linking mesh).
+Creates natural "vs" keyword clusters ("XF 56mm vs Sigma 56mm").
+
+---
+
+## Missing data handling
+
+When a lens has no optical scores or genre marks, display an explanation
+instead of hiding the section.
+
+Data model: `scoringStatus?: "niche" | "new" | "discontinued" | "specialty" | "pending"`
+
+| Status         | Phrase                                                       |
+| -------------- | ------------------------------------------------------------ |
+| `niche`        | Limited professional review coverage for this lens.          |
+| `new`          | Recently released — professional reviews pending.            |
+| `discontinued` | Discontinued before comprehensive optical testing.           |
+| `specialty`    | Standard optical bench tests do not apply to this lens type. |
+| `pending`      | Scoring in progress.                                         |
+
+Default when `scoringStatus` absent on an unscored lens: `niche`.
+
+Applies to: Optical Quality, Genre Fit sections.
+
+---
+
+## Meta description template
+
+```
+{brand} {model}: {topGenre1}, {topGenre2} lens. Strengths: {strength1}, {strength2}. {weight}g, ~${price}.
+```
+
+Target: ~150 characters, unique per lens, keyword-rich.
+
+---
+
+## Example: Fujifilm XF 56mm f/1.2 R
+
+### Summary
+
+A 56mm f/1.2 prime for Fujifilm X-mount (84mm equivalent) — short telephoto ideal for portraits and subject isolation. 400g, ~$1000. Discontinued.
+
+**Strengths:**
+
+- Excellent center sharpness when stopped down
+- Minimal astigmatism
+- Proper spherical aberration correction
+- Practically zero lateral chromatic aberration
+- Negligible distortion
+- Virtually no vignetting stopped down
+- Smooth, pleasing bokeh rendering
+
+**Weaknesses:**
+
+- Soft center wide open, improves on stopping down
+- Very weak corner performance wide open
+- Noticeable longitudinal chromatic aberration
+- Distinct vignetting wide open
+- Performance against bright light could be better
+
+### Specifications
+
+_(Lens configuration: future)_
+
+_(MTF chart: not available for this lens)_
+
+_(Specs table: existing implementation)_
+
+### Optical Quality
+
+**Sharpness:** Excellent center sharpness when stopped down, but soft center wide open that improves on stopping down. Very weak corner performance wide open. Sharpest at f/4.
+
+**Aberrations:** Practically zero lateral chromatic aberration. Minimal astigmatism and proper spherical aberration correction. However, noticeable longitudinal chromatic aberration produces color fringing in bokeh.
+
+**Rendering:** Smooth, pleasing bokeh rendering. Virtually no vignetting stopped down, but distinct vignetting wide open. Performance against bright light could be better.
+
+**Distortion:** Negligible distortion.
+
+### Genre Fit
+
+**Street (4/5):** Excellent center sharpness stopped down and fast f/1.2 aperture make this ideal for decisive-moment shooting. Noticeable longitudinal CA is rarely an issue at street distances.
+
+**Travel (4/5):** Excellent center sharpness stopped down in a compact 400g body. Performance against bright light could be better for harsh midday conditions.
+
+**Nightscape (3/5):** Fast f/1.2 aperture gathers light well. However, soft center wide open and noticeable coma on point light sources limit astrophotography use. Distinct vignetting wide open.
+
+**Landscape (3/5):** Excellent center sharpness stopped down, but very weak corner performance wide open requires stopping down. Negligible distortion is a plus.
+
+**Architecture (3/5):** Excellent center and corner sharpness stopped down with negligible distortion. Weaker flare resistance may be problematic for interior shots with window light.
+
+**Portrait (2/5):** Smooth bokeh rendering and proper spherical aberration correction work well for subject separation. However, soft center wide open limits critical sharpness at maximum aperture, and noticeable longitudinal CA produces color fringing in bokeh highlights.
+
+**Sport (2/5):** Fast f/1.2 aperture helps in low light, but soft center wide open means AF accuracy is critical. Noticeable longitudinal CA.
+
+**Wildlife (2/5):** Soft center wide open and limited reach (84mm equivalent) make this impractical for distant subjects.
+
+**Macro (1/5):** Low magnification (0.09x) with 70cm minimum focus distance. Not suited for close-up work.
+
+### User Consensus
+
+Reviewed by: [LensTip](https://www.lenstip.com/420.1-Lens_review-Fujifilm_Fujinon_XF_56_mm_f_1.2_R.html)

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -17,7 +17,7 @@ const navLinks = [
   { href: "/lenses/", label: "Lenses" },
   { href: "/cameras/", label: "Cameras" },
   { href: "/accessories/", label: "Accessories" },
-  { href: "/genre/", label: "Genre Guide" },
+  { href: "/genre/", label: "Genres" },
   { href: "/wiki/", label: "Wiki" },
 ];
 ---


### PR DESCRIPTION
## Summary
- ADR-027: MTF images → `src/assets/mtf/` (Astro optimization), analysis .md stays in `docs/mtf-charts/`, implementation specs → `docs/specs/`
- Move `lens-content-spine.md` from untracked `temp/` to `docs/specs/`
- Update ADR-026 path reference

Closes #693

## Test plan
- [x] ADR reviewed for consistency
- [x] Content spine accessible at new path
- [ ] Migration task created for moving 31 .png files

🤖 Generated with [Claude Code](https://claude.com/claude-code)