### PR TITLE
chore: release v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wuseria",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- Bump package.json version from 0.5.0 to 0.6.0

Milestone v0.6.0 was closed on 2026-05-17 but the version bump and tag were missed.

## Test plan

- [x] package.json updated
- [ ] CI passes
- Tag after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)