### PR TITLE
fix: optimize wiki page titles for search queries

### DIFF
--- a/src/content/wiki/bortle-scale.md
+++ b/src/content/wiki/bortle-scale.md
@@ -1,5 +1,5 @@
 ---
-title: "Bortle Scale"
+title: "Bortle Scale: Dark Sky Rating"
 categories:
   - "Exposure"
 summary: "A 1-9 scale measuring night sky darkness, critical for astrophotography and nightscape planning."

--- a/src/content/wiki/coma.md
+++ b/src/content/wiki/coma.md
@@ -1,5 +1,5 @@
 ---
-title: "Coma"
+title: "Coma Aberration"
 categories:
   - "Optics"
 summary: "An optical aberration that stretches point light sources into comet-like shapes near frame edges."

--- a/src/content/wiki/cri.md
+++ b/src/content/wiki/cri.md
@@ -1,6 +1,5 @@
 ---
-title: "CRI"
-fullTitle: "Colour Rendering Index"
+title: "CRI (Colour Rendering Index)"
 categories:
   - "Lighting"
 summary: "A scale (0–100) measuring how accurately a light source renders colours compared to natural sunlight."

--- a/src/content/wiki/dof.md
+++ b/src/content/wiki/dof.md
@@ -1,6 +1,5 @@
 ---
-title: "DoF"
-fullTitle: "Depth of Field"
+title: "Depth of Field (DoF)"
 categories:
   - "Geometry"
 summary: "The range of distances in a scene that appear acceptably sharp."

--- a/src/content/wiki/gamma-correction.md
+++ b/src/content/wiki/gamma-correction.md
@@ -1,6 +1,5 @@
 ---
-title: "Gamma correction"
-fullTitle: "Gamma Correction"
+title: "Gamma Correction in Photography"
 categories:
   - "Post-Processing"
 summary: "A nonlinear tone mapping applied to image data to match human perception of brightness."

--- a/src/content/wiki/golden-ratio.md
+++ b/src/content/wiki/golden-ratio.md
@@ -1,9 +1,8 @@
 ---
-title: "Golden ratio"
-fullTitle: "Golden Ratio"
+title: "Golden Ratio in Photography"
 categories:
   - "Composition"
-summary: "Mathematical ratio ≈1."
+summary: "The golden ratio (≈1.618:1) as a compositional guide — place subjects at golden ratio intersections or along spiral curves for naturally pleasing images."
 ---
 
 Mathematical ratio ≈1.618:1 (φ, phi) found throughout nature and classical art. Used as a compositional guide: placing subjects at golden ratio intersections or along spiral curves creates naturally pleasing images.

--- a/src/content/wiki/image-resolution.md
+++ b/src/content/wiki/image-resolution.md
@@ -1,9 +1,8 @@
 ---
-title: "Image resolution"
-fullTitle: "Image Resolution"
+title: "Image Resolution in Photography"
 categories:
   - "Optics"
-summary: "The number of pixels in a captured image, typically expressed as megapixels (MP) or as width × height (e."
+summary: "The number of pixels in a captured image, typically expressed as megapixels (MP) or as width x height."
 ---
 
 The number of pixels in a captured image, typically expressed as megapixels (MP) or as width × height (e.g. 7728×5152). Higher resolution enables larger prints and more crop flexibility.

--- a/src/content/wiki/rule-of-thirds.md
+++ b/src/content/wiki/rule-of-thirds.md
@@ -1,5 +1,5 @@
 ---
-title: "Rule of thirds"
+title: "Rule of Thirds"
 categories:
   - "Composition"
 summary: "Divide the frame into a 3×3 grid; place key subjects or horizon lines along the grid lines or at their intersections (power points)."

--- a/src/content/wiki/snoot.md
+++ b/src/content/wiki/snoot.md
@@ -1,5 +1,5 @@
 ---
-title: "Snoot"
+title: "Snoot Lighting"
 categories:
   - "Lighting"
 summary: "A cone or tube attached to a flash or studio head to narrow the light beam to a small spot."

--- a/src/content/wiki/speedlight.md
+++ b/src/content/wiki/speedlight.md
@@ -1,5 +1,5 @@
 ---
-title: "Speedlight"
+title: "Speedlight Flash"
 categories:
   - "Lighting"
 summary: "A portable battery-powered flash unit that mounts on the camera hotshoe or is used off-camera."


### PR DESCRIPTION
## Summary
- Align 10 wiki page titles with actual GSC search queries
- Biggest impact: golden ratio (81 impressions at position 73), bortle scale (24 imp at position 40), coma (8 imp at position 59)
- Fix truncated golden-ratio summary
- Remove redundant fullTitle fields where title now contains the full form

Closes #698

## Test plan
- [x] `npm run validate` passes
- [x] Built titles verified in dist/
- [ ] Monitor GSC position changes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)