### PR TITLE
chore: remove data fix exception for main commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ Follow `docs/solid-ai-templates/templates/base/workflow/scope.md` for scope guar
 ### 6.2 During the session
 
 - **One theme per session.** If an unrelated topic comes up, create a GitHub issue for it and say: "Noted as #X — let's come back to it next session."
-- **Always branch before coding.** No commits directly to `main` for feature work. Data fixes (single field updates) are acceptable on `main`.
+- **Always branch before coding.** No commits directly to `main` — no exceptions.
 - **Build after every change.** Don't accumulate multiple changes without verifying.
 
 ### 6.3 End of session


### PR DESCRIPTION
## Summary
- Remove the "data fixes are acceptable on main" clause from CLAUDE.md section 6.2
- Rule is now absolute: no commits directly to main, no exceptions
- Eliminates ambiguity that led to docs/ADRs being committed to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)