### PR TITLE
feat: skeletonization MTF extraction and ADR-029 optical quality page structure (#727, #730)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -221,15 +221,34 @@ py scripts/fetch-sigma-mtf.py             # fetch all to docs/mtf-charts/
 py scripts/fetch-sigma-mtf.py --dry-run   # list without downloading
 ```
 
-**Extract MTF readings from chart PNGs (requires Python + Pillow):**
+**Extract MTF readings from chart PNGs:**
+
+Skeleton tool (recommended — requires Python + scikit-image + opencv-python):
 
 ```bash
-py tools/mtf-extract-sigma.py docs/mtf-charts/sigma-16mm-f1-4-dc-dn-c.png
+py tools/mtf-extract-skeleton.py docs/mtf-charts/samyang-35mm-f1-2.png
+py tools/mtf-extract-skeleton.py docs/mtf-charts/sigma-56mm-f1-4-dc-dn-c.png
+py tools/mtf-extract-skeleton.py docs/mtf-charts/samyang-*.png   # batch
 ```
 
-Auto-detects plot area, extracts values at grid positions + edge, classifies
-S/M via curve-following gap detection. Copy the TypeScript output into
-`src/data/mtf-readings.ts`.
+Auto-detects chart type (Samyang 4-color / Sigma solid+dashed). Uses
+color isolation → skeletonization → connected components for S/M
+classification. Handles occlusion fill, auto grid step detection (APS-C
+2.5mm / full-frame 5mm), and M-value interpolation. Copy the TypeScript
+output into `src/data/mtf-readings.ts`.
+
+Comparison mode (Samyang only — validates against old pixel-scan tool):
+
+```bash
+py tools/mtf-extract-skeleton.py --compare docs/mtf-charts/samyang-35mm-f1-2.png
+```
+
+Legacy tools (Pillow only, no scikit-image needed):
+
+```bash
+py tools/mtf-extract-samyang.py docs/mtf-charts/samyang-35mm-f1-2.png
+py tools/mtf-extract-sigma.py docs/mtf-charts/sigma-16mm-f1-4-dc-dn-c.png
+```
 
 **List unscored lenses:**
 

--- a/docs/decisions/029-optical-quality-page-structure.md
+++ b/docs/decisions/029-optical-quality-page-structure.md
@@ -1,0 +1,382 @@
+# ADR-029: Optical Quality page structure — design analysis + lab tests
+
+**Status:** Accepted
+**Date:** 2026-05-19
+**Supersedes:** ADR-026 section 3 (Optical Quality)
+
+## Context
+
+ADR-026 defined Optical Quality as a single section with 4 clusters (Sharpness,
+Aberrations, Rendering, Distortion) derived from review scores. This works for
+scored lenses but leaves unscored lenses — especially Chinese budget brands
+(7Artisans, TTartisan, Meike, Pergear, Kamlan) — with no optical content at all.
+
+We now have two additional data sources beyond review scores:
+
+1. **MTF chart readings** — digitized from manufacturer charts (22 lenses
+   and growing, stored in `src/data/mtf-readings.ts`)
+2. **Optical construction data** — element/group count, special glass
+   (stored on the Lens interface: `opticalElements`, `opticalGroups`,
+   `specialElements`)
+
+These sources are available for many unscored lenses because manufacturers
+publish MTF charts and construction specs regardless of whether reviewers
+have tested the lens. Separating design-side evidence from measured evidence
+also makes provenance explicit (see #709).
+
+### The budget brand problem
+
+Budget Chinese lenses often have impressive manufacturer MTF charts but
+higher unit-to-unit variation than premium brands. Users need to:
+
+- See what the optical design promises (MTF + construction analysis)
+- Understand what reviewers confirmed (lab/field test scores)
+- Know when the gap between promise and delivery is uncertain
+
+A single flat section cannot express this distinction.
+
+## Decision
+
+Split the Optical Quality section into three sub-sections:
+
+### 3.1 Overview
+
+Score pips for all 14 optical fields at a glance. One-line overall verdict
+(e.g. "Strong performer with well-controlled aberrations"). Hidden when
+no scores exist.
+
+### 3.2 Optical Design Analysis
+
+What the lens design tells us about performance. Renders when MTF readings
+or optical construction data exist — does not require review scores.
+
+**MTF contains real optical information.** Spike #730 confirmed through
+authoritative sources (Nikon USA, Zeiss H.H. Nasse, LensRentals Roger
+Cicala, Eckhardt Optics) that MTF charts reveal sharpness, astigmatism
+(S/M divergence), bokeh tendency (S/M convergence), and field curvature.
+These are established optical principles, not speculation.
+
+The key variable is **computed vs measured MTF** — not whether the
+relationships are valid:
+
+| MTF type                              | Manufacturers                                | Content confidence                                                 |
+| ------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| **Measured** (from production lenses) | Zeiss, Leica, Sigma Art                      | High — real performance; can support scoring alongside reviews     |
+| **Computed** (from optical design)    | Canon, Nikon, Fujifilm, Samyang, most others | Design intent — actual performance varies by manufacturing quality |
+
+Content language adapts to the confidence tier. Measured MTF warrants
+direct statements ("resolves fine detail well at the center"). Computed
+MTF uses qualified language ("the optical design targets strong center
+resolution").
+
+**MTF Chart Analysis** (when `mtfReadings` exist for this lens):
+
+- SVG chart rendered inline (already implemented)
+- Center vs corner contrast (10 lp/mm S/M curves at wide open)
+- Center vs corner resolution (30 lp/mm S/M curves at wide open)
+- Astigmatism (S/M divergence across the field — this IS how astigmatism
+  manifests in MTF; confirmed by Nikon USA, Eckhardt Optics)
+- Bokeh tendency (S/M convergence — closer lines = smoother out-of-focus
+  rendering; confirmed by Nikon USA, Luminous Landscape, Fstoppers)
+- Field curvature (wavy mid-field dip pattern)
+- Stopped-down improvement (if second aperture data available)
+
+Phrase mapping — **measured MTF** (Sigma Art, Zeiss, Leica):
+
+| MTF range (30 lp/mm center) | Phrase                                                           |
+| --------------------------- | ---------------------------------------------------------------- |
+| ≥ 0.90                      | Excellent center resolution                                      |
+| 0.75–0.89                   | Good center resolution — typical for this aperture class         |
+| 0.60–0.74                   | Moderate center resolution — sharpness improves on stopping down |
+| < 0.60                      | Soft center wide open — stopping down recommended                |
+
+Phrase mapping — **computed MTF** (Samyang, Nikon, Canon, Fujifilm, others):
+
+| MTF range (30 lp/mm center) | Phrase                                                                               |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| ≥ 0.90                      | The optical design targets excellent center resolution                               |
+| 0.75–0.89                   | The optical design targets good center resolution                                    |
+| 0.60–0.74                   | The optical design trades center resolution for other priorities (speed, size, cost) |
+| < 0.60                      | Limited fine-detail resolution in the design — stopping down expected                |
+
+Similar tables for edge performance, S/M divergence (astigmatism), and
+S/M convergence (bokeh). Full phrase tables defined in implementation.
+
+Thresholds follow Luminous Landscape convention: >0.8 = excellent, >0.6 =
+satisfactory (for 10 lp/mm contrast). Resolution (30 lp/mm) thresholds
+are more demanding.
+
+**Rendering Character** (derived from MTF contrast-resolution relationship):
+
+Some lenses are deliberately designed for "pop" — punchy subject separation
+with smooth micro-detail — rather than maximum clinical sharpness. This is
+readable from the gap between 10 lp/mm (contrast) and 30 lp/mm (resolution)
+curves. Classic examples: XF 35mm f/1.4 R, XF 56mm f/1.2 R.
+
+| 10 lp/mm (contrast) | 30 lp/mm (resolution) | Rendering character                                                                                         |
+| ------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| High (≥0.90)        | High (≥0.85)          | Clinical / analytical — every detail resolved; ideal for landscape, architecture, product                   |
+| High (≥0.90)        | Moderate (0.65–0.80)  | "Pop" / 3D rendering — punchy contrast with smooth micro-detail; flattering for skin, compelling for street |
+| High (≥0.90)        | Low (<0.65)           | Soft-focus character — dreamy, vintage rendering                                                            |
+| Moderate (<0.90)    | Moderate              | Flat rendering — neither clinical nor artistic                                                              |
+
+Additional rendering signals from MTF:
+
+- **Bokeh transition quality** — S/M convergence (already in MTF analysis)
+  indicates how smoothly the lens transitions between in-focus and
+  out-of-focus areas
+- **3D rendering tendency** — high contrast + controlled resolution =
+  subject separation ("the subject jumps off the background")
+- **Cinema character** — cinema lenses deliberately introduce controlled
+  spherical aberration for smooth focus falloff (gradual roll-off rather
+  than cliff edge between center and corners); they also prioritize
+  consistent cross-frame rendering (flatter curves) over peak sharpness
+  (high curves)
+
+This section is especially valuable for:
+
+- Portrait photographers choosing between clinical vs flattering rendering
+- Street photographers wanting subject "pop" in busy scenes
+- Video/cinema shooters looking for organic rendering character
+- Budget lens buyers — a 7Artisans 35mm f/0.95 with high contrast but
+  moderate resolution has genuine artistic appeal that pure sharpness
+  scores miss entirely
+
+Genre relevance: rendering character directly informs portrait, street,
+and travel genre fit explanations. A lens with "pop" rendering gets a
+qualitative edge in these genres even if its raw sharpness score is
+moderate.
+
+**Stopped-Down Behavior** (when both wide-open and stopped-down MTF exist):
+
+The delta between wide-open and stopped-down MTF answers "should I stop
+down this lens?" — a question every photographer asks.
+
+| Wide open → stopped down              | Meaning                                                      | Phrase                                                                              |
+| ------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Small improvement (Δ30S < 0.05)       | Well-corrected wide open — shoot confidently at max aperture | "Already sharp wide open — stopping down gains little"                              |
+| Moderate improvement (Δ30S 0.05–0.15) | Aberration-limited wide open, benefits from stopping down    | "Sharpens noticeably when stopped down — best results around f/5.6–f/8"             |
+| Large improvement (Δ30S > 0.15)       | Significant aberrations wide open, transforms stopped down   | "Wide-open rendering is soft — stop down to f/5.6 or beyond for critical sharpness" |
+
+Genre relevance: landscape, architecture, and product photographers
+need to know if stopping down is required. Portrait and street photographers
+need to know if wide-open performance holds up.
+
+Samyang charts provide both MAX aperture and F8 data. Sigma charts are
+wide-open only (second aperture requires separate charts not yet collected).
+
+**Cross-Frame Consistency** (center-to-edge MTF delta):
+
+How flat the MTF curves are across the field. Two lenses with the same
+average sharpness can have very different uniformity.
+
+| Center-edge delta (30 lp/mm) | Pattern                             | Phrase                                                    |
+| ---------------------------- | ----------------------------------- | --------------------------------------------------------- |
+| Small (< 0.10)               | Flat — consistent across frame      | "Even performance from center to corners"                 |
+| Moderate (0.10–0.25)         | Gradual falloff — typical           | "Moderate corner softening — typical for this lens class" |
+| Large (> 0.25)               | Steep — strong center, weak corners | "Sharp center with significant corner falloff"            |
+
+Genre relevance:
+
+- Architecture, astrophotography, group portraits need high consistency
+  (flat curves matter more than peak sharpness)
+- Portrait, street tolerate steep falloff (center subject sharpness is
+  what matters; soft corners add natural vignette-like focus)
+- Landscape depends on the shot — foreground-to-infinity compositions
+  need consistency; distant subjects need center sharpness
+
+**What MTF charts cannot reveal** (every authoritative source agrees):
+
+- Chromatic aberration (longitudinal or lateral)
+- Distortion (barrel/pincushion)
+- Vignetting / light falloff
+- Flare resistance
+- Coma (partially visible in S/M edge divergence, but not cleanly isolated
+  from astigmatism)
+
+**Optical Construction Analysis** (when `opticalElements` or `specialElements`
+exist):
+
+These are physical optical properties — the element types determine what
+aberrations the design corrects. This is established optical engineering,
+not inference. Validated against LensTip lab reviews for 5 Fujifilm lenses
+in spike #730 preliminary research (~90% confidence).
+
+High-confidence construction signals:
+
+| Construction feature                        | Optical effect                                                                                            | Confidence |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------- |
+| ED/SED/UED/fluorite elements                | Control chromatic aberration (fringing)                                                                   | High       |
+| Aspherical elements                         | Correct spherical aberration and reduce distortion                                                        | High       |
+| Aspherical count ≥ 3 on FL ≤ 16mm           | Optical (not software) distortion correction                                                              | High       |
+| ED count ≥ 5 on FL ≥ 200mm                  | Advanced fringing suppression for telephoto                                                               | High       |
+| Elements − groups (cemented boundaries)     | Fewer air-glass surfaces = less internal reflection; diff ≤ 2 = high flare risk without advanced coatings | High       |
+| UMC/SMC/nano/T\* coatings                   | Flare and ghosting resistance                                                                             | High       |
+| High element count for a simple prime       | Modern high-resolution sensor-optimized design                                                            | Medium     |
+| Symmetric layout (e.g. Double Gauss)        | Naturally cancels barrel/pincushion distortion                                                            | Medium     |
+| High aspherical ratio in low-element design | Sharp center, potentially softer corners                                                                  | Medium     |
+
+Content generation from construction:
+
+- Element/group count in context (e.g. "13 elements in 10 groups — a
+  complex design for a 56mm prime")
+- Special element interpretation with direct language: "2 ED elements
+  control chromatic aberration" — not "designed to control"
+- Construction class relative to price point (value assessment)
+- When scored: cross-reference with lab results ("2 ED elements control
+  CA — reviewer testing confirms well-controlled fringing")
+- When unscored: state the physical properties without a score claim
+  ("2 ED elements control CA; no independent test data available yet")
+
+What construction CANNOT predict:
+
+| Field                  | Why                                                                                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Vignetting             | Depends on physical barrel diameter vs sensor, not glass layout                                                                                                        |
+| Coating-override flare | Nano-GI/T\* coatings can overcome structural flare risk; need coating data to assess (validated: XF 16mm f/1.4 has only 2 cemented boundaries but Nano-GI compensates) |
+| Bokeh quality          | Blade count affects highlight shape, but rendering smoothness depends on aberration balance that construction alone cannot predict                                     |
+| Sample variation       | High group count + budget assembly = alignment risk, but this is manufacturing quality, not optical design                                                             |
+
+**Manufacturing variance disclaimer** (conditional):
+
+Tied to whether MTF data is computed or measured — not just brand tier.
+A Sigma Art lens with measured MTF (every copy tested) warrants more
+confidence than a Samyang with computed MTF. Roger Cicala (LensRentals):
+_"the real-life curves are never quite as good as the image suggests"_
+— but they are correlated, not random.
+
+Shown for lenses with computed MTF from manufacturers without per-copy
+testing:
+
+> _Manufacturer MTF charts represent optimal production samples. Budget
+> manufacturers may show higher unit-to-unit variation — real-world
+> performance can fall below these design targets._
+
+Shown for brands where community consensus or known QC issues warrant it.
+Not a blanket disclaimer on all budget brands — some (e.g. Viltrox) have
+good consistency.
+
+### 3.3 Lab & Field Tests
+
+What reviewers actually measured. Renders only when optical scores exist.
+Grouped by concern using the same 4-cluster structure from ADR-026:
+
+**Sharpness**
+
+- centerWideOpen, cornerWideOpen, centerStopped, cornerStopped
+
+**Chromatic Aberration**
+
+- longitudinalCA, lateralCA
+
+**Aberrations**
+
+- coma, astigmatism, sphericalAberration
+
+**Rendering**
+
+- bokeh, vignettingWideOpen, vignettingStopped, flareResistance
+
+**Distortion**
+
+- distortion
+
+Each cluster uses score-to-phrase mapping (unchanged from ADR-026). When
+both design analysis and lab test data exist for the same concern, the lab
+test prose can reference the design prediction:
+
+> "MTF charts predicted strong center sharpness — reviewer testing confirms
+> excellent performance wide open (2/2)."
+
+Or flag a discrepancy:
+
+> "Despite promising MTF curves, reviewer testing found only moderate center
+> sharpness (1/2) — possibly due to sample variation or focus calibration."
+
+### Content availability matrix
+
+| Data available              | 3.1 Overview | 3.2 Design Analysis | 3.3 Lab & Field        |
+| --------------------------- | ------------ | ------------------- | ---------------------- |
+| Scores + MTF + construction | Pips         | MTF + construction  | Full prose             |
+| Scores only                 | Pips         | Hidden              | Full prose             |
+| MTF + construction only     | Hidden       | MTF + construction  | `scoringStatus` phrase |
+| MTF only                    | Hidden       | MTF only            | `scoringStatus` phrase |
+| Construction only           | Hidden       | Construction only   | `scoringStatus` phrase |
+| Nothing                     | Hidden       | Hidden              | `scoringStatus` phrase |
+
+### Estimated word counts
+
+| Section              | Scored lens | Unscored + MTF + construction | Unscored + nothing |
+| -------------------- | ----------- | ----------------------------- | ------------------ |
+| 3.1 Overview         | 10–20       | —                             | —                  |
+| 3.2 Design Analysis  | 80–120      | 80–120                        | —                  |
+| 3.3 Lab & Field      | 120–180     | 20–30 (status phrase)         | 20–30              |
+| **Total OQ section** | **210–320** | **100–150**                   | **20–30**          |
+
+Combined with other page sections (Summary, Specs, Genre Fit, Reviews,
+Community, Alternatives), unscored lenses with MTF data reach **250–350
+words** — well above thin-content thresholds.
+
+## Alternatives considered
+
+| Alternative                                    | Rejected because                                                      |
+| ---------------------------------------------- | --------------------------------------------------------------------- |
+| Keep flat 4-cluster structure (ADR-026)        | No content for unscored lenses; no provenance distinction             |
+| Integrated "expected vs delivered" per cluster | Reads better for scored lenses but produces nothing for unscored ones |
+| Separate Optical Quality page (not section)    | Over-fragments the lens detail page; worse for SEO                    |
+
+## Consequences
+
+- Unscored lenses with MTF charts get ~100–150 words of optical content
+  where they previously got zero
+- Chinese budget brands become genuinely useful pages instead of thin
+  spec-only shells
+- Manufacturing variance disclaimer builds user trust — honest about
+  limitations without hiding data
+- Design analysis creates natural "upgrade path" content: user sees budget
+  lens MTF, then sees scored premium alternative with confirmed lab results
+- Requires backfilling `opticalElements`/`specialElements` on more lenses
+  (currently 1/244) — but MTF readings already cover 22 lenses
+- Phrase tables grow: MTF-to-phrase and construction-to-phrase tables needed
+  alongside existing score-to-phrase tables
+- Provenance is now visible to the user: "the design says X" vs "testing
+  confirmed Y" — aligns with #709 (OQ score provenance)
+- **Measured MTF (Sigma Art, Zeiss, Leica) can support scoring** as
+  evidence alongside reviews — these manufacturers test real production
+  lenses. Computed MTF (most others) describes design intent only.
+- **ADR-014 fallback #2 (MTF chart for astigmatism) stands** — S/M
+  divergence is the established way astigmatism manifests in MTF charts
+  (confirmed by Nikon USA, Eckhardt Optics). The earlier data analysis
+  that questioned this was methodologically flawed (compared computed MTF
+  against measured scores without accounting for the known gap).
+- Spikes #707 and #708 remain viable — scoped to confidence-tiered
+  content generation, with measured MTF enabling stronger claims than
+  computed MTF
+
+## Data requirements
+
+To populate Design Analysis at scale:
+
+1. **MTF readings** — continue digitizing with `mtf-extract-skeleton.py`
+   (22 lenses done, 31 charts available)
+2. **MTF source type** — track whether each lens's MTF is computed or
+   measured. New field: `mtfType?: "computed" | "measured"` on the MTF
+   data record. Defaults to `"computed"`. Sigma Art, Zeiss, Leica get
+   `"measured"`.
+3. **Optical construction** — backfill `opticalElements`, `opticalGroups`,
+   `specialElements` from manufacturer spec sheets (data is readily
+   available, just not yet entered)
+4. **Manufacturing consistency** — the variance disclaimer is now driven
+   by `mtfType` (computed vs measured) rather than a separate brand flag.
+   Computed MTF automatically gets the qualified language tier.
+
+## Implementation
+
+- `generateOpticalContent(lens, mtfReadings?) → OpticalContentSpine`
+- Three sub-generators: `generateOverview`, `generateDesignAnalysis`,
+  `generateLabTests`
+- MTF phrase tables: value ranges → natural-language descriptions
+- Construction phrase tables: special element types → optical implications
+- Variance disclaimer: driven by brand-level flag (TBD: field name and
+  location)
+- ADR-026 page structure updated: section 3 now references this ADR

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1992,3 +1992,65 @@ GSC data: 106/461 pages indexed (23%), ranking only for wiki content ("golden ra
 - Apply continuity fix to Sigma extraction tool (#726)
 - Evaluate skeletonization pipeline (#727)
 - Continue ADR-026 implementation (#694)
+
+---
+
+### Session 63 — MTF Extraction and Optical Quality Architecture
+
+**Tool:** Claude Opus 4.6 (1M context)
+
+#### PRs
+
+- #734 — skeletonization MTF extraction tool + ADR-029
+
+#### Issues closed
+
+- #727 — Skeletonization-based MTF curve extraction pipeline (spike, ADAPT)
+- #730 — MTF inference validation (spike, revised conclusions after literature review)
+
+#### Issues created
+
+- #732 — Collect missing tele-end MTF charts for Sigma zoom lenses
+- #733 — Evaluate contrast fields and consistency scoring for genre formulas
+
+#### Key changes
+
+- **MTF extraction tool v2** (`tools/mtf-extract-skeleton.py`):
+  Color isolation → skeletonize → connected components for S/M classification.
+  Sigma: no dilation, fragment width classifies solid vs dashed. Samyang: dilate
+  for anti-aliasing, 4-color masks. Occlusion fill for overlapping curves.
+  Auto-detects grid step (APS-C 2.5mm vs full-frame 5mm). Zero gaps across
+  all 31 charts (20 Samyang + 11 Sigma).
+
+- **Spike #730 revised conclusions**: Initially concluded MTF can't predict
+  scores (data correlation showed no signal). After authoritative literature
+  review (Nikon USA, Zeiss H.H. Nasse, LensRentals Roger Cicala, Eckhardt
+  Optics), revised: the optical relationships are valid (sharpness, astigmatism,
+  bokeh tendency). The limitation is computed vs measured MTF — not MTF itself.
+  ADR-014 fallback #2 stands.
+
+- **ADR-029**: Splits Optical Quality into Overview + Optical Design Analysis +
+  Lab & Field Tests. Design Analysis covers MTF chart analysis, rendering
+  character (contrast-resolution gap for "pop" vs clinical), stopped-down
+  behavior, cross-frame consistency, and optical construction. Confidence
+  tiers: measured MTF (Sigma Art, Zeiss, Leica) gets direct language,
+  computed MTF gets qualified language. Enables ~100-150 extra words for
+  unscored lenses.
+
+#### Key decisions
+
+- ADR-029 (supersedes ADR-026 section 3)
+- Rendering character readable from 10 vs 30 lp/mm gap — but current genre
+  scoring has no contrast fields, only resolution (#733 created)
+- Construction inference uses confident language ("controls CA" not "designed
+  to control") — these are physical optical properties
+- Variance disclaimer tied to computed vs measured MTF, not brand tier
+- Coating data needed for flare analysis (#99 updated with ADR-029 context)
+
+#### Next
+
+- Merge PR #734
+- #733 — evaluate contrast fields and consistency scoring for genre formulas
+- #726 — apply continuity fix to Sigma extraction tool
+- #728 — MTF chart wiki page
+- Continue ADR-026 implementation (#694)

--- a/tools/mtf-extract-skeleton.py
+++ b/tools/mtf-extract-skeleton.py
@@ -1,0 +1,992 @@
+"""Skeletonization-based MTF curve extraction (spike #727).
+
+Pipeline:
+  1. Color isolation — extract each curve by color into a binary mask
+  2. Skeletonization — reduce each curve to a 1px-wide skeleton
+  3. Connected components — classify solid vs dashed by fragment width
+  4. Y readout — read curve values at grid positions
+
+Samyang: 4 distinct colors, no S/M ambiguity — dilate + skeletonize + read.
+Sigma: 2 colors (red/blue), solid/dashed share color — skeletonize without
+       dilation, then connected components classify S vs M by fragment width.
+
+Usage:
+    py tools/mtf-extract-skeleton.py docs/mtf-charts/samyang-35mm-f1-2.png
+    py tools/mtf-extract-skeleton.py docs/mtf-charts/sigma-56mm-f1-4-dc-dn-c.png
+    py tools/mtf-extract-skeleton.py --compare docs/mtf-charts/samyang-35mm-f1-2.png
+"""
+
+import sys
+import glob
+import os
+import re
+import cv2
+import numpy as np
+from PIL import Image
+from skimage.morphology import skeletonize
+
+
+# ---------------------------------------------------------------------------
+# Chart type detection
+# ---------------------------------------------------------------------------
+
+def detect_chart_type(img):
+    """Detect whether chart is Samyang (4-color) or Sigma (red/blue).
+
+    Uses numpy for fast full-image scan — the curves may be concentrated
+    in a small vertical band that sparse sampling misses.
+    """
+    arr = np.array(img)
+    r, g, b = arr[:, :, 0].astype(int), arr[:, :, 1].astype(int), arr[:, :, 2].astype(int)
+
+    blue_count = int(np.sum((b > 160) & (r < 130) & ((b - r) > 60)))
+    pink_count = int(np.sum(
+        (r > 180) & (g > 80) & (b > 80) &
+        ((r - g) > 30) & ((r - b) > 20) & (g < 190)
+    ))
+
+    if blue_count > 100:
+        return "sigma"
+    if pink_count > 50:
+        return "samyang"
+    return "samyang"
+
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+def load_on_white(path):
+    img = Image.open(path)
+    if img.mode == "P":
+        img = img.convert("RGBA")
+    bg = Image.new("RGB", img.size, (255, 255, 255))
+    if img.mode == "RGBA":
+        bg.paste(img, mask=img.split()[3])
+    else:
+        bg.paste(img)
+    return bg
+
+
+def img_to_array(img):
+    return np.array(img)
+
+
+# ---------------------------------------------------------------------------
+# Color masks — Samyang (4 distinct colors)
+# ---------------------------------------------------------------------------
+
+def samyang_mask_dark_red(arr):
+    """10 lp/mm Sagittal — saturated dark red (~197,1,51)."""
+    r, g, b = arr[:, :, 0], arr[:, :, 1], arr[:, :, 2]
+    return (r > 160) & (g < 100) & (b < 120) & ((r.astype(int) - g.astype(int)) > 70)
+
+
+def samyang_mask_pink(arr):
+    """10 lp/mm Meridional — lighter pink (~225,127,152)."""
+    r, g, b = arr[:, :, 0], arr[:, :, 1], arr[:, :, 2]
+    return ((r > 180) & (g > 80) & (b > 80) &
+            ((r.astype(int) - g.astype(int)) > 30) &
+            ((r.astype(int) - b.astype(int)) > 20) &
+            (g < 190))
+
+
+def samyang_mask_dark_gray(arr):
+    """30 lp/mm Sagittal — dark gray (~102)."""
+    r, g, b = arr[:, :, 0].astype(int), arr[:, :, 1].astype(int), arr[:, :, 2].astype(int)
+    avg = (r + g + b) / 3
+    spread = np.maximum(np.maximum(r, g), b) - np.minimum(np.minimum(r, g), b)
+    not_red = ~samyang_mask_dark_red(arr)
+    not_pink = ~samyang_mask_pink(arr)
+    return (avg >= 85) & (avg <= 120) & (spread < 20) & not_red & not_pink
+
+
+def samyang_mask_light_gray(arr):
+    """30 lp/mm Meridional — medium gray (~178)."""
+    r, g, b = arr[:, :, 0].astype(int), arr[:, :, 1].astype(int), arr[:, :, 2].astype(int)
+    avg = (r + g + b) / 3
+    spread = np.maximum(np.maximum(r, g), b) - np.minimum(np.minimum(r, g), b)
+    not_red = ~samyang_mask_dark_red(arr)
+    not_pink = ~samyang_mask_pink(arr)
+    return (avg >= 160) & (avg <= 195) & (spread < 20) & not_red & not_pink
+
+
+# ---------------------------------------------------------------------------
+# Color masks — Sigma (red and blue, solid + dashed share color)
+# ---------------------------------------------------------------------------
+
+def sigma_mask_red(arr):
+    """10 lp/mm (both S and M) — red."""
+    r, g, b = arr[:, :, 0].astype(int), arr[:, :, 1].astype(int), arr[:, :, 2].astype(int)
+    return (r > 160) & (g < 130) & (b < 120) & ((r - g) > 50)
+
+
+def sigma_mask_blue(arr):
+    """30 lp/mm (both S and M) — blue."""
+    r, g, b = arr[:, :, 0].astype(int), arr[:, :, 1].astype(int), arr[:, :, 2].astype(int)
+    return (b > 160) & (r < 130) & ((b - r) > 60)
+
+
+# ---------------------------------------------------------------------------
+# Axis and grid detection (reused from existing tools)
+# ---------------------------------------------------------------------------
+
+def is_any_dark(r, g, b):
+    return r < 240 and g < 240 and b < 240
+
+
+def find_axis_and_plot(img, y_min, y_max):
+    w = img.size[0]
+    p = img.load()
+
+    best_x, best_count = 0, 0
+    for x in range(w // 4):
+        count = sum(1 for y in range(y_min, y_max) if is_any_dark(*p[x, y]))
+        if count > best_count:
+            best_count = count
+            best_x = x
+
+    runs = []
+    in_run = False
+    start = 0
+    for y in range(y_min, y_max):
+        if is_any_dark(*p[best_x, y]):
+            if not in_run:
+                in_run = True
+                start = y
+        else:
+            if in_run:
+                in_run = False
+                runs.append((start, y - 1))
+    if in_run:
+        runs.append((start, y_max - 1))
+
+    runs.sort(key=lambda r: -(r[1] - r[0]))
+    if not runs:
+        return best_x, y_min, y_max
+    y_top, y_bot = runs[0]
+    return best_x, y_top, y_bot
+
+
+def find_vertical_grids(img, ax_x, y_top, y_bot):
+    w = img.size[0]
+    p = img.load()
+
+    def is_grid(r, g, b):
+        return r < 250 and g < 250 and b < 250
+
+    col_density = []
+    for x in range(ax_x, w):
+        count = sum(1 for y in range(y_top, y_bot, 3) if is_grid(*p[x, y]))
+        col_density.append((x, count))
+
+    if not col_density:
+        return []
+
+    max_density = max(d[1] for d in col_density)
+    threshold = max_density * 0.12
+
+    peaks = []
+    in_peak = False
+    peak_data = []
+    for x, count in col_density:
+        if count > threshold:
+            if not in_peak:
+                in_peak = True
+                peak_data = []
+            peak_data.append((x, count))
+        else:
+            if in_peak:
+                in_peak = False
+                total_w = sum(c for _, c in peak_data)
+                centroid = sum(x * c for x, c in peak_data) / total_w
+                peaks.append((int(centroid), max(c for _, c in peak_data)))
+    if in_peak:
+        total_w = sum(c for _, c in peak_data)
+        centroid = sum(x * c for x, c in peak_data) / total_w
+        peaks.append((int(centroid), max(c for _, c in peak_data)))
+
+    filtered = []
+    for px, density in peaks:
+        if filtered and px - filtered[-1][0] < 40:
+            if density > filtered[-1][1]:
+                filtered[-1] = (px, density)
+        else:
+            filtered.append((px, density))
+
+    grid_xs = [px for px, _ in filtered]
+
+    if len(grid_xs) >= 3:
+        spacings = [grid_xs[i + 1] - grid_xs[i] for i in range(len(grid_xs) - 1)]
+        avg = sum(spacings[:-1]) / len(spacings[:-1]) if len(spacings) > 1 else spacings[0]
+        if len(spacings) > 1 and abs(spacings[-1] - avg) > avg * 0.3:
+            grid_xs = grid_xs[:-1]
+
+    return grid_xs
+
+
+def find_plot_split(img):
+    """Find the y-coordinate that splits two stacked plots (Samyang)."""
+    w, h = img.size
+    p = img.load()
+
+    x_lo = w // 4
+    x_hi = 3 * w // 4
+    row_density = []
+    for y in range(h):
+        count = 0
+        for x in range(x_lo, x_hi, 2):
+            r, g, b = p[x, y]
+            if r < 250 or g < 250 or b < 250:
+                count += 1
+        row_density.append(count)
+
+    mid_start = h // 4
+    mid_end = 3 * h // 4
+
+    best_gap_start = mid_start
+    best_gap_len = 0
+    gap_start = None
+
+    for y in range(mid_start, mid_end):
+        if row_density[y] < 3:
+            if gap_start is None:
+                gap_start = y
+        else:
+            if gap_start is not None:
+                gap_len = y - gap_start
+                if gap_len > best_gap_len:
+                    best_gap_len = gap_len
+                    best_gap_start = gap_start
+                gap_start = None
+    if gap_start is not None:
+        gap_len = mid_end - gap_start
+        if gap_len > best_gap_len:
+            best_gap_len = gap_len
+            best_gap_start = gap_start
+
+    return best_gap_start + best_gap_len // 2
+
+
+def detect_grid_step(grid_xs):
+    """Auto-detect grid step in mm (Samyang: 2/3/5mm)."""
+    n = len(grid_xs)
+    if n < 2:
+        return 2.0
+    avg_spacing = (grid_xs[-1] - grid_xs[0]) / (n - 1)
+    if avg_spacing >= 93:
+        return 5.0
+    elif avg_spacing >= 73:
+        return 3.0
+    else:
+        return 2.0
+
+
+def detect_sigma_grid_step(grid_xs):
+    """Auto-detect grid step for Sigma charts.
+
+    Sigma uses two formats:
+    - APS-C: 6 grids, 2.5mm step, 0-12.5mm range (~470px between grids)
+    - Full-frame: 5 grids, 5mm step, 0-20mm range (~615px between grids)
+
+    Pixel spacing threshold: 500px separates the two formats reliably.
+    """
+    n = len(grid_xs)
+    if n < 2:
+        return 2.5
+    avg_spacing = (grid_xs[-1] - grid_xs[0]) / (n - 1)
+    if avg_spacing > 500:
+        return 5.0
+    return 2.5
+
+
+# ---------------------------------------------------------------------------
+# Core: skeletonize a binary mask and extract y-values
+# ---------------------------------------------------------------------------
+
+def dilate_mask(mask, iterations=1):
+    """Dilate binary mask to connect anti-aliased fragments."""
+    from scipy.ndimage import binary_dilation
+    struct = np.ones((3, 3), dtype=bool)
+    return binary_dilation(mask, structure=struct, iterations=iterations)
+
+
+def skeleton_to_curve(skeleton, x_start, x_end, y_top, y_bot):
+    """Extract y-value at each x from a skeletonized binary image.
+
+    For each x column, find skeleton pixels in the plot region and return
+    their centroid. When multiple disconnected skeleton branches exist at
+    the same x (e.g. from dashed lines), cluster them and return all branches.
+
+    Returns dict: x -> list of y centroids (one per branch).
+    """
+    x_to_branches = {}
+    for x in range(max(0, x_start), min(skeleton.shape[1], x_end + 1)):
+        ys = np.where(skeleton[y_top:y_bot + 1, x])[0] + y_top
+        if len(ys) == 0:
+            continue
+
+        # Cluster y values into branches (gap > 3px = separate branch)
+        branches = []
+        current = [ys[0]]
+        for y in ys[1:]:
+            if y - current[-1] <= 3:
+                current.append(y)
+            else:
+                branches.append(current)
+                current = [y]
+        branches.append(current)
+
+        centroids = [sum(b) / len(b) for b in branches]
+        x_to_branches[x] = centroids
+
+    return x_to_branches
+
+
+def pick_continuous_curve(branches_map, x_positions, y_top, y_bot):
+    """From a branches map (x -> [y1, y2, ...]), pick the single continuous curve.
+
+    Uses left-to-right continuity: at each x, pick the branch closest to
+    the previous y value. This resolves multi-branch ambiguity from dashed
+    lines or noise.
+    """
+    x_to_y = {}
+    prev_y = None
+
+    # Process all x values in order
+    all_xs = sorted(branches_map.keys())
+    for x in all_xs:
+        centroids = branches_map[x]
+        if prev_y is not None:
+            best = min(centroids, key=lambda c: abs(c - prev_y))
+        else:
+            best = min(centroids)  # topmost = highest MTF
+        x_to_y[x] = best
+        prev_y = best
+
+    return x_to_y
+
+
+def split_solid_dashed_cc(skeleton_uint8, y_top, y_bot, x_start, label=""):
+    """Split a skeleton into solid (S) and dashed (M) curves using connected components.
+
+    After skeletonization WITHOUT dilation, solid lines remain as one or a few
+    large connected components spanning most of the x-axis. Dashed lines break
+    into many small fragments. cv2.connectedComponentsWithStats classifies them
+    by bounding box width.
+
+    Returns (solid_curve, dashed_curve) as x -> y dicts.
+    """
+    num_labels, labels, stats, centroids = cv2.connectedComponentsWithStats(
+        skeleton_uint8, connectivity=8
+    )
+
+    if num_labels <= 1:
+        return {}, None
+
+    # Collect component info (skip background label 0)
+    components = []
+    for i in range(1, num_labels):
+        width = stats[i, cv2.CC_STAT_WIDTH]
+        area = stats[i, cv2.CC_STAT_AREA]
+        x_min = stats[i, cv2.CC_STAT_LEFT]
+        y_min_c = stats[i, cv2.CC_STAT_TOP]
+        components.append({
+            "label": i, "width": width, "area": area,
+            "x_min": x_min, "y_min": y_min_c,
+        })
+
+    # Find the widest component — this anchors our threshold
+    max_width = max(c["width"] for c in components)
+
+    # Solid components span a large fraction of the plot width.
+    # Dashed fragments are narrow. Threshold: 15% of the widest component.
+    width_threshold = max(max_width * 0.15, 30)
+
+    solid_components = [c for c in components if c["width"] > width_threshold]
+    dashed_components = [c for c in components if c["width"] <= width_threshold]
+
+    solid_area = sum(c["area"] for c in solid_components)
+    dashed_area = sum(c["area"] for c in dashed_components)
+
+    if label:
+        print(f"    {label}: {len(solid_components)} solid components "
+              f"({solid_area}px), {len(dashed_components)} dashed fragments "
+              f"({dashed_area}px), threshold={width_threshold:.0f}px")
+
+    def components_to_curve(comp_list):
+        """Pool all component pixels into an x -> y mapping."""
+        curve = {}
+        for c in comp_list:
+            component_mask = (labels == c["label"])
+            ys, xs = np.where(component_mask)
+            for x, y in zip(xs, ys):
+                if y_top <= y <= y_bot and x >= x_start:
+                    if x not in curve or abs(y - curve.get(x, y)) < 5:
+                        # For each x, keep the centroid of nearby skeleton pixels
+                        if x in curve:
+                            curve[x] = (curve[x] + y) / 2
+                        else:
+                            curve[x] = float(y)
+        return curve
+
+    solid_curve = components_to_curve(solid_components)
+    dashed_curve = components_to_curve(dashed_components) if dashed_components else None
+
+    return solid_curve, dashed_curve
+
+
+# ---------------------------------------------------------------------------
+# Interpolate curve values at grid positions
+# ---------------------------------------------------------------------------
+
+def interpolate_at(curve_map, target_x, y_top, y_bot):
+    """Get MTF value at target_x from a curve map (x -> y).
+
+    Returns MTF value (0-1) or None.
+    """
+    if not curve_map:
+        return None
+
+    xs = sorted(curve_map.keys())
+    if not xs:
+        return None
+
+    def to_mtf(y):
+        return round(1.0 - (y - y_top) / (y_bot - y_top), 4)
+
+    # Exact or very close match
+    for x in xs:
+        if abs(x - target_x) <= 3:
+            return to_mtf(curve_map[x])
+
+    # Find bracketing
+    left_x = None
+    right_x = None
+    for x in xs:
+        if x <= target_x:
+            left_x = x
+        if x >= target_x and right_x is None:
+            right_x = x
+
+    if left_x is not None and right_x is not None:
+        gap = right_x - left_x
+        if gap <= 100:
+            t = (target_x - left_x) / gap
+            y = curve_map[left_x] + t * (curve_map[right_x] - curve_map[left_x])
+            return to_mtf(y)
+        # Gap too large for interpolation — fall through to nearest-point check
+
+    if left_x is not None and abs(left_x - target_x) <= 20:
+        return to_mtf(curve_map[left_x])
+    if right_x is not None and abs(right_x - target_x) <= 20:
+        return to_mtf(curve_map[right_x])
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Occlusion fill for Samyang (4-color z-order overlap)
+# ---------------------------------------------------------------------------
+
+def fill_occluded_samyang(readings):
+    """Fill missing values caused by z-order occlusion in Samyang charts.
+
+    When two curves share the same y-position in the PNG, the top-drawn color
+    hides the bottom one. Sibling pairs that can occlude each other:
+      - 10S (dark red) ↔ 10M (pink) — same frequency, different direction
+      - 30S (dark gray) ↔ 30M (light gray) — same frequency, different direction
+
+    Strategy: if one sibling is missing but the other is present, copy the
+    sibling's value. This is only valid when the curves genuinely overlap
+    (same y-position), which is the exact condition that causes occlusion.
+
+    Also fills cross-frequency occlusion: 30S/30M can be hidden by 10S/10M
+    when all four curves converge near the same value (common at center
+    positions on F8 plots).
+    """
+    result = [dict(r) for r in readings]
+
+    for r in result:
+        s10 = r["contrast10S"]
+        m10 = r["contrast10M"]
+        s30 = r["resolution30S"]
+        m30 = r["resolution30M"]
+
+        # Same-frequency sibling fill: 10S ↔ 10M
+        if s10 is None and m10 is not None:
+            r["contrast10S"] = m10
+        elif m10 is None and s10 is not None:
+            r["contrast10M"] = s10
+
+        # Same-frequency sibling fill: 30S ↔ 30M
+        if s30 is None and m30 is not None:
+            r["resolution30S"] = m30
+        elif m30 is None and s30 is not None:
+            r["resolution30M"] = s30
+
+        # Cross-frequency fill: all four curves converge at the same value.
+        # Re-read after sibling fill.
+        s10_now = r["contrast10S"]
+        m10_now = r["contrast10M"]
+        s30_now = r["resolution30S"]
+        m30_now = r["resolution30M"]
+
+        # 30 lp/mm both missing, 10 lp/mm present → 30 hidden under 10
+        if s30_now is None and m30_now is None and (s10_now or m10_now):
+            val = s10_now or m10_now
+            r["resolution30S"] = val
+            r["resolution30M"] = val
+
+        # 10 lp/mm both missing, 30 lp/mm present → all four overlapping
+        # (10 lp/mm ≥ 30 lp/mm, so at convergence they share the same value)
+        if s10_now is None and m10_now is None and (s30_now or m30_now):
+            r["contrast10S"] = s30_now or m30_now
+            r["contrast10M"] = m30_now or s30_now
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Process Samyang chart (4 colors, 2 stacked plots)
+# ---------------------------------------------------------------------------
+
+def process_samyang_plot(img, arr, y_min, y_max, label):
+    """Extract MTF readings from one Samyang plot region using skeletonization."""
+    ax_x, y_top, y_bot = find_axis_and_plot(img, y_min, y_max)
+    grid_xs = find_vertical_grids(img, ax_x, y_top, y_bot)
+    n = len(grid_xs)
+
+    if n < 2:
+        print(f"  [{label}] WARNING: only {n} grid lines found, skipping")
+        return None, [], []
+
+    x_step = detect_grid_step(grid_xs)
+    x_left = grid_xs[0]
+    x_right = grid_xs[-1]
+    x_max_mm = x_step * (n - 1)
+    px_per_mm = (x_right - x_left) / x_max_mm
+
+    print(f"  [{label}] axis={ax_x}, plot y={y_top}..{y_bot} ({y_bot - y_top}px)")
+    print(f"  [{label}] grids ({n}): {grid_xs}, step={x_step}mm, max={x_max_mm}mm")
+
+    # Crop array to plot region for mask generation
+    plot_arr = arr.copy()
+
+    # Generate color masks
+    mask_10s = samyang_mask_dark_red(plot_arr)
+    mask_10m = samyang_mask_pink(plot_arr)
+    mask_30s = samyang_mask_dark_gray(plot_arr)
+    mask_30m = samyang_mask_light_gray(plot_arr)
+
+    # Restrict to plot region
+    for mask in [mask_10s, mask_10m, mask_30s, mask_30m]:
+        mask[:y_top, :] = False
+        mask[y_bot + 1:, :] = False
+        mask[:, :ax_x + 2] = False
+
+    # Dilate to connect anti-aliased fragments, then skeletonize
+    curves = {}
+    for name, mask in [("10S", mask_10s), ("10M", mask_10m),
+                       ("30S", mask_30s), ("30M", mask_30m)]:
+        pixel_count = np.sum(mask)
+        if pixel_count < 10:
+            print(f"  [{label}] {name}: only {pixel_count} pixels, skipping")
+            curves[name] = {}
+            continue
+
+        dilated = dilate_mask(mask, iterations=1)
+        skel = skeletonize(dilated)
+        skel_pixels = np.sum(skel)
+        print(f"  [{label}] {name}: {pixel_count} color pixels -> {skel_pixels} skeleton pixels")
+
+        branches = skeleton_to_curve(skel, ax_x + 3, img.size[0], y_top, y_bot)
+        curve = pick_continuous_curve(branches, range(ax_x + 3, img.size[0]), y_top, y_bot)
+        curves[name] = curve
+
+    # Build position list
+    positions = [round(i * x_step, 1) for i in range(n)]
+
+    # Check for edge extension
+    if curves["10S"]:
+        edge_x = max(curves["10S"].keys())
+        edge_mm = round((edge_x - x_left) / px_per_mm, 1)
+        if edge_mm > positions[-1] + x_step * 0.3:
+            edge_pos = round(edge_mm * 2) / 2
+            positions.append(edge_pos)
+            print(f"  [{label}] edge at ~{edge_mm}mm, adding position {edge_pos}mm")
+
+    # Read values at grid positions
+    readings = []
+    for pos in positions:
+        xp = int(x_left + pos * px_per_mm)
+        readings.append({
+            "position": pos,
+            "contrast10S": interpolate_at(curves["10S"], xp, y_top, y_bot),
+            "contrast10M": interpolate_at(curves["10M"], xp, y_top, y_bot),
+            "resolution30S": interpolate_at(curves["30S"], xp, y_top, y_bot),
+            "resolution30M": interpolate_at(curves["30M"], xp, y_top, y_bot),
+        })
+
+    # Fill occluded values — when curves overlap in the PNG, the top layer
+    # hides the one underneath. Sibling pairs: 10S↔10M, 30S↔30M.
+    readings = fill_occluded_samyang(readings)
+
+    return x_step, positions, readings
+
+
+# ---------------------------------------------------------------------------
+# M-value interpolation for overlapping regions
+# ---------------------------------------------------------------------------
+
+def interpolate_missing_m(readings):
+    """Fill missing M values where S and M curves overlap.
+
+    At center positions where solid and dashed lines coincide, the dashed
+    fragments merge into the solid component during skeletonization, leaving
+    M undetected. Strategy:
+
+    1. Find the first position where M is detected.
+    2. For positions before that: set M = S (curves are coincident at center).
+    3. For interior gaps: linear interpolation between nearest detected M values.
+
+    Applies independently to 10 lp/mm and 30 lp/mm pairs.
+    """
+    result = [dict(r) for r in readings]
+    n = len(result)
+
+    for s_key, m_key in [("contrast10S", "contrast10M"),
+                         ("resolution30S", "resolution30M")]:
+        s_vals = [r[s_key] for r in result]
+        m_vals = [r[m_key] for r in result]
+
+        # Find first and last detected M
+        first_m = next((i for i in range(n) if m_vals[i] is not None), None)
+        last_m = next((i for i in range(n - 1, -1, -1) if m_vals[i] is not None), None)
+
+        if first_m is None:
+            # No M detected at all — set M = S everywhere
+            for i in range(n):
+                if s_vals[i] is not None:
+                    result[i][m_key] = s_vals[i]
+            continue
+
+        # Fill positions before first detected M with M = S
+        for i in range(first_m):
+            if s_vals[i] is not None and m_vals[i] is None:
+                result[i][m_key] = s_vals[i]
+
+        # Fill interior gaps by linear interpolation
+        for i in range(first_m + 1, (last_m or n)):
+            if m_vals[i] is None and s_vals[i] is not None:
+                left = next((j for j in range(i - 1, -1, -1) if m_vals[j] is not None), None)
+                right = next((j for j in range(i + 1, n) if m_vals[j] is not None), None)
+                if left is not None and right is not None:
+                    t = (i - left) / (right - left)
+                    result[i][m_key] = round(
+                        m_vals[left] + t * (m_vals[right] - m_vals[left]), 4
+                    )
+                elif left is not None:
+                    result[i][m_key] = s_vals[i]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Process Sigma chart (2 colors, solid/dashed, single plot)
+# ---------------------------------------------------------------------------
+
+def process_sigma(img, arr):
+    """Extract MTF readings from a Sigma chart.
+
+    Pipeline: color mask (no dilation) -> skeletonize -> connected components
+    -> classify solid/dashed by fragment width -> reassemble curves -> read values.
+
+    Sigma PNGs are palette-based with no anti-aliasing, so no dilation is needed.
+    This preserves dash gaps for accurate S/M classification.
+    """
+    ax_x, y_top, y_bot = find_axis_and_plot(img, 0, img.size[1])
+    grid_xs = find_vertical_grids(img, ax_x, y_top, y_bot)
+    n = len(grid_xs)
+
+    print(f"  Axis: x={ax_x}, plot: y={y_top}..{y_bot} ({y_bot - y_top}px)")
+    print(f"  Grids ({n}): {grid_xs}")
+
+    if n < 2:
+        print("  WARNING: insufficient grid lines")
+        return
+
+    x_left = grid_xs[0]
+    x_right = grid_xs[-1]
+    x_step = detect_sigma_grid_step(grid_xs)
+    x_max_mm = x_step * (n - 1)
+    px_per_mm = (x_right - x_left) / x_max_mm
+    print(f"  Grid step: {x_step}mm, range: 0-{x_max_mm}mm")
+
+    # Generate color masks
+    mask_red = sigma_mask_red(arr)
+    mask_blue = sigma_mask_blue(arr)
+
+    # Restrict to plot region
+    for mask in [mask_red, mask_blue]:
+        mask[:y_top, :] = False
+        mask[y_bot + 1:, :] = False
+        mask[:, :ax_x + 2] = False
+
+    # Skeletonize each color WITHOUT dilation — preserves dash gaps
+    results = {}
+    for name, mask in [("red(10)", mask_red), ("blue(30)", mask_blue)]:
+        pixel_count = int(np.sum(mask))
+        skel = skeletonize(mask)
+        skel_uint8 = skel.astype(np.uint8) * 255
+        skel_pixels = int(np.sum(skel))
+        print(f"  {name}: {pixel_count} color pixels -> {skel_pixels} skeleton pixels")
+
+        # Connected components classify solid vs dashed by fragment width
+        solid, dashed = split_solid_dashed_cc(
+            skel_uint8, y_top, y_bot, ax_x + 3, label=name
+        )
+        results[name] = (solid, dashed)
+
+    solid_10, dashed_10 = results["red(10)"]
+    solid_30, dashed_30 = results["blue(30)"]
+
+    # Build positions
+    positions = [round(i * x_step, 1) for i in range(n)]
+
+    # Edge detection
+    edge_curve = solid_10 or dashed_10
+    if edge_curve:
+        edge_x = max(edge_curve.keys())
+        edge_mm = round((edge_x - x_left) / px_per_mm, 1)
+        if edge_mm > positions[-1] + 0.5:
+            edge_pos = round(edge_mm * 2) / 2
+            positions.append(edge_pos)
+            print(f"  Edge at ~{edge_mm}mm, adding position {edge_pos}mm")
+
+    # Read raw values
+    raw_readings = []
+    for pos in positions:
+        xp = int(x_left + pos * px_per_mm)
+        raw_readings.append({
+            "position": pos,
+            "contrast10S": interpolate_at(solid_10, xp, y_top, y_bot),
+            "contrast10M": interpolate_at(dashed_10, xp, y_top, y_bot) if dashed_10 else None,
+            "resolution30S": interpolate_at(solid_30, xp, y_top, y_bot),
+            "resolution30M": interpolate_at(dashed_30, xp, y_top, y_bot) if dashed_30 else None,
+        })
+
+    # Interpolate missing M values — where S and M overlap at center, dashed
+    # fragments merge into the solid component so M is undetected. Fill M from
+    # S (curves are coincident) or interpolate from nearest detected M values.
+    readings = interpolate_missing_m(raw_readings)
+
+    return positions, readings
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def print_table(positions, readings):
+    print(f"  {'Pos':>5}  {'10S':>6}  {'10M':>6}  {'30S':>6}  {'30M':>6}")
+    print("  " + "-" * 38)
+    for r in readings:
+        def fmt(v):
+            return f"{v:.3f}" if v is not None else "  --- "
+        print(
+            f"  {r['position']:5.1f}  "
+            f"{fmt(r['contrast10S'])}  {fmt(r['contrast10M'])}  "
+            f"{fmt(r['resolution30S'])}  {fmt(r['resolution30M'])}"
+        )
+
+
+def print_typescript(aperture_label, readings):
+    print(f"      {{")
+    print(f'        aperture: "{aperture_label}",')
+    print(f"        readings: [")
+    for r in readings:
+        s10 = r["contrast10S"]
+        m10 = r["contrast10M"]
+        s30 = r["resolution30S"]
+        m30 = r["resolution30M"]
+        if s10 is None and m10 is None and s30 is None and m30 is None:
+            continue
+        if s10 is None:
+            s10 = m10 if m10 is not None else 0
+        if m10 is None:
+            m10 = s10
+        if m30 is None:
+            m30 = s30 if s30 is not None else 0
+        if s30 is None:
+            s30 = m30 if m30 is not None else 0
+        print(
+            f"          {{ position: {r['position']}, "
+            f"contrast10S: {round(s10, 2)}, contrast10M: {round(m10, 2)}, "
+            f"resolution30S: {round(s30, 2)}, resolution30M: {round(m30, 2)} }},"
+        )
+    print(f"        ],")
+    print(f"      }},")
+
+
+# ---------------------------------------------------------------------------
+# Comparison mode — run both old and new, show diffs
+# ---------------------------------------------------------------------------
+
+def compare_samyang(path):
+    """Run both extraction methods and compare results."""
+    # Import the old tool's functions
+    sys.path.insert(0, os.path.dirname(__file__))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "old_samyang",
+        os.path.join(os.path.dirname(__file__), "mtf-extract-samyang.py")
+    )
+    old_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(old_mod)
+
+    img = load_on_white(path)
+    arr = img_to_array(img)
+    w, h = img.size
+
+    split_y = find_plot_split(img)
+
+    print("=" * 60)
+    print(f"COMPARISON: {os.path.basename(path)}")
+    print("=" * 60)
+
+    for region, y_min, y_max, label in [(0, 0, split_y, "MAX"), (1, split_y, h, "F8")]:
+        print(f"\n--- {label} aperture ---")
+
+        # New (skeleton)
+        print("\n[SKELETON]")
+        new_step, new_pos, new_readings = process_samyang_plot(img, arr, y_min, y_max, label)
+
+        # Old (pixel scan)
+        print("\n[PIXEL SCAN]")
+        old_step, old_pos, old_readings = old_mod.process_plot(img, y_min, y_max, label)
+
+        if not new_readings or not old_readings:
+            print("  Skipped (no data)")
+            continue
+
+        # Compare at matching positions
+        print(f"\n  {'Pos':>5}  {'10S diff':>8}  {'10M diff':>8}  {'30S diff':>8}  {'30M diff':>8}")
+        print("  " + "-" * 50)
+
+        diffs = []
+        for nr in new_readings:
+            # Find matching old reading
+            old_r = None
+            for o in old_readings:
+                if abs(o["position"] - nr["position"]) < 0.01:
+                    old_r = o
+                    break
+            if old_r is None:
+                continue
+
+            row_diffs = []
+            for key in ["contrast10S", "contrast10M", "resolution30S", "resolution30M"]:
+                nv = nr[key]
+                ov = old_r[key]
+                if nv is not None and ov is not None:
+                    d = nv - ov
+                    row_diffs.append(d)
+                    diffs.append(abs(d))
+                else:
+                    row_diffs.append(None)
+
+            def fmt_diff(d):
+                if d is None:
+                    return "   ---  "
+                sign = "+" if d >= 0 else ""
+                return f"{sign}{d:7.4f}"
+
+            print(
+                f"  {nr['position']:5.1f}  "
+                f"{fmt_diff(row_diffs[0])}  {fmt_diff(row_diffs[1])}  "
+                f"{fmt_diff(row_diffs[2])}  {fmt_diff(row_diffs[3])}"
+            )
+
+        if diffs:
+            avg = sum(diffs) / len(diffs)
+            mx = max(diffs)
+            print(f"\n  Mean |diff|: {avg:.4f}  Max |diff|: {mx:.4f}  N={len(diffs)}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def process_file(path, compare=False):
+    if compare:
+        compare_samyang(path)
+        return
+
+    img = load_on_white(path)
+    arr = img_to_array(img)
+    w, h = img.size
+    chart_type = detect_chart_type(img)
+    print(f"\nImage: {path} ({w}x{h}) — detected: {chart_type}")
+
+    if chart_type == "sigma":
+        result = process_sigma(img, arr)
+        if result:
+            positions, readings = result
+            print()
+            print_table(positions, readings)
+            print()
+            print("// TypeScript readings:")
+            print_typescript("f/?", readings)
+
+    else:  # samyang
+        split_y = find_plot_split(img)
+        print(f"Plot split at y={split_y}")
+
+        # MAX aperture
+        print()
+        step1, pos1, readings1 = process_samyang_plot(img, arr, 0, split_y, "MAX")
+        if readings1:
+            print_table(pos1, readings1)
+
+        # F8
+        print()
+        step2, pos2, readings2 = process_samyang_plot(img, arr, split_y, h, "F8")
+        if readings2:
+            print_table(pos2, readings2)
+
+        # TypeScript output
+        print()
+        print("// TypeScript readings:")
+        name = os.path.splitext(os.path.basename(path))[0]
+        match = re.search(r'-f(\d+(?:-\d+)?)', name)
+        aperture_label = f"f/{match.group(1).replace('-', '.')}" if match else "f/?"
+        if readings1:
+            print_typescript(aperture_label, readings1)
+        if readings2:
+            print_typescript("f/8", readings2)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: py tools/mtf-extract-skeleton.py <image.png> [image2.png ...]")
+        print("       py tools/mtf-extract-skeleton.py --compare <samyang-image.png>")
+        sys.exit(1)
+
+    compare = "--compare" in sys.argv
+    files = []
+    for arg in sys.argv[1:]:
+        if arg == "--compare":
+            continue
+        expanded = glob.glob(arg)
+        if expanded:
+            files.extend(expanded)
+        else:
+            files.append(arg)
+
+    for path in sorted(files):
+        process_file(path, compare=compare)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Spike #727: Skeletonization-based MTF curve extraction tool (`tools/mtf-extract-skeleton.py`) — color isolation → skeletonize → connected components for solid/dashed classification. Zero gaps across all 31 charts.
- Spike #730: Validated MTF inference rules against authoritative optics literature. MTF reliably reveals sharpness, astigmatism, bokeh tendency, field curvature. Key variable is computed vs measured MTF.
- ADR-029: Splits Optical Quality into Overview + Optical Design Analysis + Lab & Field Tests. Enables meaningful content for unscored lenses.

## Test plan

- [x] `npm run validate` passes
- [x] Skeleton tool tested on all 31 charts (20 Samyang + 11 Sigma)
- [x] Zero data gaps in extraction output
- [x] S/M classification verified against visual chart inspection
- [x] Full-frame grid step auto-detection verified (Sigma 100-400mm)

Closes #727, closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)