### PR TITLE
feat: rework alternatives logic with OQ ranking and type grouping (#717)

### DIFF
--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -69,6 +69,10 @@
 - https://ultralightphotography.net/gear/fuji-cameras/everything-you-wanted-to-know-about-np-w126-batteries/
 - https://www.fujirumors.com/fuji-guys-explain-which-battery-power-banks-are-best-for-your-fujifilm-cameras/
 
+## Genre and lens selection
+
+- https://fstoppers.com/originals/ups-and-downs-using-macro-lenses-portraiture-129330 — Macro lenses for portraiture: trade-offs (sharp detail, slow AF, harsh skin, focus breathing) but viable for portraits
+
 ## Technique and tutorials
 
 - https://photographylife.com/rating-each-focal-length-as-a-landscape-photographer

--- a/src/utils/lens-content.test.ts
+++ b/src/utils/lens-content.test.ts
@@ -191,14 +191,162 @@ describe("generateLensContent", () => {
   });
 
   describe("alternatives", () => {
-    it("finds alternatives in same mount", () => {
-      const content = generateLensContent(scoredLens, allLenses);
-      expect(content.alternatives.length).toBeGreaterThan(0);
-      expect(content.alternatives[0].slug).toContain("fujifilm-xf-50mm");
+    const altHighOQ = makeLens({
+      brand: "Sigma",
+      model: "56mm f/1.4 DC DN",
+      mount: "X",
+      focalLengthMin: 56,
+      focalLengthMax: 56,
+      maxAperture: 1.4,
+      weight: 280,
+      price: 480,
+      centerWideOpen: 1.5,
+      cornerWideOpen: 1.5,
+      centerStopped: 1.5,
+      cornerStopped: 1.5,
+      longitudinalCA: 1.5,
+      lateralCA: 1.5,
+      coma: 1.5,
+      astigmatism: 1.5,
+      sphericalAberration: 1.5,
+      distortion: 1.5,
+      vignettingWideOpen: 1.5,
+      vignettingStopped: 1.5,
+      bokeh: 1.5,
+      flareResistance: 1.5,
+    });
+
+    const altLowOQ = makeLens({
+      brand: "Viltrox",
+      model: "56mm f/1.4 STM",
+      mount: "X",
+      focalLengthMin: 56,
+      focalLengthMax: 56,
+      maxAperture: 1.4,
+      weight: 260,
+      price: 300,
+      centerWideOpen: 1,
+      cornerWideOpen: 1,
+      centerStopped: 1,
+      cornerStopped: 1,
+      longitudinalCA: 1,
+      lateralCA: 1,
+      coma: 1,
+      astigmatism: 1,
+      sphericalAberration: 1,
+      distortion: 1,
+      vignettingWideOpen: 1,
+      vignettingStopped: 1,
+      bokeh: 1,
+      flareResistance: 1,
+    });
+
+    const altZoom = makeLens({
+      brand: "Fujifilm",
+      model: "XF 50-140mm f/2.8 R LM OIS WR",
+      mount: "X",
+      type: "zoom",
+      focalLengthMin: 50,
+      focalLengthMax: 140,
+      maxAperture: 2.8,
+      weight: 995,
+      price: 1600,
+      centerWideOpen: 1.5,
+      cornerWideOpen: 1.5,
+      centerStopped: 1.5,
+      cornerStopped: 1.5,
+      longitudinalCA: 1.5,
+      lateralCA: 1.5,
+      coma: 1.5,
+      astigmatism: 1.5,
+      sphericalAberration: 1.5,
+      distortion: 1.5,
+      vignettingWideOpen: 1.5,
+      vignettingStopped: 1.5,
+      bokeh: 1.5,
+      flareResistance: 1.5,
+    });
+
+    const altUnscored = makeLens({
+      brand: "7Artisans",
+      model: "55mm f/1.4 II",
+      mount: "X",
+      focalLengthMin: 55,
+      focalLengthMax: 55,
+      maxAperture: 1.4,
+      weight: 230,
+      price: 150,
+    });
+
+    const altLenses = [
+      scoredLens,
+      unscoredLens,
+      weakLens,
+      altHighOQ,
+      altLowOQ,
+      altZoom,
+      altUnscored,
+    ];
+
+    it("shows same-type alternatives first, sorted by OQ", () => {
+      const content = generateLensContent(scoredLens, altLenses);
+      const slugs = content.alternatives.map((a) => a.slug);
+      const highIdx = slugs.findIndex((s) => s.includes("sigma"));
+      const lowIdx = slugs.findIndex((s) => s.includes("viltrox"));
+      expect(highIdx).toBeLessThan(lowIdx);
+    });
+
+    it("limits same-type to 5 and other-type to 3", () => {
+      const content = generateLensContent(scoredLens, altLenses);
+      expect(content.alternatives.length).toBeLessThanOrEqual(8);
+    });
+
+    it("places unscored same-type alternatives after scored", () => {
+      const content = generateLensContent(scoredLens, altLenses);
+      const slugs = content.alternatives.map((a) => a.slug);
+      const scoredIdx = slugs.findIndex((s) => s.includes("sigma"));
+      const unscoredIdx = slugs.findIndex((s) => s.includes("xf-50mm"));
+      expect(scoredIdx).toBeGreaterThanOrEqual(0);
+      expect(unscoredIdx).toBeGreaterThanOrEqual(0);
+      expect(scoredIdx).toBeLessThan(unscoredIdx);
+    });
+
+    it("includes zooms that cover the focal length as other-type", () => {
+      const content = generateLensContent(scoredLens, altLenses);
+      const zoom = content.alternatives.find((a) =>
+        a.slug.includes("50-140mm"),
+      );
+      expect(zoom).toBeDefined();
+    });
+
+    it("excludes lenses outside ±20% range", () => {
+      const content = generateLensContent(scoredLens, altLenses);
+      // weakLens at 35mm: |35-56| = 21 > 56*0.2 = 11.2
+      const found = content.alternatives.find((a) =>
+        a.slug.includes("xf-35mm"),
+      );
+      expect(found).toBeUndefined();
+    });
+
+    it("excludes discontinued lenses", () => {
+      const discontinued = makeLens({
+        brand: "Fujifilm",
+        model: "XF 56mm f/1.2 R",
+        mount: "X",
+        focalLengthMin: 56,
+        focalLengthMax: 56,
+        isDiscontinued: true,
+      });
+      const withDiscontinued = [...altLenses, discontinued];
+      const content = generateLensContent(scoredLens, withDiscontinued);
+      const found = content.alternatives.find(
+        (a) => a.model === "XF 56mm f/1.2 R",
+      );
+      expect(found).toBeUndefined();
     });
 
     it("excludes the lens itself", () => {
-      const content = generateLensContent(scoredLens, allLenses);
+      const content = generateLensContent(scoredLens, altLenses);
       const self = content.alternatives.find(
         (a) => a.model === scoredLens.model,
       );

--- a/src/utils/lens-content.ts
+++ b/src/utils/lens-content.ts
@@ -549,50 +549,47 @@ function generateGenreFit(lens: Lens): GenreFitEntry[] {
 // ALTERNATIVES
 // =============================================================================
 
-function findAlternatives(lens: Lens, allLenses: Lens[]): Alternative[] {
-  // Focal length midpoint for distance calculation
-  const mid = (lens.focalLengthMin + lens.focalLengthMax) / 2;
+function sortByOQ(a: Lens, b: Lens): number {
+  const oqA = computeOpticalQuality(a);
+  const oqB = computeOpticalQuality(b);
+  if (oqA == null && oqB == null) return 0;
+  if (oqA == null) return 1;
+  if (oqB == null) return -1;
+  return oqB - oqA;
+}
 
-  return allLenses
-    .filter((other) => {
-      if (other.model === lens.model || other.mount !== lens.mount)
-        return false;
-      // Must cover the lens FL or start within ±15mm
-      const coversFL =
-        other.focalLengthMin <= mid && other.focalLengthMax >= mid;
-      const nearFL =
-        Math.abs(other.focalLengthMin - mid) <= 15 ||
-        Math.abs(other.focalLengthMax - mid) <= 15;
-      if (!coversFL && !nearFL) return false;
-      // Reject superzooms (>4x range) — they're not direct alternatives
-      const zoomRatio = other.focalLengthMax / other.focalLengthMin;
-      if (zoomRatio > 4) return false;
-      return true;
-    })
-    .sort((a, b) => {
-      // Distance: 0 if FL range covers the midpoint, otherwise gap
-      const distA =
-        mid >= a.focalLengthMin && mid <= a.focalLengthMax
-          ? 0
-          : Math.min(
-              Math.abs(a.focalLengthMin - mid),
-              Math.abs(a.focalLengthMax - mid),
-            );
-      const distB =
-        mid >= b.focalLengthMin && mid <= b.focalLengthMax
-          ? 0
-          : Math.min(
-              Math.abs(b.focalLengthMin - mid),
-              Math.abs(b.focalLengthMax - mid),
-            );
-      return distA - distB;
-    })
-    .slice(0, 10)
-    .map((other) => ({
-      brand: other.brand,
-      model: other.model,
-      slug: toSlug(`${other.brand} ${other.model}`),
-    }));
+function findAlternatives(lens: Lens, allLenses: Lens[]): Alternative[] {
+  const mid = (lens.focalLengthMin + lens.focalLengthMax) / 2;
+  const isSameType = (other: Lens): boolean => other.type === lens.type;
+
+  const candidates = allLenses.filter((other) => {
+    if (other.model === lens.model || other.mount !== lens.mount) return false;
+    if (other.isDiscontinued) return false;
+    // Must cover the lens FL or be within ±20%
+    const margin = mid * 0.2;
+    const coversFL = other.focalLengthMin <= mid && other.focalLengthMax >= mid;
+    const nearFL =
+      Math.abs(other.focalLengthMin - mid) <= margin ||
+      Math.abs(other.focalLengthMax - mid) <= margin;
+    if (!coversFL && !nearFL) return false;
+    // Reject superzooms (>4x range) — they're not direct alternatives
+    const zoomRatio = other.focalLengthMax / other.focalLengthMin;
+    if (zoomRatio > 4) return false;
+    return true;
+  });
+
+  // Same type first (up to 5), then other type (up to 3)
+  const sameType = candidates.filter(isSameType).sort(sortByOQ).slice(0, 5);
+  const otherType = candidates
+    .filter((c) => !isSameType(c))
+    .sort(sortByOQ)
+    .slice(0, 3);
+
+  return [...sameType, ...otherType].map((other) => ({
+    brand: other.brand,
+    model: other.model,
+    slug: toSlug(`${other.brand} ${other.model}`),
+  }));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- **FL range**: ±15mm fixed → ±20% proportional (scales with focal length — tight for UW, wide for tele)
- **Sorting**: FL distance → OQ score descending (unscored lenses last)
- **Grouping**: same type first (up to 5 primes/zooms), then other type (up to 3)
- **Filtering**: exclude discontinued lenses, keep superzoom (>4x) filter
- Bookmark added for macro-as-portrait reference article

## Example: XF 56mm f/1.2 R WR
Before (10 alternatives, FL-sorted): kit zooms, discontinued lenses, budget primes mixed together
After (7 alternatives, OQ-sorted + type-grouped):
- **Primes (5):** Laowa 65mm, XF 50mm, XF 60mm, Viltrox 56mm, Samyang 50mm
- **Zooms (2):** XF 50-140mm, XF 16-55mm II

## Test plan
- [x] `npm run validate` passes (lint, format, types, 25 tests, build, links)
- [x] OQ sorting verified — higher OQ primes appear first
- [x] Unscored lenses sort after scored
- [x] Discontinued lenses excluded
- [x] ±20% range verified (35mm excluded from 56mm, 50mm included)
- [x] Zooms covering FL appear in other-type section
- [x] Build output verified for XF 56mm f/1.2 R WR page

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)