### PR TITLE
docs: session 58 journal entry and CLAUDE.md updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Project-specific overrides and additions follow below.
 - `src/test/` — Vitest setup and test factories
 - `public/` — static assets (favicon, icons, CNAME, robots.txt)
 - `docs/scoring-log.md` — per-lens scoring justifications (source data → rubric → score)
-- `docs/mtf-charts/` — official MTF chart images with companion `.md` analysis files
+- `docs/mtf-charts/` — MTF chart reading data (`.md` analysis files) and manufacturer `.png` reference images (not served on site, per ADR-027)
 
 ### 1.3 Commands
 
@@ -95,6 +95,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 - Releases MUST follow PLAYBOOK 5.1 — never tag without bumping `package.json` first
 - When creating GitHub issues, follow the formats in `docs/solid-ai-templates/templates/base/workflow/issues.md` — use the correct label (`epic`, `bug`, `incident`, `question`) and body structure for each type
 - Creating a new directory or moving content between documents is an architectural decision — write the ADR **at the moment of the decision**, before creating the files
+- Always ask before auto-merging PRs — never set `--auto` without explicit user permission
 
 ### 2.2 TypeScript
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1837,3 +1837,28 @@ GSC data: 106/461 pages indexed (23%), ranking only for wiki content ("golden ra
   - `communityNotes: string[]` for user opinions (deferred population)
   - Focus on 120 scored lenses first — usable pages over data completeness
   - v0.7.0 milestone: content depth, implementing ADR-026
+
+---
+
+### Session 58 — v0.7.0 Spikes and Lightweight Promise
+
+- Tool: Claude Code (Opus 4.6)
+- PRs: #700, #702, #703, #704
+- Issues closed: #693 (spike), #695 (spike), #697 (bug)
+- Issues created: #701 (structured data review check), #705 (PWA offline support)
+- Upstream: solid-ai-templates#319 (structured data semantic accuracy), solid-ai-templates#320 (ADR conventions)
+- Key changes:
+  - Removed misleading `offers` from JSON-LD on all product pages (not a store)
+  - ADR-026 updated: unscored lenses get ~150-200 words of spec-based content (no noindex needed)
+  - ADR-026 expanded: phrase tables, genre formulas, templates, worked example folded in from content spine
+  - ADR-027: asset storage strategy — MTF charts as generated SVG, readings table inline, chart as linked asset
+  - Content spine deleted — implementation specs belong in their ADR
+  - `docs/specs/` created then removed (folded into ADR)
+  - Homepage hero tagline: "No install. No login. No bloat. Works on 3G in the field."
+- Key decisions:
+  - ADR-027: generate own MTF chart SVGs, not manufacturer images (copyright, consistency)
+  - ADR-027: readings table inline (3G-friendly), SVG chart as linked asset (ref: `docs/decisions/027-asset-and-spec-storage.md`)
+  - Unscored pages are not thin — specs provide enough content without noindex
+  - No forward references between ADRs — self-contained or reference backward only
+  - Implementation specs fold into their ADR, not separate files
+  - "No install" not "No app" — future-proofs for PWA (#705)


### PR DESCRIPTION
## Summary
- Dev journal: session 58 summary
- CLAUDE.md: auto-merge requires explicit permission
- CLAUDE.md: updated docs/mtf-charts/ description per ADR-027

🤖 Generated with [Claude Code](https://claude.com/claude-code)