### PR TITLE
fix: downgrade Pages actions to v4 — v5 SHA unreachable on GitHub CDN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - run: npm run validate
 
       # Package dist/ as a GitHub Pages artifact for the deploy job
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist/
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       # Deploy the uploaded artifact to GitHub Pages
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Downgrades `actions/upload-pages-artifact` and `actions/deploy-pages` from v5 to v4
- v5 tag (SHA `fc324d35`) consistently fails to download during workflow setup — GitHub CDN returns 404 for the tarball
- v4 uses a different SHA (`7b1f4a76`) and was the last stable version

## Test plan
- [ ] CI passes on this PR (proves the actions download correctly)
- [ ] Deploy succeeds after merge to main

Generated with [Claude Code](https://claude.com/claude-code)