### PR TITLE
feat: improve optical specs research workflow (#846)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Project-specific overrides and additions follow below.
 - `tools/viltrox/` — Viltrox optical spec extraction (fetch_specs, audit, download_images, Shopify JSON + HTML scraping)
 - `tools/zeiss/` — Carl Zeiss optical spec extraction (fetch_specs, audit, PDF datasheet download)
 - `tools/mitakon/` — Mitakon optical spec extraction (fetch_specs, audit, SeleniumBase UC for zyoptics.net)
+- `tools/lenstip/` — LensTip lens index (build_index, search); local JSON index of 2300+ lenses for instant ID lookup
+- `tools/lookup.py` — unified lens lookup; generates research URLs for all PLAYBOOK 2.8 sources in one shot
 - `tools/` — MTF extraction tools (mtf-extract-skeleton.py), page fetch utility, `FETCH-PAGE.md` dev journal
 
 ### 1.3 Commands
@@ -297,8 +299,9 @@ Follow `docs/solid-ai-templates/templates/base/workflow/scope.md` for scope guar
 2. Check `git status` — if uncommitted changes exist, resolve before starting
 3. Clean up stale branches: `git fetch --prune` to remove stale remote tracking refs, then `git branch --merged main | grep -v main` to delete merged local branches
 4. Check deploy health: `gh run list --branch main --limit 1` — if the latest deploy is not `completed/success`, flag it before starting work
-5. Ask: "What's the theme for this session?" — agree on ONE theme
-6. Review open issues for that theme before writing code
+5. Check open PRs: `gh pr list --state open` — flag Dependabot bumps, stale PRs, or anything awaiting review
+6. Ask: "What's the theme for this session?" — agree on ONE theme
+7. Review open issues for that theme before writing code
 
 ### 6.2 During the session
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 - Run `npm run validate` before committing
 - Releases MUST follow PLAYBOOK 5.1 — never tag without bumping `package.json` first
 - When creating GitHub issues, follow the formats in `docs/solid-ai-templates/templates/base/workflow/issues.md` — use the correct label (`epic`, `bug`, `incident`, `question`) and body structure for each type
+- Every issue MUST have a type label, a priority label (P0–P4), and a milestone assigned at creation — no exceptions
 - Creating a new directory or moving content between documents is an architectural decision — write the ADR **at the moment of the decision**, before creating the files
 - Always ask before auto-merging PRs — never set `--auto` without explicit user permission
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -400,6 +400,8 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
    - Radojuva
    - DPReview
    - Google Image Search (construction diagram + MTF chart)
+   - If these five come up empty, continue down the source reference table
+     below until data is found or all sources are exhausted
 6. **Verify** extracted data against diagrams and official pages — element/group
    counts, special elements, coatings (including protective), X-mount dimensions
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -380,59 +380,69 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
 
 ### 2.8 Fill and verify tech specs per brand
 
-1. **Verify the brand's full lens lineup first** — before researching individual
-   lens specs, confirm every X-mount and GFX lens the brand offers. Do not
-   assume the database is complete. Cross-reference against:
-   - Official manufacturer product pages or catalog
-   - Retailers (B&H, Adorama) — search `<brand> Fuji X mount`
-   - [alikgriffin.com X-mount list](https://alikgriffin.com/a-complete-list-of-fujifilm-x-mount-lenses/) and [GFX list](https://alikgriffin.com/fujifilm-g-lenses-the-ultimate-list/) — note: lens tables are AJAX-loaded (Ninja Tables plugin), not in page HTML; use the API endpoint `https://alikgriffin.com/wp-admin/admin-ajax.php?action=wp_ajax_ninja_tables_public_action&table_id=<ID>&target_action=get-all-data` to fetch data, or ask the user to paste the table
-   - If missing lenses are found, create a separate issue before continuing
-2. Run `npx tsx scripts/audit-brand.ts <Brand>` to see gaps
-3. Run the brand extraction tool if available: `py tools/<brand>/fetch_specs.py`
-4. **Generate research URLs** — run `py tools/lookup.py "<lens name>"` to get direct
-   links and search URLs for all sources in one shot. For LensTip, the tool uses
-   the local index (`tools/lenstip/lenstip-index.json`) to resolve the opaque numeric
-   ID automatically. To rebuild the index: `py tools/lenstip/build_index.py`
-5. Research missing fields from these sources (priority order):
-   - Official manufacturer pages (dimensions, filter thread, build features)
-   - DPReview spec database (`dpreview.com/products/<brand>/lenses/<slug>`) — comprehensive specs including magnification; manufacturer descriptions often contain data not on official pages
-   - LensTip spec database (`lenstip.com/<id>-<name>-lens_specifications.html`) — best for maxMagnification on budget lenses; use `py tools/lenstip/search.py "<lens>"` to find the page ID
-   - Radojuva lens database (`radojuva.com`) — hands-on magnification measurements and detailed optical data
-   - digitalkamera.de Datenblatt pages — good for dimensions, rarely has magnification
-   - cameradecision.com via `fetch-page.py` (403s on direct fetch, Playwright bypasses)
-   - Mobile01 (`mobile01.com`) — Taiwan's largest tech forum; staff reviewers with systematic testing, construction diagrams from manufacturers; especially good for Chinese/Taiwanese brands (Kamlan, etc.); requires SeleniumBase UC mode to fetch (Akamai CDN blocks headless browsers)
-   - Photography Life lens database (`photographylife.com/lenses/<slug>`) — spec tables with magnification, construction diagrams, special elements
-   - Dustin Abbott / Phillip Reeve reviews — trust-3 field measurements
-   - Duclos Lenses (`ducloslenses.com`) — reliable spec tables for cinema lenses (length, weight, min focus)
-   - **Google Image Search** for construction diagrams and MTF charts — text-based searches miss images on non-English blogs, press kit reposts, and pages with minimal surrounding text; search `<brand> <model> optical construction diagram` or `<brand> <model> MTF chart`
-   - **Image filename caveat:** when checking article pages for diagrams and MTF charts, do not rely on image filename keywords alone — news sites use generic filenames (e.g. `APO200F14-lens.jpg` for a combined construction diagram + MTF chart). For pages with a small number of images (< 10), download and visually check all content images rather than filtering by filename patterns.
-6. **LensTip page ID caveat:** URL names are ignored; only the numeric ID matters. Always verify `Manufacturer` and `Model` fields on the page — wrong IDs redirect silently to unrelated lenses.
-7. Verify extracted data against downloaded images and official pages:
-   - Count elements and groups in construction diagrams — must match `opticalElements` and `opticalGroups`
-   - Identify special elements (aspherical, LD, ED) marked in diagrams — must match `specialElements`
-   - Check that all coatings on the product page are captured, including protective coatings (fluorine, water-repellent) that are often listed separately from optical coatings (AR, multi-coating)
-   - For lenses with X-mount variants, verify physical specs (weight, length, diameter) use X-mount values, not Sony E or other mounts
-8. **Per-lens provenance workflow** (mandatory sequence for every lens touched):
-   1. Run `py tools/lookup.py "<lens name>"` to generate all research URLs
-   2. Check each mandatory source and record the result in specs-log.md (found/not found/404/paywall)
-   3. User confirms or corrects findings
-   4. Update `specs-log.md` FIRST — document the source, date, result, and caveats
-   5. Edit `lenses.ts` — apply the verified data
-   6. Confirm both files updated before moving to the next lens
-   - The specs-log is the **primary deliverable** — data without provenance is unverifiable
-   - If lenses share optical design across mounts (e.g. X + GFX), update BOTH specs-logs
-   - **Mandatory source checklist** — every specs-log MUST include a row for each of
-     these sources, even if the result is "Not found":
-     1. Official manufacturer page
-     2. LensTip (use `py tools/lenstip/search.py "<lens>"` for the page ID)
-     3. Radojuva
-     4. DPReview
-     5. Google Image Search (construction diagram + MTF chart)
-9. Add fields to `src/data/lenses.ts`, run `npm run validate`
-10. If adding `maxMagnification` to a scored lens, also add `macro` genre mark (test will fail if missing)
-11. **Audit false negatives** — periodically run `py tools/lenstip/audit_specslog.py --fix`
-    to find specs-logs that say "Not covered" but where LensTip actually has a page.
-    Rebuild the index quarterly: `py tools/lenstip/build_index.py`
+#### Phase 1 — Prepare
+
+1. **Verify the brand's full lineup** — confirm every X-mount and GFX lens
+   the brand offers before researching individual specs. Cross-reference
+   official catalog, retailers (B&H, Adorama), and
+   [alikgriffin.com](https://alikgriffin.com/a-complete-list-of-fujifilm-x-mount-lenses/).
+   Create a separate issue for any missing lenses.
+2. **Audit gaps** — run `npx tsx scripts/audit-brand.ts <Brand>`
+3. **Run extraction tool** if available: `py tools/<brand>/fetch_specs.py`
+
+#### Phase 2 — Research each lens
+
+4. **Generate research URLs** — `py tools/lookup.py "<lens name>"`
+5. **Check each source** and record result in `specs-log.md` (found / not found / 404 / paywall).
+   Every specs-log MUST include a row for at least these five sources:
+   - Official manufacturer page
+   - LensTip (`py tools/lenstip/search.py "<lens>"` resolves the page ID)
+   - Radojuva
+   - DPReview
+   - Google Image Search (construction diagram + MTF chart)
+6. **Verify** extracted data against diagrams and official pages — element/group
+   counts, special elements, coatings (including protective), X-mount dimensions
+
+#### Phase 3 — Commit per lens
+
+7. Update `specs-log.md` FIRST — the specs-log is the primary deliverable
+8. Edit `lenses.ts` — apply the verified data
+9. Confirm both files updated before moving to the next lens
+10. Run `npm run validate`
+11. If adding `maxMagnification` to a scored lens, also add `macro` genre mark
+
+#### Maintenance
+
+- **Audit false negatives** — `py tools/lenstip/audit_specslog.py --fix`
+- **Rebuild LensTip index** quarterly — `py tools/lenstip/build_index.py`
+
+#### Source reference (priority order)
+
+| Source                        | Best for                                  | Notes                                  |
+| ----------------------------- | ----------------------------------------- | -------------------------------------- |
+| Official manufacturer         | Dimensions, filter thread, build features | Always check first                     |
+| DPReview                      | Comprehensive specs incl. magnification   | Archived but still available           |
+| LensTip                       | maxMagnification on budget lenses         | Opaque numeric IDs — use the index     |
+| Radojuva                      | Hands-on magnification measurements       | Multi-language, search all variants    |
+| digitalkamera.de              | Dimensions                                | Rarely has magnification               |
+| cameradecision.com            | Spec comparison                           | 403s on direct fetch, use Playwright   |
+| Mobile01                      | Construction diagrams, Chinese brands     | Requires SeleniumBase UC               |
+| Photography Life              | Spec tables, diagrams, special elements   | Predictable URL pattern                |
+| Dustin Abbott / Phillip Reeve | Trust-3 field measurements                | Thorough optical analysis              |
+| Duclos Lenses                 | Cinema lens specs                         | Length, weight, min focus              |
+| Google Image Search           | Construction diagrams, MTF charts         | Text searches miss non-English sources |
+
+#### Caveats
+
+- **LensTip IDs:** URL names are ignored; only the numeric ID matters. Verify
+  `Manufacturer` and `Model` on the page — wrong IDs redirect silently.
+- **Image filenames:** do not filter by filename keywords — news sites use
+  generic names (e.g. `APO200F14-lens.jpg` for a combined diagram + MTF).
+  For pages with < 10 images, visually check all content images.
+- **Mount variants:** if lenses share optical design across mounts, update
+  BOTH specs-logs.
+- **alikgriffin.com tables:** AJAX-loaded (Ninja Tables plugin), not in page
+  HTML. Use the admin-ajax API endpoint or ask the user to paste the table.
 
 ## 3. Quality
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -413,15 +413,26 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
    - Check that all coatings on the product page are captured, including protective coatings (fluorine, water-repellent) that are often listed separately from optical coatings (AR, multi-coating)
    - For lenses with X-mount variants, verify physical specs (weight, length, diameter) use X-mount values, not Sony E or other mounts
 8. **Per-lens provenance workflow** (mandatory sequence for every lens touched):
-   1. Check source (official page, diagram, third-party review)
-   2. User confirms or corrects findings
-   3. Update `specs-log.md` FIRST — document the source, date, result, and caveats
-   4. Edit `lenses.ts` — apply the verified data
-   5. Confirm both files updated before moving to the next lens
+   1. Run `py tools/lookup.py "<lens name>"` to generate all research URLs
+   2. Check each mandatory source and record the result in specs-log.md (found/not found/404/paywall)
+   3. User confirms or corrects findings
+   4. Update `specs-log.md` FIRST — document the source, date, result, and caveats
+   5. Edit `lenses.ts` — apply the verified data
+   6. Confirm both files updated before moving to the next lens
    - The specs-log is the **primary deliverable** — data without provenance is unverifiable
    - If lenses share optical design across mounts (e.g. X + GFX), update BOTH specs-logs
+   - **Mandatory source checklist** — every specs-log MUST include a row for each of
+     these sources, even if the result is "Not found":
+     1. Official manufacturer page
+     2. LensTip (use `py tools/lenstip/search.py "<lens>"` for the page ID)
+     3. Radojuva
+     4. DPReview
+     5. Google Image Search (construction diagram + MTF chart)
 9. Add fields to `src/data/lenses.ts`, run `npm run validate`
 10. If adding `maxMagnification` to a scored lens, also add `macro` genre mark (test will fail if missing)
+11. **Audit false negatives** — periodically run `py tools/lenstip/audit_specslog.py --fix`
+    to find specs-logs that say "Not covered" but where LensTip actually has a page.
+    Rebuild the index quarterly: `py tools/lenstip/build_index.py`
 
 ## 3. Quality
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -389,10 +389,14 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
    - If missing lenses are found, create a separate issue before continuing
 2. Run `npx tsx scripts/audit-brand.ts <Brand>` to see gaps
 3. Run the brand extraction tool if available: `py tools/<brand>/fetch_specs.py`
-4. Research missing fields from these sources (priority order):
+4. **Generate research URLs** — run `py tools/lookup.py "<lens name>"` to get direct
+   links and search URLs for all sources in one shot. For LensTip, the tool uses
+   the local index (`tools/lenstip/lenstip-index.json`) to resolve the opaque numeric
+   ID automatically. To rebuild the index: `py tools/lenstip/build_index.py`
+5. Research missing fields from these sources (priority order):
    - Official manufacturer pages (dimensions, filter thread, build features)
    - DPReview spec database (`dpreview.com/products/<brand>/lenses/<slug>`) — comprehensive specs including magnification; manufacturer descriptions often contain data not on official pages
-   - LensTip spec database (`lenstip.com/<id>-<name>-lens_specifications.html`) — best for maxMagnification on budget lenses
+   - LensTip spec database (`lenstip.com/<id>-<name>-lens_specifications.html`) — best for maxMagnification on budget lenses; use `py tools/lenstip/search.py "<lens>"` to find the page ID
    - Radojuva lens database (`radojuva.com`) — hands-on magnification measurements and detailed optical data
    - digitalkamera.de Datenblatt pages — good for dimensions, rarely has magnification
    - cameradecision.com via `fetch-page.py` (403s on direct fetch, Playwright bypasses)
@@ -402,13 +406,13 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
    - Duclos Lenses (`ducloslenses.com`) — reliable spec tables for cinema lenses (length, weight, min focus)
    - **Google Image Search** for construction diagrams and MTF charts — text-based searches miss images on non-English blogs, press kit reposts, and pages with minimal surrounding text; search `<brand> <model> optical construction diagram` or `<brand> <model> MTF chart`
    - **Image filename caveat:** when checking article pages for diagrams and MTF charts, do not rely on image filename keywords alone — news sites use generic filenames (e.g. `APO200F14-lens.jpg` for a combined construction diagram + MTF chart). For pages with a small number of images (< 10), download and visually check all content images rather than filtering by filename patterns.
-5. **LensTip page ID caveat:** URL names are ignored; only the numeric ID matters. Always verify `Manufacturer` and `Model` fields on the page — wrong IDs redirect silently to unrelated lenses.
-6. Verify extracted data against downloaded images and official pages:
+6. **LensTip page ID caveat:** URL names are ignored; only the numeric ID matters. Always verify `Manufacturer` and `Model` fields on the page — wrong IDs redirect silently to unrelated lenses.
+7. Verify extracted data against downloaded images and official pages:
    - Count elements and groups in construction diagrams — must match `opticalElements` and `opticalGroups`
    - Identify special elements (aspherical, LD, ED) marked in diagrams — must match `specialElements`
    - Check that all coatings on the product page are captured, including protective coatings (fluorine, water-repellent) that are often listed separately from optical coatings (AR, multi-coating)
    - For lenses with X-mount variants, verify physical specs (weight, length, diameter) use X-mount values, not Sony E or other mounts
-7. **Per-lens provenance workflow** (mandatory sequence for every lens touched):
+8. **Per-lens provenance workflow** (mandatory sequence for every lens touched):
    1. Check source (official page, diagram, third-party review)
    2. User confirms or corrects findings
    3. Update `specs-log.md` FIRST — document the source, date, result, and caveats
@@ -416,8 +420,8 @@ npx tsx scripts/compute-marks.ts patch       # patch lenses.ts with marks
    5. Confirm both files updated before moving to the next lens
    - The specs-log is the **primary deliverable** — data without provenance is unverifiable
    - If lenses share optical design across mounts (e.g. X + GFX), update BOTH specs-logs
-8. Add fields to `src/data/lenses.ts`, run `npm run validate`
-9. If adding `maxMagnification` to a scored lens, also add `macro` genre mark (test will fail if missing)
+9. Add fields to `src/data/lenses.ts`, run `npm run validate`
+10. If adding `maxMagnification` to a scored lens, also add `macro` genre mark (test will fail if missing)
 
 ## 3. Quality
 

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -276,6 +276,12 @@ No public affiliate programs found (2026-04-06). Contact ФотоСинтези�
 - https://www.camelcamelcamel.com — Amazon price history tracker
 - https://www.skinflint.co.uk — Skinflint (formerly Geizhals UK); EU price aggregator
 
+## Web scraping and bot protection
+
+- https://brightdata.com/products/web-unlocker/captcha-solver/perimeterx — Bright Data; PerimeterX CAPTCHA solver (paid service)
+- https://www.scraperapi.com/blog/scrape-perimeterx-protected-websites-with-python/ — ScraperAPI; guide for bypassing PerimeterX with Python
+- https://chrome-relay.kushalsm.com/ — Chrome Relay; remote headed Chrome service, potential replacement for local SeleniumBase UC
+
 ## Framework and hosting
 
 - https://docs.astro.build/en/getting-started/ — Astro docs

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -2959,3 +2959,47 @@ Issues created: solid-ai-templates#329 (no-force-push convention)
 - AstrHori 50mm f/1.4 Tilt: contact manufacturer for missing construction diagram and MTF
 - Brand transparency spike (#838) — AstrHori is a case study
 - Add 14 missing AstrHori lenses (#867)
+
+---
+
+### Session 86 — Research Workflow Improvements
+
+**Tool:** Claude Code (Opus 4.6, 1M context)
+
+#### PRs
+
+- #873 — feat: improve optical specs research workflow (#846)
+
+#### Issues
+
+- #846 assigned to v0.7.0 milestone
+- #845, #857, #838 assigned to Backlog (no milestone → Backlog)
+- #865 updated with PerimeterX layer analysis, test matrix (7 runs), screenshot, downgraded P3 → P4
+- Session 6.1 startup checklist: added step 5 (check open PRs)
+
+#### Key changes
+
+- **LensTip index scraper** (`tools/lenstip/build_index.py`): scrapes all 42 brands from lenstip.com catalog, builds a 2302-lens JSON index mapping names to opaque numeric page IDs
+- **LensTip search** (`tools/lenstip/search.py`): fuzzy word-boundary matching against local index
+- **Specs-log audit** (`tools/lenstip/audit_specslog.py`): cross-references "Not covered" entries vs index — found 10 false negatives (2 AstrHori, 2 Kamlan, 6 Mitakon)
+- **Unified lens lookup** (`tools/lookup.py`): generates DuckDuckGo site-search URLs for all PLAYBOOK 2.8 sources in one command
+- **PLAYBOOK 2.8 restructured**: 4 phases (Prepare, Research, Commit, Maintenance) + source reference table + mandatory 5-source checklist + fallback instruction
+- **CLAUDE.md**: new tools documented, PR check in startup, mandatory milestone rule on issues
+- **PerimeterX testing** (#865): Nodriver headed passes Layer 1 (fingerprint), gets Press & Hold on Layer 2; current product pages load without challenge inconsistently (5/7 passed); price extraction confirmed ($1,129.98 for XF 56mm f/1.2)
+- **chrome-relay evaluation**: reviewed Kushal's codebase (B+ overall), genuine project, no Windows support yet — blocker for us
+- **Bookmarks**: added Bright Data, ScraperAPI, Chrome Relay under new "Web scraping and bot protection" section
+
+#### Key decisions
+
+- Every issue MUST have type label, priority label, and milestone at creation (CLAUDE.md rule)
+- Session startup MUST check open PRs (`gh pr list --state open`) — step 5 in 6.1
+- LensTip index committed (not gitignored) — agents need it without setup
+- DuckDuckGo HTML over Google for all site-searches in lookup.py — no CAPTCHAs, works with fetch-page.py via urllib
+- PerimeterX spike (#865) downgraded to P4 — Nodriver sufficient for occasional lookups
+
+#### Next
+
+- Merge PR #873 (pending CI — GitHub CDN outage)
+- 8 Dependabot PRs pending (same CDN outage)
+- Re-check 10 false negative specs-logs with actual LensTip data
+- Continue optical specs: NiSi (#758), Meike (#755), 7Artisans (#748)

--- a/tools/lenstip/audit_specslog.py
+++ b/tools/lenstip/audit_specslog.py
@@ -1,0 +1,140 @@
+"""Audit specs-logs for false LensTip "Not covered" entries.
+
+Cross-references specs-log.md files that claim LensTip has no coverage
+against the local LensTip index to find lenses that ARE covered but
+were missed during research.
+
+Usage:
+    py tools/lenstip/audit_specslog.py           # check all specs-logs
+    py tools/lenstip/audit_specslog.py --fix      # also print the correct URLs
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+OPTICAL_SPECS_DIR = Path("docs/optical-specs")
+INDEX_FILE = Path(__file__).parent / "lenstip-index.json"
+
+# Import search from sibling module
+sys.path.insert(0, str(Path(__file__).parent))
+from search import search
+
+
+def extract_lens_name_from_slug(slug: str) -> str:
+    """Convert a directory slug back to a searchable lens name.
+
+    e.g. "viltrox-af-56mm-f1-4" → "Viltrox 56mm f/1.4"
+    """
+    name = slug.replace("-", " ")
+    # Restore f/ prefix: "f1.4" or "f1 4" → "f/1.4"
+    name = re.sub(r"\bf(\d)", r"f/\1", name)
+    # Restore decimal: "f/1 4" → "f/1.4"
+    name = re.sub(r"(f/\d+) (\d+)", r"\1.\2", name)
+    return name
+
+
+def has_lenstip_not_covered(specs_log_path: Path) -> bool:
+    """Check if a specs-log says LensTip is not covered."""
+    text = specs_log_path.read_text(encoding="utf-8").lower()
+    # Look for LensTip mentioned near "not covered/found" indicators
+    lines = text.split("\n")
+    for line in lines:
+        if "lenstip" not in line:
+            continue
+        if any(neg in line for neg in [
+            "not covered", "not found", "no coverage", "no results",
+            "no page", "no entry", "n/a", "not listed", "not in database",
+            "no lenstip", "not available",
+        ]):
+            return True
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit specs-logs for false LensTip 'Not covered' entries"
+    )
+    parser.add_argument(
+        "--fix", action="store_true",
+        help="Print the correct LensTip URLs for false negatives",
+    )
+    args = parser.parse_args()
+
+    if not INDEX_FILE.exists():
+        print("Index not found. Run: py tools/lenstip/build_index.py")
+        sys.exit(1)
+
+    false_negatives = []
+    checked = 0
+
+    for specs_dir in sorted(OPTICAL_SPECS_DIR.iterdir()):
+        if not specs_dir.is_dir():
+            continue
+        specs_log = specs_dir / "specs-log.md"
+        if not specs_log.exists():
+            continue
+
+        if not has_lenstip_not_covered(specs_log):
+            continue
+
+        checked += 1
+        slug = specs_dir.name
+        lens_name = extract_lens_name_from_slug(slug)
+
+        results = search(lens_name, limit=3)
+        if not results or results[0]["score"] < 0.8:
+            continue
+
+        # Verify the brand actually matches — prevent cross-brand false positives
+        # Extract brand from slug (first token before the model number)
+        slug_brand = slug.split("-")[0].lower()
+        # Brand aliases
+        brand_aliases = {
+            "kamlan": ["sainsonic", "kamlan"],
+            "handevision": ["handevision", "kipon", "iberit"],
+            "mitakon": ["mitakon", "zhongyi"],
+            "pergear": ["pergear"],
+        }
+        allowed = brand_aliases.get(slug_brand, [slug_brand])
+        match = results[0]
+        match_brand = match["brand"].lower()
+        match_name = match["name"].lower()
+
+        brand_matches = any(
+            alias in match_brand or alias in match_name
+            for alias in allowed
+        )
+        if not brand_matches:
+            continue
+
+        false_negatives.append({
+            "slug": slug,
+            "search_query": lens_name,
+            "lenstip_match": match["name"],
+            "lenstip_url": match["url"],
+            "score": match["score"],
+            "specs_log": str(specs_log),
+        })
+
+    print(f"Checked {checked} specs-logs with LensTip 'not covered' entries")
+    print(f"Found {len(false_negatives)} probable false negative(s)\n")
+
+    if not false_negatives:
+        print("All 'not covered' entries appear correct.")
+        return
+
+    for fn in false_negatives:
+        print(f"  {fn['slug']}")
+        print(f"    Searched: {fn['search_query']}")
+        print(f"    Match:    {fn['lenstip_match']} (score: {fn['score']:.2f})")
+        if args.fix:
+            print(f"    URL:      {fn['lenstip_url']}")
+        print(f"    File:     {fn['specs_log']}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lenstip/build_index.py
+++ b/tools/lenstip/build_index.py
@@ -1,0 +1,215 @@
+"""Build a local LensTip lens index from their catalog pages.
+
+Scrapes manufacturer pages on lenstip.com to create a JSON lookup table
+mapping lens names to their spec page URLs. This solves the problem of
+LensTip using opaque numeric IDs in URLs that are impossible to guess.
+
+Usage:
+    py tools/lenstip/build_index.py                  # build full index
+    py tools/lenstip/build_index.py --brand Fujifilm  # single brand only
+    py tools/lenstip/build_index.py --no-cache        # bypass cache
+
+Output: tools/lenstip/lenstip-index.json
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BASE_URL = "https://www.lenstip.com"
+TOOL_DIR = Path(__file__).parent
+INDEX_FILE = TOOL_DIR / "lenstip-index.json"
+FETCH_PAGE = Path(__file__).parent.parent / "fetch-page.py"
+
+# Manufacturer IDs from the LensTip dropdown (producent select element).
+# Format: {dropdown_value: (url_name, display_name)}
+MANUFACTURERS = {
+    "147": ("7Artisans", "7Artisans"),
+    "152": ("AstrHori", "AstrHori"),
+    "26": ("Canon", "Canon"),
+    "16": ("Carl_Zeiss", "Carl Zeiss"),
+    "94": ("CCCP", "CCCP"),
+    "86": ("Cosina", "Cosina"),
+    "100": ("Falcon", "Falcon"),
+    "66": ("Fujifilm", "Fujifilm"),
+    "131": ("Hasselblad", "Hasselblad"),
+    "112": ("IBE_Optics", "IBE Optics"),
+    "127": ("Irix", "Irix"),
+    "103": ("Kenko", "Kenko"),
+    "38": ("Konica_Minolta", "Konica Minolta"),
+    "31": ("Kowa", "Kowa"),
+    "42": ("Leica", "Leica"),
+    "95": ("Mamiya", "Mamiya"),
+    "128": ("Meike", "Meike"),
+    "113": ("Mitakon", "Mitakon"),
+    "77": ("Nikon_Nikkor", "Nikon Nikkor"),
+    "39": ("Olympus", "Olympus"),
+    "150": ("OM_System", "OM System"),
+    "64": ("Panasonic", "Panasonic"),
+    "13": ("Pentax", "Pentax"),
+    "79": ("Rollei", "Rollei"),
+    "135": ("SainSonic", "SainSonic"),
+    "68": ("Samsung", "Samsung"),
+    "96": ("Samyang", "Samyang"),
+    "83": ("Schneider-Kreuznach", "Schneider-Kreuznach"),
+    "73": ("Sigma", "Sigma"),
+    "146": ("Sirui", "Sirui"),
+    "111": ("SLR_Magic", "SLR Magic"),
+    "62": ("Sony", "Sony"),
+    "76": ("Tamron", "Tamron"),
+    "154": ("Thypoch", "Thypoch"),
+    "82": ("Tokina", "Tokina"),
+    "148": ("TTartisan", "TTartisan"),
+    "125": ("Venus_Optics_LAOWA", "Venus Optics LAOWA"),
+    "136": ("Viltrox", "Viltrox"),
+    "85": ("Vivitar", "Vivitar"),
+    "92": ("Voigtlander", "Voigtlander"),
+    "93": ("Yashica", "Yashica"),
+    "118": ("Yongnuo", "Yongnuo"),
+}
+
+# Pattern: <id>-<Name>-lens_specifications.html
+SPEC_LINK_RE = re.compile(
+    r'href="(\d+-[^"]*-lens_specifications\.html)"'
+)
+
+# Extract lens name from the link text (h2 tag content)
+LENS_NAME_RE = re.compile(
+    r'<h2><a href="\d+-[^"]*-lens_specifications\.html">([^<]+)</a></h2>'
+)
+
+
+def fetch_html(url: str, *, no_cache: bool = False) -> str:
+    """Fetch a page using fetch-page.py and return raw HTML."""
+    cmd = [sys.executable, str(FETCH_PAGE), url, "--html"]
+    if no_cache:
+        cmd.append("--no-cache")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        print(f"  WARNING: fetch failed for {url}: {result.stderr[:200]}")
+        return ""
+    return result.stdout
+
+
+def parse_lenses_from_html(html: str) -> list[dict]:
+    """Extract lens entries from a manufacturer page HTML."""
+    lenses = []
+    seen_ids = set()
+
+    # Find all spec links and their names
+    for match in SPEC_LINK_RE.finditer(html):
+        href = match.group(1)
+        lens_id = href.split("-")[0]
+        if lens_id in seen_ids:
+            continue
+        seen_ids.add(lens_id)
+
+        # Extract the lens name from the nearest h2 tag
+        # Look backwards from the href position for the name
+        url = f"{BASE_URL}/{href}"
+
+        lenses.append({
+            "id": int(lens_id),
+            "url": url,
+            "href": href,
+        })
+
+    # Now extract names — match h2 links to their hrefs
+    for name_match in LENS_NAME_RE.finditer(html):
+        name = name_match.group(1).strip()
+        href_in_name = name_match.group(0)
+        # Find the ID from this match
+        id_match = re.search(r'href="(\d+)-', href_in_name)
+        if id_match:
+            lens_id = id_match.group(1)
+            for lens in lenses:
+                if str(lens["id"]) == lens_id and "name" not in lens:
+                    lens["name"] = name
+                    break
+
+    # Fallback: derive name from URL slug for any missing names
+    for lens in lenses:
+        if "name" not in lens:
+            slug = lens["href"].split("-", 1)[1].replace("-lens_specifications.html", "")
+            lens["name"] = slug.replace("_", " ")
+
+    return lenses
+
+
+def build_index(
+    *, brand_filter: str | None = None, no_cache: bool = False
+) -> dict:
+    """Build the full lens index by scraping manufacturer pages."""
+    index = {
+        "_meta": {
+            "source": "lenstip.com",
+            "description": "LensTip lens index — maps lens names to spec page URLs",
+            "total_lenses": 0,
+            "total_brands": 0,
+        },
+        "brands": {},
+    }
+
+    brands_to_fetch = []
+    for mid, (url_name, display_name) in MANUFACTURERS.items():
+        if brand_filter and brand_filter.lower() not in display_name.lower():
+            continue
+        brands_to_fetch.append((mid, url_name, display_name))
+
+    print(f"Building LensTip index for {len(brands_to_fetch)} brand(s)...")
+
+    total_lenses = 0
+    for i, (mid, url_name, display_name) in enumerate(brands_to_fetch):
+        url = f"{BASE_URL}/{mid}-{url_name}-lenses.html"
+        print(f"  [{i + 1}/{len(brands_to_fetch)}] {display_name}...", end=" ", flush=True)
+
+        html = fetch_html(url, no_cache=no_cache)
+        if not html:
+            print("FAILED")
+            continue
+
+        lenses = parse_lenses_from_html(html)
+        print(f"{len(lenses)} lenses")
+
+        if lenses:
+            index["brands"][display_name] = [
+                {"id": l["id"], "name": l["name"], "url": l["url"]}
+                for l in sorted(lenses, key=lambda x: x["name"])
+            ]
+            total_lenses += len(lenses)
+
+        # Be polite — small delay between requests
+        if i < len(brands_to_fetch) - 1:
+            time.sleep(0.5)
+
+    index["_meta"]["total_lenses"] = total_lenses
+    index["_meta"]["total_brands"] = len(index["brands"])
+
+    return index
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build LensTip lens index from catalog pages"
+    )
+    parser.add_argument(
+        "--brand", type=str, help="Filter to a single brand (case-insensitive substring)"
+    )
+    parser.add_argument(
+        "--no-cache", action="store_true", help="Bypass fetch-page.py cache"
+    )
+    args = parser.parse_args()
+
+    index = build_index(brand_filter=args.brand, no_cache=args.no_cache)
+
+    INDEX_FILE.write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\nIndex saved to {INDEX_FILE}")
+    print(f"Total: {index['_meta']['total_lenses']} lenses across {index['_meta']['total_brands']} brands")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lenstip/lenstip-index.json
+++ b/tools/lenstip/lenstip-index.json
@@ -1,0 +1,11604 @@
+{
+  "_meta": {
+    "source": "lenstip.com",
+    "description": "LensTip lens index — maps lens names to spec page URLs",
+    "total_lenses": 2302,
+    "total_brands": 42
+  },
+  "brands": {
+    "7Artisans": [
+      {
+        "id": 1843,
+        "name": "7Artisans 10 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1843-7Artisans_10_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2186,
+        "name": "7Artisans 10 mm f/2.8 Fisheye II",
+        "url": "https://www.lenstip.com/2186-7Artisans_10_mm_f_2.8_Fisheye_II-lens_specifications.html"
+      },
+      {
+        "id": 2242,
+        "name": "7Artisans 10 mm f/3.5",
+        "url": "https://www.lenstip.com/2242-7Artisans_10_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 2004,
+        "name": "7Artisans 12 mm T2.9 Cine",
+        "url": "https://www.lenstip.com/2004-7Artisans_12_mm_T2.9_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1724,
+        "name": "7Artisans 12 mm f/2.8",
+        "url": "https://www.lenstip.com/1724-7Artisans_12_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2012,
+        "name": "7Artisans 12 mm f/2.8 Mark II",
+        "url": "https://www.lenstip.com/2012-7Artisans_12_mm_f_2.8_Mark_II-lens_specifications.html"
+      },
+      {
+        "id": 2248,
+        "name": "7Artisans 14 mm f/2.8",
+        "url": "https://www.lenstip.com/2248-7Artisans_14_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2044,
+        "name": "7Artisans 15 mm f/4",
+        "url": "https://www.lenstip.com/2044-7Artisans_15_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 2197,
+        "name": "7Artisans 18 mm f/5.6",
+        "url": "https://www.lenstip.com/2197-7Artisans_18_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 1760,
+        "name": "7Artisans 18 mm f/6.3",
+        "url": "https://www.lenstip.com/1760-7Artisans_18_mm_f_6.3-lens_specifications.html"
+      },
+      {
+        "id": 2023,
+        "name": "7Artisans 18 mm f/6.3 Mark II",
+        "url": "https://www.lenstip.com/2023-7Artisans_18_mm_f_6.3_Mark_II-lens_specifications.html"
+      },
+      {
+        "id": 2057,
+        "name": "7Artisans 24 mm f/1.4",
+        "url": "https://www.lenstip.com/2057-7Artisans_24_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1880,
+        "name": "7Artisans 25 mm f/0.95",
+        "url": "https://www.lenstip.com/1880-7Artisans_25_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1725,
+        "name": "7Artisans 25 mm f/1.8",
+        "url": "https://www.lenstip.com/1725-7Artisans_25_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1758,
+        "name": "7Artisans 35 mm f/0.95",
+        "url": "https://www.lenstip.com/1758-7Artisans_35_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1727,
+        "name": "7Artisans 35 mm f/1.2",
+        "url": "https://www.lenstip.com/1727-7Artisans_35_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1762,
+        "name": "7Artisans 35 mm f/1.2 Mark II",
+        "url": "https://www.lenstip.com/1762-7Artisans_35_mm_f_1.2_Mark_II-lens_specifications.html"
+      },
+      {
+        "id": 1728,
+        "name": "7Artisans 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1728-7Artisans_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2155,
+        "name": "7Artisans 35 mm f/1.4 FF",
+        "url": "https://www.lenstip.com/2155-7Artisans_35_mm_f_1.4_FF-lens_specifications.html"
+      },
+      {
+        "id": 1729,
+        "name": "7Artisans 35 mm f/2.0",
+        "url": "https://www.lenstip.com/1729-7Artisans_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 1736,
+        "name": "7Artisans 35 mm f/5.6 Drone",
+        "url": "https://www.lenstip.com/1736-7Artisans_35_mm_f_5.6_Drone-lens_specifications.html"
+      },
+      {
+        "id": 1984,
+        "name": "7Artisans 4 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1984-7Artisans_4_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1862,
+        "name": "7Artisans 50 mm f/0.95",
+        "url": "https://www.lenstip.com/1862-7Artisans_50_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1761,
+        "name": "7Artisans 50 mm f/1.05",
+        "url": "https://www.lenstip.com/1761-7Artisans_50_mm_f_1.05-lens_specifications.html"
+      },
+      {
+        "id": 2291,
+        "name": "7Artisans 50 mm f/1.2",
+        "url": "https://www.lenstip.com/2291-7Artisans_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2124,
+        "name": "7Artisans 50 mm f/1.4 Tilt-Shift",
+        "url": "https://www.lenstip.com/2124-7Artisans_50_mm_f_1.4_Tilt-Shift-lens_specifications.html"
+      },
+      {
+        "id": 1732,
+        "name": "7Artisans 50 mm f/1.8",
+        "url": "https://www.lenstip.com/1732-7Artisans_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1733,
+        "name": "7Artisans 55 mm f/1.4",
+        "url": "https://www.lenstip.com/1733-7Artisans_55_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1842,
+        "name": "7Artisans 55 mm f/1.4 II",
+        "url": "https://www.lenstip.com/1842-7Artisans_55_mm_f_1.4_II-lens_specifications.html"
+      },
+      {
+        "id": 2292,
+        "name": "7Artisans 6 mm f/2.0 Fisheye",
+        "url": "https://www.lenstip.com/2292-7Artisans_6_mm_f_2.0_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2169,
+        "name": "7Artisans 60 mm f/2.8 FF 2x Ultra-Macro",
+        "url": "https://www.lenstip.com/2169-7Artisans_60_mm_f_2.8_FF_2x_Ultra-Macro-lens_specifications.html"
+      },
+      {
+        "id": 1734,
+        "name": "7Artisans 60 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/1734-7Artisans_60_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1834,
+        "name": "7Artisans 60 mm f/2.8 Macro II",
+        "url": "https://www.lenstip.com/1834-7Artisans_60_mm_f_2.8_Macro_II-lens_specifications.html"
+      },
+      {
+        "id": 1723,
+        "name": "7Artisans 7.5 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1723-7Artisans_7.5_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1844,
+        "name": "7Artisans 7.5 mm f/2.8 Fisheye II",
+        "url": "https://www.lenstip.com/1844-7Artisans_7.5_mm_f_2.8_Fisheye_II-lens_specifications.html"
+      },
+      {
+        "id": 2017,
+        "name": "7Artisans 7.5 mm f/3.5 Fisheye",
+        "url": "https://www.lenstip.com/2017-7Artisans_7.5_mm_f_3.5_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2249,
+        "name": "7Artisans 75 mm f/1.4",
+        "url": "https://www.lenstip.com/2249-7Artisans_75_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2081,
+        "name": "7Artisans 9 mm f/5.6",
+        "url": "https://www.lenstip.com/2081-7Artisans_9_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 2273,
+        "name": "7Artisans AF 10 mm f/2.8",
+        "url": "https://www.lenstip.com/2273-7Artisans_AF_10_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2334,
+        "name": "7Artisans AF 135 mm f/1.8 Max",
+        "url": "https://www.lenstip.com/2334-7Artisans_AF_135_mm_f_1.8_Max-lens_specifications.html"
+      },
+      {
+        "id": 2232,
+        "name": "7Artisans AF 24 mm f/1.8",
+        "url": "https://www.lenstip.com/2232-7Artisans_AF_24_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2309,
+        "name": "7Artisans AF 25 mm f/1.8 Lite",
+        "url": "https://www.lenstip.com/2309-7Artisans_AF_25_mm_f_1.8_Lite-lens_specifications.html"
+      },
+      {
+        "id": 2125,
+        "name": "7Artisans AF 27 mm f/2.8",
+        "url": "https://www.lenstip.com/2125-7Artisans_AF_27_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2219,
+        "name": "7Artisans AF 35 mm f/1.4",
+        "url": "https://www.lenstip.com/2219-7Artisans_AF_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2277,
+        "name": "7Artisans AF 35 mm f/1.8",
+        "url": "https://www.lenstip.com/2277-7Artisans_AF_35_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2310,
+        "name": "7Artisans AF 35 mm f/1.8 Lite",
+        "url": "https://www.lenstip.com/2310-7Artisans_AF_35_mm_f_1.8_Lite-lens_specifications.html"
+      },
+      {
+        "id": 2318,
+        "name": "7Artisans AF 40 mm f/2.5 Lite",
+        "url": "https://www.lenstip.com/2318-7Artisans_AF_40_mm_f_2.5_Lite-lens_specifications.html"
+      },
+      {
+        "id": 2119,
+        "name": "7Artisans AF 50 mm f/1.8",
+        "url": "https://www.lenstip.com/2119-7Artisans_AF_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2311,
+        "name": "7Artisans AF 50 mm f/1.8 Lite",
+        "url": "https://www.lenstip.com/2311-7Artisans_AF_50_mm_f_1.8_Lite-lens_specifications.html"
+      },
+      {
+        "id": 2149,
+        "name": "7Artisans AF 85 mm f/1.8",
+        "url": "https://www.lenstip.com/2149-7Artisans_AF_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1726,
+        "name": "7Artisans M 28 mm f/1.4",
+        "url": "https://www.lenstip.com/1726-7Artisans_M_28_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1938,
+        "name": "7Artisans M 28 mm f/5.6",
+        "url": "https://www.lenstip.com/1938-7Artisans_M_28_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 1737,
+        "name": "7Artisans M 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1737-7Artisans_M_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1730,
+        "name": "7Artisans M 35 mm f/2.0",
+        "url": "https://www.lenstip.com/1730-7Artisans_M_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 2001,
+        "name": "7Artisans M 35 mm f/2.0 Mark II",
+        "url": "https://www.lenstip.com/2001-7Artisans_M_35_mm_f_2.0_Mark_II-lens_specifications.html"
+      },
+      {
+        "id": 2329,
+        "name": "7Artisans M 35 mm f/2.8",
+        "url": "https://www.lenstip.com/2329-7Artisans_M_35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1783,
+        "name": "7Artisans M 35 mm f/5.6",
+        "url": "https://www.lenstip.com/1783-7Artisans_M_35_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 1731,
+        "name": "7Artisans M 50 mm f/1.1",
+        "url": "https://www.lenstip.com/1731-7Artisans_M_50_mm_f_1.1-lens_specifications.html"
+      },
+      {
+        "id": 1735,
+        "name": "7Artisans M 75 mm f/1.25",
+        "url": "https://www.lenstip.com/1735-7Artisans_M_75_mm_f_1.25-lens_specifications.html"
+      },
+      {
+        "id": 2297,
+        "name": "7Artisans M 75 mm f/1.25 II",
+        "url": "https://www.lenstip.com/2297-7Artisans_M_75_mm_f_1.25_II-lens_specifications.html"
+      }
+    ],
+    "AstrHori": [
+      {
+        "id": 2005,
+        "name": "AstrHori 12 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/2005-AstrHori_12_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2154,
+        "name": "AstrHori 120 mm f/2.8 macro 2x",
+        "url": "https://www.lenstip.com/2154-AstrHori_120_mm_f_2.8_macro_2x-lens_specifications.html"
+      },
+      {
+        "id": 2266,
+        "name": "AstrHori 18 mm f/5.6 Pancake Shift",
+        "url": "https://www.lenstip.com/2266-AstrHori_18_mm_f_5.6_Pancake_Shift-lens_specifications.html"
+      },
+      {
+        "id": 2055,
+        "name": "AstrHori 18 mm f/8 Periscope Probe 2x Macro",
+        "url": "https://www.lenstip.com/2055-AstrHori_18_mm_f_8_Periscope_Probe_2x_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2006,
+        "name": "AstrHori 18 mm f/8 Shift",
+        "url": "https://www.lenstip.com/2006-AstrHori_18_mm_f_8_Shift-lens_specifications.html"
+      },
+      {
+        "id": 2109,
+        "name": "AstrHori 25 mm f/2.8 Ultra Macro",
+        "url": "https://www.lenstip.com/2109-AstrHori_25_mm_f_2.8_Ultra_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2188,
+        "name": "AstrHori 27 mm f/2.8 AF",
+        "url": "https://www.lenstip.com/2188-AstrHori_27_mm_f_2.8_AF_-lens_specifications.html"
+      },
+      {
+        "id": 2258,
+        "name": "AstrHori 6 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/2258-AstrHori_6_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2220,
+        "name": "AstrHori 6.5 mm f/2 Circular Fisheye",
+        "url": "https://www.lenstip.com/2220-AstrHori_6.5_mm_f_2_Circular_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2007,
+        "name": "AstrHori 85 mm f/1.8",
+        "url": "https://www.lenstip.com/2007-AstrHori_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2071,
+        "name": "AstrHori 85 mm f/1.8 AF",
+        "url": "https://www.lenstip.com/2071-AstrHori_85_mm_f_1.8_AF-lens_specifications.html"
+      },
+      {
+        "id": 2284,
+        "name": "AstrHori 85 mm f/1.8 AF II",
+        "url": "https://www.lenstip.com/2284-AstrHori_85_mm_f_1.8_AF_II-lens_specifications.html"
+      },
+      {
+        "id": 2286,
+        "name": "AstrHori 9 mm f/2.8",
+        "url": "https://www.lenstip.com/2286-AstrHori_9_mm_f_2.8-lens_specifications.html"
+      }
+    ],
+    "Canon": [
+      {
+        "id": 32,
+        "name": "Canon EF 100 mm f/2.0 USM",
+        "url": "https://www.lenstip.com/32-Canon_EF_100_mm_f_2.0_USM-lens_specifications.html"
+      },
+      {
+        "id": 879,
+        "name": "Canon EF 100 mm f/2.8 L Macro IS USM",
+        "url": "https://www.lenstip.com/879-Canon_EF_100_mm_f_2.8_L_Macro_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 159,
+        "name": "Canon EF 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/159-Canon_EF_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 160,
+        "name": "Canon EF 100 mm f/2.8 Macro USM",
+        "url": "https://www.lenstip.com/160-Canon_EF_100_mm_f_2.8_Macro_USM-lens_specifications.html"
+      },
+      {
+        "id": 486,
+        "name": "Canon EF 100-200 mm f/4.5A",
+        "url": "https://www.lenstip.com/486-Canon_EF_100-200_mm_f_4.5A-lens_specifications.html"
+      },
+      {
+        "id": 33,
+        "name": "Canon EF 100-300 mm f/4.5-5.6 USM",
+        "url": "https://www.lenstip.com/33-Canon_EF_100-300_mm_f_4.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 487,
+        "name": "Canon EF 100-300 mm f/5.6",
+        "url": "https://www.lenstip.com/487-Canon_EF_100-300_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 488,
+        "name": "Canon EF 100-300 mm f/5.6 L",
+        "url": "https://www.lenstip.com/488-Canon_EF_100-300_mm_f_5.6_L-lens_specifications.html"
+      },
+      {
+        "id": 489,
+        "name": "Canon EF 100-400 mm f/4.5-5.6 L IS USM",
+        "url": "https://www.lenstip.com/489-Canon_EF_100-400_mm_f_4.5-5.6_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1255,
+        "name": "Canon EF 100-400 mm f/4.5-5.6L IS II USM",
+        "url": "https://www.lenstip.com/1255-Canon_EF_100-400_mm_f_4.5-5.6L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 1270,
+        "name": "Canon EF 11-24 mm f/4L USM",
+        "url": "https://www.lenstip.com/1270-Canon_EF_11-24_mm_f_4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 180,
+        "name": "Canon EF 1200 mm f/5.6 L USM",
+        "url": "https://www.lenstip.com/180-Canon_EF_1200_mm_f_5.6_L_USM-lens_specifications.html"
+      },
+      {
+        "id": 162,
+        "name": "Canon EF 135 mm f/2.8 Soft Fokus",
+        "url": "https://www.lenstip.com/162-Canon_EF_135_mm_f_2.8_Soft_Fokus-lens_specifications.html"
+      },
+      {
+        "id": 161,
+        "name": "Canon EF 135 mm f/2L USM",
+        "url": "https://www.lenstip.com/161-Canon_EF_135_mm_f_2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 146,
+        "name": "Canon EF 14 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/146-Canon_EF_14_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 639,
+        "name": "Canon EF 14 mm f/2.8L USM II",
+        "url": "https://www.lenstip.com/639-Canon_EF_14_mm_f_2.8L_USM_II-lens_specifications.html"
+      },
+      {
+        "id": 147,
+        "name": "Canon EF 15 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/147-Canon_EF_15_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 430,
+        "name": "Canon EF 16-35 mm f/2.8L  USM",
+        "url": "https://www.lenstip.com/430-Canon_EF_16-35_mm_f_2.8L__USM-lens_specifications.html"
+      },
+      {
+        "id": 619,
+        "name": "Canon EF 16-35 mm f/2.8L II USM",
+        "url": "https://www.lenstip.com/619-Canon_EF_16-35_mm_f_2.8L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 1379,
+        "name": "Canon EF 16-35 mm f/2.8L III USM",
+        "url": "https://www.lenstip.com/1379-Canon_EF_16-35_mm_f_2.8L_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 1202,
+        "name": "Canon EF 16-35 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/1202-Canon_EF_16-35_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 431,
+        "name": "Canon EF 17-35 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/431-Canon_EF_17-35_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 31,
+        "name": "Canon EF 17-40 mm f/4.0L USM",
+        "url": "https://www.lenstip.com/31-Canon_EF_17-40_mm_f_4.0L_USM-lens_specifications.html"
+      },
+      {
+        "id": 163,
+        "name": "Canon EF 180 mm f/3.5L Macro USM",
+        "url": "https://www.lenstip.com/163-Canon_EF_180_mm_f_3.5L_Macro_USM-lens_specifications.html"
+      },
+      {
+        "id": 39,
+        "name": "Canon EF 20 mm f/2.8 USM",
+        "url": "https://www.lenstip.com/39-Canon_EF_20_mm_f_2.8_USM-lens_specifications.html"
+      },
+      {
+        "id": 432,
+        "name": "Canon EF 20-35 mm f/2.8L",
+        "url": "https://www.lenstip.com/432-Canon_EF_20-35_mm_f_2.8L-lens_specifications.html"
+      },
+      {
+        "id": 433,
+        "name": "Canon EF 20-35 mm f/3.5-4.5 USM",
+        "url": "https://www.lenstip.com/433-Canon_EF_20-35_mm_f_3.5-4.5_USM-lens_specifications.html"
+      },
+      {
+        "id": 164,
+        "name": "Canon EF 200 mm f/1.8L USM",
+        "url": "https://www.lenstip.com/164-Canon_EF_200_mm_f_1.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 675,
+        "name": "Canon EF 200 mm f/2.0L IS USM",
+        "url": "https://www.lenstip.com/675-Canon_EF_200_mm_f_2.0L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 166,
+        "name": "Canon EF 200 mm f/2.8L II USM",
+        "url": "https://www.lenstip.com/166-Canon_EF_200_mm_f_2.8L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 165,
+        "name": "Canon EF 200 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/165-Canon_EF_200_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 973,
+        "name": "Canon EF 200-400 mm f/4 L IS USM EXT. 1.4x",
+        "url": "https://www.lenstip.com/973-Canon_EF_200-400_mm_f_4_L_IS_USM_EXT._1.4x-lens_specifications.html"
+      },
+      {
+        "id": 434,
+        "name": "Canon EF 22-55 mm f/4-5.6 USM",
+        "url": "https://www.lenstip.com/434-Canon_EF_22-55_mm_f_4-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 814,
+        "name": "Canon EF 24 mm f/1.4L II USM",
+        "url": "https://www.lenstip.com/814-Canon_EF_24_mm_f_1.4L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 148,
+        "name": "Canon EF 24 mm f/1.4L USM",
+        "url": "https://www.lenstip.com/148-Canon_EF_24_mm_f_1.4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 149,
+        "name": "Canon EF 24 mm f/2.8",
+        "url": "https://www.lenstip.com/149-Canon_EF_24_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1034,
+        "name": "Canon EF 24 mm f/2.8 IS USM",
+        "url": "https://www.lenstip.com/1034-Canon_EF_24_mm_f_2.8_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1229,
+        "name": "Canon EF 24-105 mm f/3.5-5.6 IS STM",
+        "url": "https://www.lenstip.com/1229-Canon_EF_24-105_mm_f_3.5-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1380,
+        "name": "Canon EF 24-105 mm f/4L IS II USM",
+        "url": "https://www.lenstip.com/1380-Canon_EF_24-105_mm_f_4L_IS_II_USM_-lens_specifications.html"
+      },
+      {
+        "id": 436,
+        "name": "Canon EF 24-105 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/436-Canon_EF_24-105_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1033,
+        "name": "Canon EF 24-70 mm f/2.8L II USM",
+        "url": "https://www.lenstip.com/1033-Canon_EF_24-70_mm_f_2.8L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 435,
+        "name": "Canon EF 24-70 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/435-Canon_EF_24-70_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1090,
+        "name": "Canon EF 24-70 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/1090-Canon_EF_24-70_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 12,
+        "name": "Canon EF 24-85 mm f/3.5-4.5 USM",
+        "url": "https://www.lenstip.com/12-Canon_EF_24-85_mm_f_3.5-4.5_USM-lens_specifications.html"
+      },
+      {
+        "id": 150,
+        "name": "Canon EF 28 mm f/1.8 USM",
+        "url": "https://www.lenstip.com/150-Canon_EF_28_mm_f_1.8_USM-lens_specifications.html"
+      },
+      {
+        "id": 3,
+        "name": "Canon EF 28 mm f/2.8",
+        "url": "https://www.lenstip.com/3-Canon_EF_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1035,
+        "name": "Canon EF 28 mm f/2.8 IS USM",
+        "url": "https://www.lenstip.com/1035-Canon_EF_28_mm_f_2.8_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 392,
+        "name": "Canon EF 28-105 mm f/3.5-4.5 II USM",
+        "url": "https://www.lenstip.com/392-Canon_EF_28-105_mm_f_3.5-4.5_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 400,
+        "name": "Canon EF 28-105 mm f/3.5-4.5 USM",
+        "url": "https://www.lenstip.com/400-Canon_EF_28-105_mm_f_3.5-4.5_USM-lens_specifications.html"
+      },
+      {
+        "id": 393,
+        "name": "Canon EF 28-105 mm f/4-5.6 USM",
+        "url": "https://www.lenstip.com/393-Canon_EF_28-105_mm_f_4-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 36,
+        "name": "Canon EF 28-135 mm f/3.5-5.6 IS USM",
+        "url": "https://www.lenstip.com/36-Canon_EF_28-135_mm_f_3.5-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 465,
+        "name": "Canon EF 28-200 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/465-Canon_EF_28-200_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 466,
+        "name": "Canon EF 28-200 mm f/3.5-5.6 USM",
+        "url": "https://www.lenstip.com/466-Canon_EF_28-200_mm_f_3.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 467,
+        "name": "Canon EF 28-300 mm f/3.5-5.6L IS USM",
+        "url": "https://www.lenstip.com/467-Canon_EF_28-300_mm_f_3.5-5.6L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 449,
+        "name": "Canon EF 28-70 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/449-Canon_EF_28-70_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 450,
+        "name": "Canon EF 28-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/450-Canon_EF_28-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 451,
+        "name": "Canon EF 28-70 mm f/3.5-4.5 II",
+        "url": "https://www.lenstip.com/451-Canon_EF_28-70_mm_f_3.5-4.5_II-lens_specifications.html"
+      },
+      {
+        "id": 452,
+        "name": "Canon EF 28-80 mm f/2.8-4L USM",
+        "url": "https://www.lenstip.com/452-Canon_EF_28-80_mm_f_2.8-4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 453,
+        "name": "Canon EF 28-80 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/453-Canon_EF_28-80_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 455,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 II",
+        "url": "https://www.lenstip.com/455-Canon_EF_28-80_mm_f_3.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 456,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 II USM",
+        "url": "https://www.lenstip.com/456-Canon_EF_28-80_mm_f_3.5-5.6_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 457,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 III USM",
+        "url": "https://www.lenstip.com/457-Canon_EF_28-80_mm_f_3.5-5.6_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 458,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 IV USM",
+        "url": "https://www.lenstip.com/458-Canon_EF_28-80_mm_f_3.5-5.6_IV_USM-lens_specifications.html"
+      },
+      {
+        "id": 454,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 USM",
+        "url": "https://www.lenstip.com/454-Canon_EF_28-80_mm_f_3.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 459,
+        "name": "Canon EF 28-80 mm f/3.5-5.6 V USM",
+        "url": "https://www.lenstip.com/459-Canon_EF_28-80_mm_f_3.5-5.6_V_USM-lens_specifications.html"
+      },
+      {
+        "id": 460,
+        "name": "Canon EF 28-90 mm f/4-5.6",
+        "url": "https://www.lenstip.com/460-Canon_EF_28-90_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 462,
+        "name": "Canon EF 28-90 mm f/4-5.6 II",
+        "url": "https://www.lenstip.com/462-Canon_EF_28-90_mm_f_4-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 463,
+        "name": "Canon EF 28-90 mm f/4-5.6 II USM",
+        "url": "https://www.lenstip.com/463-Canon_EF_28-90_mm_f_4-5.6_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 464,
+        "name": "Canon EF 28-90 mm f/4-5.6 III",
+        "url": "https://www.lenstip.com/464-Canon_EF_28-90_mm_f_4-5.6_III-lens_specifications.html"
+      },
+      {
+        "id": 461,
+        "name": "Canon EF 28-90 mm f/4-5.6 USM",
+        "url": "https://www.lenstip.com/461-Canon_EF_28-90_mm_f_4-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 943,
+        "name": "Canon EF 300 mm f/2.8 L IS II USM",
+        "url": "https://www.lenstip.com/943-Canon_EF_300_mm_f_2.8_L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 168,
+        "name": "Canon EF 300 mm f/2.8L IS USM",
+        "url": "https://www.lenstip.com/168-Canon_EF_300_mm_f_2.8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 167,
+        "name": "Canon EF 300 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/167-Canon_EF_300_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 170,
+        "name": "Canon EF 300 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/170-Canon_EF_300_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 169,
+        "name": "Canon EF 300 mm f/4L USM",
+        "url": "https://www.lenstip.com/169-Canon_EF_300_mm_f_4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1307,
+        "name": "Canon EF 35 mm f/1.4L II USM",
+        "url": "https://www.lenstip.com/1307-Canon_EF_35_mm_f_1.4L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 151,
+        "name": "Canon EF 35 mm f/1.4L USM",
+        "url": "https://www.lenstip.com/151-Canon_EF_35_mm_f_1.4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1091,
+        "name": "Canon EF 35 mm f/2 IS USM",
+        "url": "https://www.lenstip.com/1091-Canon_EF_35_mm_f_2_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 152,
+        "name": "Canon EF 35 mm f/2.0",
+        "url": "https://www.lenstip.com/152-Canon_EF_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 442,
+        "name": "Canon EF 35-105 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/442-Canon_EF_35-105_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 443,
+        "name": "Canon EF 35-105 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/443-Canon_EF_35-105_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 444,
+        "name": "Canon EF 35-105 mm f/4.5-5.6 USM",
+        "url": "https://www.lenstip.com/444-Canon_EF_35-105_mm_f_4.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 445,
+        "name": "Canon EF 35-135 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/445-Canon_EF_35-135_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 446,
+        "name": "Canon EF 35-135 mm f/4-5.6 USM",
+        "url": "https://www.lenstip.com/446-Canon_EF_35-135_mm_f_4-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 447,
+        "name": "Canon EF 35-350 mm f/3.5-5.6L USM",
+        "url": "https://www.lenstip.com/447-Canon_EF_35-350_mm_f_3.5-5.6L_USM-lens_specifications.html"
+      },
+      {
+        "id": 437,
+        "name": "Canon EF 35-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/437-Canon_EF_35-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 440,
+        "name": "Canon EF 35-80 mm F4-5.6 II",
+        "url": "https://www.lenstip.com/440-Canon_EF_35-80_mm_F4-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 441,
+        "name": "Canon EF 35-80 mm f/4-5.6 III",
+        "url": "https://www.lenstip.com/441-Canon_EF_35-80_mm_f_4-5.6_III-lens_specifications.html"
+      },
+      {
+        "id": 438,
+        "name": "Canon EF 35-80 mm f/4-5.6 PZ",
+        "url": "https://www.lenstip.com/438-Canon_EF_35-80_mm_f_4-5.6_PZ-lens_specifications.html"
+      },
+      {
+        "id": 439,
+        "name": "Canon EF 35-80 mm f/4-5.6 USM",
+        "url": "https://www.lenstip.com/439-Canon_EF_35-80_mm_f_4-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 448,
+        "name": "Canon EF 38-76 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/448-Canon_EF_38-76_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1049,
+        "name": "Canon EF 40 mm f/2.8 STM",
+        "url": "https://www.lenstip.com/1049-Canon_EF_40_mm_f_2.8_STM-lens_specifications.html"
+      },
+      {
+        "id": 944,
+        "name": "Canon EF 400 mm f/2.8 L IS II USM",
+        "url": "https://www.lenstip.com/944-Canon_EF_400_mm_f_2.8_L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 172,
+        "name": "Canon EF 400 mm f/2.8L II  USM",
+        "url": "https://www.lenstip.com/172-Canon_EF_400_mm_f_2.8L_II__USM-lens_specifications.html"
+      },
+      {
+        "id": 1564,
+        "name": "Canon EF 400 mm f/2.8L IS III USM",
+        "url": "https://www.lenstip.com/1564-Canon_EF_400_mm_f_2.8L_IS_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 173,
+        "name": "Canon EF 400 mm f/2.8L IS USM",
+        "url": "https://www.lenstip.com/173-Canon_EF_400_mm_f_2.8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 171,
+        "name": "Canon EF 400 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/171-Canon_EF_400_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1230,
+        "name": "Canon EF 400 mm f/4 DO IS II USM",
+        "url": "https://www.lenstip.com/1230-Canon_EF_400_mm_f_4_DO_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 174,
+        "name": "Canon EF 400 mm f/4 DO IS USM",
+        "url": "https://www.lenstip.com/174-Canon_EF_400_mm_f_4_DO_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 175,
+        "name": "Canon EF 400 mm f/5.6L USM",
+        "url": "https://www.lenstip.com/175-Canon_EF_400_mm_f_5.6L_USM-lens_specifications.html"
+      },
+      {
+        "id": 515,
+        "name": "Canon EF 50 mm f/1.2L USM",
+        "url": "https://www.lenstip.com/515-Canon_EF_50_mm_f_1.2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 17,
+        "name": "Canon EF 50 mm f/1.4 USM",
+        "url": "https://www.lenstip.com/17-Canon_EF_50_mm_f_1.4_USM-lens_specifications.html"
+      },
+      {
+        "id": 154,
+        "name": "Canon EF 50 mm f/1.8",
+        "url": "https://www.lenstip.com/154-Canon_EF_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1,
+        "name": "Canon EF 50 mm f/1.8 II",
+        "url": "https://www.lenstip.com/1-Canon_EF_50_mm_f_1.8_II-lens_specifications.html"
+      },
+      {
+        "id": 1291,
+        "name": "Canon EF 50 mm f/1.8 STM",
+        "url": "https://www.lenstip.com/1291-Canon_EF_50_mm_f_1.8_STM-lens_specifications.html"
+      },
+      {
+        "id": 153,
+        "name": "Canon EF 50 mm f/1L USM",
+        "url": "https://www.lenstip.com/153-Canon_EF_50_mm_f_1L_USM-lens_specifications.html"
+      },
+      {
+        "id": 155,
+        "name": "Canon EF 50 mm f/2.5 Compact Macro",
+        "url": "https://www.lenstip.com/155-Canon_EF_50_mm_f_2.5_Compact_Macro-lens_specifications.html"
+      },
+      {
+        "id": 468,
+        "name": "Canon EF 50-200 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/468-Canon_EF_50-200_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 177,
+        "name": "Canon EF 500 mm f/4.5L USM",
+        "url": "https://www.lenstip.com/177-Canon_EF_500_mm_f_4.5L_USM-lens_specifications.html"
+      },
+      {
+        "id": 946,
+        "name": "Canon EF 500 mm f/4L IS II USM",
+        "url": "https://www.lenstip.com/946-Canon_EF_500_mm_f_4L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 176,
+        "name": "Canon EF 500 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/176-Canon_EF_500_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 5,
+        "name": "Canon EF 55-200 mm f/4.5-5.6 II USM",
+        "url": "https://www.lenstip.com/5-Canon_EF_55-200_mm_f_4.5-5.6_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 469,
+        "name": "Canon EF 55-200 mm f/4.5-5.6 USM",
+        "url": "https://www.lenstip.com/469-Canon_EF_55-200_mm_f_4.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 947,
+        "name": "Canon EF 600 mm f/4L IS II USM",
+        "url": "https://www.lenstip.com/947-Canon_EF_600_mm_f_4L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 1565,
+        "name": "Canon EF 600 mm f/4L IS III USM",
+        "url": "https://www.lenstip.com/1565-Canon_EF_600_mm_f_4L_IS_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 179,
+        "name": "Canon EF 600 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/179-Canon_EF_600_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 178,
+        "name": "Canon EF 600 mm f/4L USM",
+        "url": "https://www.lenstip.com/178-Canon_EF_600_mm_f_4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 900,
+        "name": "Canon EF 70-200 mm f/2.8L IS II USM",
+        "url": "https://www.lenstip.com/900-Canon_EF_70-200_mm_f_2.8L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 1538,
+        "name": "Canon EF 70-200 mm f/2.8L IS III USM",
+        "url": "https://www.lenstip.com/1538-Canon_EF_70-200_mm_f_2.8L_IS_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 471,
+        "name": "Canon EF 70-200 mm f/2.8L IS USM",
+        "url": "https://www.lenstip.com/471-Canon_EF_70-200_mm_f_2.8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 470,
+        "name": "Canon EF 70-200 mm f/2.8L USM",
+        "url": "https://www.lenstip.com/470-Canon_EF_70-200_mm_f_2.8L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1537,
+        "name": "Canon EF 70-200 mm f/4L IS II USM",
+        "url": "https://www.lenstip.com/1537-Canon_EF_70-200_mm_f_4L_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 617,
+        "name": "Canon EF 70-200 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/617-Canon_EF_70-200_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 30,
+        "name": "Canon EF 70-200 mm f/4L USM",
+        "url": "https://www.lenstip.com/30-Canon_EF_70-200_mm_f_4L_USM-lens_specifications.html"
+      },
+      {
+        "id": 472,
+        "name": "Canon EF 70-210 mm f/3.5-4.5 USM",
+        "url": "https://www.lenstip.com/472-Canon_EF_70-210_mm_f_3.5-4.5_USM-lens_specifications.html"
+      },
+      {
+        "id": 473,
+        "name": "Canon EF 70-210 mm f/4",
+        "url": "https://www.lenstip.com/473-Canon_EF_70-210_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1393,
+        "name": "Canon EF 70-300 mm f/4-5.6 IS II USM",
+        "url": "https://www.lenstip.com/1393-Canon_EF_70-300_mm_f_4-5.6_IS_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 145,
+        "name": "Canon EF 70-300 mm f/4-5.6 IS USM",
+        "url": "https://www.lenstip.com/145-Canon_EF_70-300_mm_f_4-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 942,
+        "name": "Canon EF 70-300 mm f/4-5.6 L IS USM",
+        "url": "https://www.lenstip.com/942-Canon_EF_70-300_mm_f_4-5.6_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 474,
+        "name": "Canon EF 70-300 mm f/4.5-5.6 DO IS USM",
+        "url": "https://www.lenstip.com/474-Canon_EF_70-300_mm_f_4.5-5.6_DO_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 476,
+        "name": "Canon EF 75-300 mm f/4-5.6 II",
+        "url": "https://www.lenstip.com/476-Canon_EF_75-300_mm_f_4-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 477,
+        "name": "Canon EF 75-300 mm f/4-5.6 II USM",
+        "url": "https://www.lenstip.com/477-Canon_EF_75-300_mm_f_4-5.6_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 478,
+        "name": "Canon EF 75-300 mm f/4-5.6 III",
+        "url": "https://www.lenstip.com/478-Canon_EF_75-300_mm_f_4-5.6_III-lens_specifications.html"
+      },
+      {
+        "id": 479,
+        "name": "Canon EF 75-300 mm f/4-5.6 III USM",
+        "url": "https://www.lenstip.com/479-Canon_EF_75-300_mm_f_4-5.6_III_USM-lens_specifications.html"
+      },
+      {
+        "id": 475,
+        "name": "Canon EF 75-300 mm f/4-5.6 IS USM",
+        "url": "https://www.lenstip.com/475-Canon_EF_75-300_mm_f_4-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 941,
+        "name": "Canon EF 8-15 mm f/4 L Fisheye USM",
+        "url": "https://www.lenstip.com/941-Canon_EF_8-15_mm_f_4_L_Fisheye_USM-lens_specifications.html"
+      },
+      {
+        "id": 480,
+        "name": "Canon EF 80-200 mm f/2.8L",
+        "url": "https://www.lenstip.com/480-Canon_EF_80-200_mm_f_2.8L-lens_specifications.html"
+      },
+      {
+        "id": 481,
+        "name": "Canon EF 80-200 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/481-Canon_EF_80-200_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 483,
+        "name": "Canon EF 80-200 mm f/4.5-5.6 II",
+        "url": "https://www.lenstip.com/483-Canon_EF_80-200_mm_f_4.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 482,
+        "name": "Canon EF 80-200 mm f/4.5-5.6 USM",
+        "url": "https://www.lenstip.com/482-Canon_EF_80-200_mm_f_4.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 676,
+        "name": "Canon EF 800 mm f/5.6L IS USM",
+        "url": "https://www.lenstip.com/676-Canon_EF_800_mm_f_5.6L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 158,
+        "name": "Canon EF 85 mm f/1.2L II USM",
+        "url": "https://www.lenstip.com/158-Canon_EF_85_mm_f_1.2L_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 157,
+        "name": "Canon EF 85 mm f/1.2L USM",
+        "url": "https://www.lenstip.com/157-Canon_EF_85_mm_f_1.2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1477,
+        "name": "Canon EF 85 mm f/1.4L IS USM",
+        "url": "https://www.lenstip.com/1477-Canon_EF_85_mm_f_1.4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 13,
+        "name": "Canon EF 85 mm f/1.8 USM",
+        "url": "https://www.lenstip.com/13-Canon_EF_85_mm_f_1.8_USM-lens_specifications.html"
+      },
+      {
+        "id": 484,
+        "name": "Canon EF 90-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/484-Canon_EF_90-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 485,
+        "name": "Canon EF 90-300 mm f/4.5-5.6 USM",
+        "url": "https://www.lenstip.com/485-Canon_EF_90-300_mm_f_4.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 1123,
+        "name": "Canon EF-M 11-22 mm f/4-5.6 IS STM",
+        "url": "https://www.lenstip.com/1123-Canon_EF-M_11-22_mm_f_4-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1324,
+        "name": "Canon EF-M 15-45 mm f/3.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1324-Canon_EF-M_15-45_mm_f_3.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1392,
+        "name": "Canon EF-M 18-150 mm f/3.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1392-Canon_EF-M_18-150_mm_f_3.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1059,
+        "name": "Canon EF-M 18-55 mm f/3.5-5.6 IS STM",
+        "url": "https://www.lenstip.com/1059-Canon_EF-M_18-55_mm_f_3.5-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1058,
+        "name": "Canon EF-M 22 mm f/2 STM",
+        "url": "https://www.lenstip.com/1058-Canon_EF-M_22_mm_f_2_STM-lens_specifications.html"
+      },
+      {
+        "id": 1363,
+        "name": "Canon EF-M 28 mm f/3.5 Macro IS STM",
+        "url": "https://www.lenstip.com/1363-Canon_EF-M_28_mm_f_3.5_Macro_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1563,
+        "name": "Canon EF-M 32 mm f/1.4 STM",
+        "url": "https://www.lenstip.com/1563-Canon_EF-M_32_mm_f_1.4_STM-lens_specifications.html"
+      },
+      {
+        "id": 1294,
+        "name": "Canon EF-M 55-200 mm f/4.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1294-Canon_EF-M_55-200_mm_f_4.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1203,
+        "name": "Canon EF-S 10-18 mm f/4.5-5.6 IS STM",
+        "url": "https://www.lenstip.com/1203-Canon_EF-S_10-18_mm_f_4.5-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 20,
+        "name": "Canon EF-S 10-22 mm f/3.5-4.5 USM",
+        "url": "https://www.lenstip.com/20-Canon_EF-S_10-22_mm_f_3.5-4.5_USM-lens_specifications.html"
+      },
+      {
+        "id": 877,
+        "name": "Canon EF-S 15-85 mm f/3.5-5.6 IS USM",
+        "url": "https://www.lenstip.com/877-Canon_EF-S_15-85_mm_f_3.5-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 25,
+        "name": "Canon EF-S 17-55 mm f/2.8 IS USM",
+        "url": "https://www.lenstip.com/25-Canon_EF-S_17-55_mm_f_2.8_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 9,
+        "name": "Canon EF-S 17-85 mm f/4-5.6 IS USM",
+        "url": "https://www.lenstip.com/9-Canon_EF-S_17-85_mm_f_4-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 878,
+        "name": "Canon EF-S 18-135 mm f/3.5-5.6 IS",
+        "url": "https://www.lenstip.com/878-Canon_EF-S_18-135_mm_f_3.5-5.6_IS-lens_specifications.html"
+      },
+      {
+        "id": 1050,
+        "name": "Canon EF-S 18-135 mm f/3.5-5.6 IS STM",
+        "url": "https://www.lenstip.com/1050-Canon_EF-S_18-135_mm_f_3.5-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1349,
+        "name": "Canon EF-S 18-135 mm f/3.5-5.6 IS USM",
+        "url": "https://www.lenstip.com/1349-Canon_EF-S_18-135_mm_f_3.5-5.6_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 802,
+        "name": "Canon EF-S 18-200 mm f/3.5-5.6 IS",
+        "url": "https://www.lenstip.com/802-Canon_EF-S_18-200_mm_f_3.5-5.6_IS-lens_specifications.html"
+      },
+      {
+        "id": 427,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/427-Canon_EF-S_18-55_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 4,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 II",
+        "url": "https://www.lenstip.com/4-Canon_EF-S_18-55_mm_f_3.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 429,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 II USM",
+        "url": "https://www.lenstip.com/429-Canon_EF-S_18-55_mm_f_3.5-5.6_II_USM-lens_specifications.html"
+      },
+      {
+        "id": 1536,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 III",
+        "url": "https://www.lenstip.com/1536-Canon_EF-S_18-55_mm_f_3.5-5.6_III-lens_specifications.html"
+      },
+      {
+        "id": 637,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 IS",
+        "url": "https://www.lenstip.com/637-Canon_EF-S_18-55_mm_f_3.5-5.6_IS-lens_specifications.html"
+      },
+      {
+        "id": 974,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 IS II",
+        "url": "https://www.lenstip.com/974-Canon_EF-S_18-55_mm_f_3.5-5.6_IS_II-lens_specifications.html"
+      },
+      {
+        "id": 1116,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 IS STM",
+        "url": "https://www.lenstip.com/1116-Canon_EF-S_18-55_mm_f_3.5-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 428,
+        "name": "Canon EF-S 18-55 mm f/3.5-5.6 USM",
+        "url": "https://www.lenstip.com/428-Canon_EF-S_18-55_mm_f_3.5-5.6_USM-lens_specifications.html"
+      },
+      {
+        "id": 1445,
+        "name": "Canon EF-S 18-55 mm f/4-5.6 IS STM",
+        "url": "https://www.lenstip.com/1445-Canon_EF-S_18-55_mm_f_4-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1228,
+        "name": "Canon EF-S 24 mm f/2.8 STM",
+        "url": "https://www.lenstip.com/1228-Canon_EF-S_24_mm_f_2.8_STM_-lens_specifications.html"
+      },
+      {
+        "id": 1458,
+        "name": "Canon EF-S 35 mm f/2.8 Macro IS STM",
+        "url": "https://www.lenstip.com/1458-Canon_EF-S_35_mm_f_2.8_Macro_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 638,
+        "name": "Canon EF-S 55-250 mm f/4-5.6 IS",
+        "url": "https://www.lenstip.com/638-Canon_EF-S_55-250_mm_f_4-5.6_IS-lens_specifications.html"
+      },
+      {
+        "id": 985,
+        "name": "Canon EF-S 55-250 mm f/4-5.6 IS II",
+        "url": "https://www.lenstip.com/985-Canon_EF-S_55-250_mm_f_4-5.6_IS_II-lens_specifications.html"
+      },
+      {
+        "id": 1135,
+        "name": "Canon EF-S 55-250 mm f/4-5.6 IS STM",
+        "url": "https://www.lenstip.com/1135-Canon_EF-S_55-250_mm_f_4-5.6_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 426,
+        "name": "Canon EF-S 60 mm f/2.8 Macro USM",
+        "url": "https://www.lenstip.com/426-Canon_EF-S_60_mm_f_2.8_Macro_USM-lens_specifications.html"
+      },
+      {
+        "id": 156,
+        "name": "Canon MP-E 65 mm f/2.8 1-5X Macro Photo",
+        "url": "https://www.lenstip.com/156-Canon_MP-E_65_mm_f_2.8_1-5X_Macro_Photo-lens_specifications.html"
+      },
+      {
+        "id": 2086,
+        "name": "Canon RF 10-20 mm f/4L IS STM",
+        "url": "https://www.lenstip.com/2086-Canon_RF_10-20_mm_f_4L_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1825,
+        "name": "Canon RF 100 mm f/2.8 L IS USM Macro",
+        "url": "https://www.lenstip.com/1825-Canon_RF_100_mm_f_2.8_L_IS_USM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2047,
+        "name": "Canon RF 100-300 mm f/2.8L IS USM",
+        "url": "https://www.lenstip.com/2047-Canon_RF_100-300_mm_f_2.8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1876,
+        "name": "Canon RF 100-400 mm f/5.6-8 IS USM",
+        "url": "https://www.lenstip.com/1876-Canon_RF_100-400_mm_f_5.6-8_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1713,
+        "name": "Canon RF 100-500 mm f/4.5-7.1L IS USM",
+        "url": "https://www.lenstip.com/1713-Canon_RF_100-500_mm_f_4.5-7.1L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1922,
+        "name": "Canon RF 1200 mm f/8L IS USM",
+        "url": "https://www.lenstip.com/1922-Canon_RF_1200_mm_f_8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1997,
+        "name": "Canon RF 135 mm f/1.8L IS USM",
+        "url": "https://www.lenstip.com/1997-Canon_RF_135_mm_f_1.8L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2300,
+        "name": "Canon RF 14 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2300-Canon_RF_14_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 1851,
+        "name": "Canon RF 14-35 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/1851-Canon_RF_14-35_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1959,
+        "name": "Canon RF 15-30 mm f/4.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1959-Canon_RF_15-30_mm_f_4.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1639,
+        "name": "Canon RF 15-35 mm f/2.8L IS USM",
+        "url": "https://www.lenstip.com/1639-Canon_RF_15-35_mm_f_2.8L_IS_USM_-lens_specifications.html"
+      },
+      {
+        "id": 1875,
+        "name": "Canon RF 16 mm f/2.8 STM",
+        "url": "https://www.lenstip.com/1875-Canon_RF_16_mm_f_2.8_STM-lens_specifications.html"
+      },
+      {
+        "id": 2198,
+        "name": "Canon RF 16-28 mm f/2.8 IS STM",
+        "url": "https://www.lenstip.com/2198-Canon_RF_16-28_mm_f_2.8_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 2217,
+        "name": "Canon RF 20 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2217-Canon_RF_20_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 2331,
+        "name": "Canon RF 20-50 mm f/4L IS USM PZ",
+        "url": "https://www.lenstip.com/2331-Canon_RF_20-50_mm_f_4L_IS_USM_PZ-lens_specifications.html"
+      },
+      {
+        "id": 2093,
+        "name": "Canon RF 200-800 mm f/6.3-9 IS USM",
+        "url": "https://www.lenstip.com/2093-Canon_RF_200-800_mm_f_6.3-9_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2179,
+        "name": "Canon RF 24 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2179-Canon_RF_24_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 1958,
+        "name": "Canon RF 24 mm f/1.8 IS STM Macro",
+        "url": "https://www.lenstip.com/1958-Canon_RF_24_mm_f_1.8_IS_STM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2092,
+        "name": "Canon RF 24-105 mm f/2.8 L IS USM Z",
+        "url": "https://www.lenstip.com/2092-Canon_RF_24-105_mm_f_2.8_L_IS_USM_Z-lens_specifications.html"
+      },
+      {
+        "id": 1677,
+        "name": "Canon RF 24-105 mm f/4-7.1 IS STM",
+        "url": "https://www.lenstip.com/1677-Canon_RF_24-105_mm_f_4-7.1_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1559,
+        "name": "Canon RF 24-105 mm f/4L IS USM",
+        "url": "https://www.lenstip.com/1559-Canon_RF_24-105_mm_f_4L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1628,
+        "name": "Canon RF 24-240 mm f/4-6.3 IS USM",
+        "url": "https://www.lenstip.com/1628-Canon_RF_24-240_mm_f_4-6.3_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2027,
+        "name": "Canon RF 24-50 mm f/4.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/2027-Canon_RF_24-50_mm_f_4.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1640,
+        "name": "Canon RF 24-70 mm f/2.8 L IS USM",
+        "url": "https://www.lenstip.com/1640-Canon_RF_24-70_mm_f_2.8_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2053,
+        "name": "Canon RF 28 mm f/2.8 STM",
+        "url": "https://www.lenstip.com/2053-Canon_RF_28_mm_f_2.8_STM-lens_specifications.html"
+      },
+      {
+        "id": 2166,
+        "name": "Canon RF 28-70 mm f/2.8 IS STM",
+        "url": "https://www.lenstip.com/2166-Canon_RF_28-70_mm_f_2.8_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1562,
+        "name": "Canon RF 28-70 mm f/2L USM",
+        "url": "https://www.lenstip.com/1562-Canon_RF_28-70_mm_f_2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 2138,
+        "name": "Canon RF 35 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2138-Canon_RF_35_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 1560,
+        "name": "Canon RF 35 mm f/1.8 IS STM Macro",
+        "url": "https://www.lenstip.com/1560-Canon_RF_35_mm_f_1.8_IS_STM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1826,
+        "name": "Canon RF 400 mm f/2.8 L IS USM",
+        "url": "https://www.lenstip.com/1826-Canon_RF_400_mm_f_2.8_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2287,
+        "name": "Canon RF 45 mm f/1.2 STM",
+        "url": "https://www.lenstip.com/2287-Canon_RF_45_mm_f_1.2_STM-lens_specifications.html"
+      },
+      {
+        "id": 1887,
+        "name": "Canon RF 5.2 mm f/2.8L Dual Fisheye",
+        "url": "https://www.lenstip.com/1887-Canon_RF_5.2_mm_f_2.8L_Dual_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1561,
+        "name": "Canon RF 50 mm f/1.2L USM",
+        "url": "https://www.lenstip.com/1561-Canon_RF_50_mm_f_1.2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 2180,
+        "name": "Canon RF 50 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2180-Canon_RF_50_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 1764,
+        "name": "Canon RF 50 mm f/1.8 STM",
+        "url": "https://www.lenstip.com/1764-Canon_RF_50_mm_f_1.8_STM-lens_specifications.html"
+      },
+      {
+        "id": 1714,
+        "name": "Canon RF 600 mm f/11 IS STM",
+        "url": "https://www.lenstip.com/1714-Canon_RF_600_mm_f_11_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1827,
+        "name": "Canon RF 600 mm f/4 L IS USM",
+        "url": "https://www.lenstip.com/1827-Canon_RF_600_mm_f_4_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2299,
+        "name": "Canon RF 7-14 mm f/2.8-3.5L Fisheye STM",
+        "url": "https://www.lenstip.com/2299-Canon_RF_7-14_mm_f_2.8-3.5L_Fisheye_STM-lens_specifications.html"
+      },
+      {
+        "id": 1658,
+        "name": "Canon RF 70-200 mm f/2.8 L IS USM",
+        "url": "https://www.lenstip.com/1658-Canon_RF_70-200_mm_f_2.8_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2181,
+        "name": "Canon RF 70-200 mm f/2.8L IS USM Z",
+        "url": "https://www.lenstip.com/2181-Canon_RF_70-200_mm_f_2.8L_IS_USM_Z-lens_specifications.html"
+      },
+      {
+        "id": 1765,
+        "name": "Canon RF 70-200 mm f/4 L IS USM",
+        "url": "https://www.lenstip.com/1765-Canon_RF_70-200_mm_f_4_L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 2227,
+        "name": "Canon RF 75-300 mm f/4-5.6",
+        "url": "https://www.lenstip.com/2227-Canon_RF_75-300_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1715,
+        "name": "Canon RF 800 mm f/11 IS STM",
+        "url": "https://www.lenstip.com/1715-Canon_RF_800_mm_f_11_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1921,
+        "name": "Canon RF 800 mm f/5.6L IS USM",
+        "url": "https://www.lenstip.com/1921-Canon_RF_800_mm_f_5.6L_IS_USM-lens_specifications.html"
+      },
+      {
+        "id": 1620,
+        "name": "Canon RF 85 mm f/1.2L USM",
+        "url": "https://www.lenstip.com/1620-Canon_RF_85_mm_f_1.2L_USM-lens_specifications.html"
+      },
+      {
+        "id": 1659,
+        "name": "Canon RF 85 mm f/1.2L USM DS",
+        "url": "https://www.lenstip.com/1659-Canon_RF_85_mm_f_1.2L_USM_DS-lens_specifications.html"
+      },
+      {
+        "id": 2263,
+        "name": "Canon RF 85 mm f/1.4L VCM",
+        "url": "https://www.lenstip.com/2263-Canon_RF_85_mm_f_1.4L_VCM-lens_specifications.html"
+      },
+      {
+        "id": 1712,
+        "name": "Canon RF 85 mm f/2 MACRO IS STM",
+        "url": "https://www.lenstip.com/1712-Canon_RF_85_mm_f_2_MACRO_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 2094,
+        "name": "Canon RF-S 10-18 mm f/4.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/2094-Canon_RF-S_10-18_mm_f_4.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 2216,
+        "name": "Canon RF-S 14-30 mm f/4-6.3 IS STM PZ",
+        "url": "https://www.lenstip.com/2216-Canon_RF-S_14-30_mm_f_4-6.3_IS_STM_PZ-lens_specifications.html"
+      },
+      {
+        "id": 1947,
+        "name": "Canon RF-S 18-150 mm f/3.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1947-Canon_RF-S_18-150_mm_f_3.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 1946,
+        "name": "Canon RF-S 18-45 mm f/4.5-6.3 IS STM",
+        "url": "https://www.lenstip.com/1946-Canon_RF-S_18-45_mm_f_4.5-6.3_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 2140,
+        "name": "Canon RF-S 3.9 mm f/3.5 STM Dual Fisheye",
+        "url": "https://www.lenstip.com/2140-Canon_RF-S_3.9_mm_f_3.5_STM_Dual_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2026,
+        "name": "Canon RF-S 55-210 mm f/5-7.1 IS STM",
+        "url": "https://www.lenstip.com/2026-Canon_RF-S_55-210_mm_f_5-7.1_IS_STM-lens_specifications.html"
+      },
+      {
+        "id": 2182,
+        "name": "Canon RF-S 7.8 mm f/4 STM Dual",
+        "url": "https://www.lenstip.com/2182-Canon_RF-S_7.8_mm_f_4_STM_Dual-lens_specifications.html"
+      },
+      {
+        "id": 1480,
+        "name": "Canon TS-E 135 mm f/4L MACRO",
+        "url": "https://www.lenstip.com/1480-Canon_TS-E_135_mm_f_4L_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 838,
+        "name": "Canon TS-E 17 mm f/4L",
+        "url": "https://www.lenstip.com/838-Canon_TS-E_17_mm_f_4L_-lens_specifications.html"
+      },
+      {
+        "id": 828,
+        "name": "Canon TS-E 24 mm f/3.5L",
+        "url": "https://www.lenstip.com/828-Canon_TS-E_24_mm_f_3.5L-lens_specifications.html"
+      },
+      {
+        "id": 837,
+        "name": "Canon TS-E 24 mm f/3.5L II",
+        "url": "https://www.lenstip.com/837-Canon_TS-E_24_mm_f_3.5L_II_-lens_specifications.html"
+      },
+      {
+        "id": 830,
+        "name": "Canon TS-E 45 mm f/2.8",
+        "url": "https://www.lenstip.com/830-Canon_TS-E_45_mm_f_2.8_-lens_specifications.html"
+      },
+      {
+        "id": 1479,
+        "name": "Canon TS-E 50 mm f/2.8L MACRO",
+        "url": "https://www.lenstip.com/1479-Canon_TS-E_50_mm_f_2.8L_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 829,
+        "name": "Canon TS-E 90 mm f/2.8",
+        "url": "https://www.lenstip.com/829-Canon_TS-E_90_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1478,
+        "name": "Canon TS-E 90 mm f/2.8L MACRO",
+        "url": "https://www.lenstip.com/1478-Canon_TS-E_90_mm_f_2.8L_MACRO-lens_specifications.html"
+      }
+    ],
+    "Carl Zeiss": [
+      {
+        "id": 1067,
+        "name": "Carl Zeiss Apo Sonnar T* 135 mm f/2.0 ZE/ZF.2",
+        "url": "https://www.lenstip.com/1067-Carl_Zeiss_Apo_Sonnar_T*_135_mm_f_2.0_ZE_ZF.2-lens_specifications.html"
+      },
+      {
+        "id": 542,
+        "name": "Carl Zeiss Aposonnar 200 mm f/2",
+        "url": "https://www.lenstip.com/542-Carl_Zeiss_Aposonnar_200_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1457,
+        "name": "Carl Zeiss Batis 135 mm f/2.8",
+        "url": "https://www.lenstip.com/1457-Carl_Zeiss_Batis_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1362,
+        "name": "Carl Zeiss Batis 18 mm f/2.8",
+        "url": "https://www.lenstip.com/1362-Carl_Zeiss_Batis_18_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1286,
+        "name": "Carl Zeiss Batis 25 mm f/2",
+        "url": "https://www.lenstip.com/1286-Carl_Zeiss_Batis_25_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1577,
+        "name": "Carl Zeiss Batis 40 mm f/2 CF",
+        "url": "https://www.lenstip.com/1577-Carl_Zeiss_Batis_40_mm_f_2_CF_-lens_specifications.html"
+      },
+      {
+        "id": 1287,
+        "name": "Carl Zeiss Batis 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1287-Carl_Zeiss_Batis_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 535,
+        "name": "Carl Zeiss Biogon T* 21 mm f/2.8 ZM",
+        "url": "https://www.lenstip.com/535-Carl_Zeiss_Biogon_T*_21_mm_f_2.8_ZM-lens_specifications.html"
+      },
+      {
+        "id": 536,
+        "name": "Carl Zeiss Biogon T* 25 mm f/2.8 ZM",
+        "url": "https://www.lenstip.com/536-Carl_Zeiss_Biogon_T*_25_mm_f_2.8_ZM-lens_specifications.html"
+      },
+      {
+        "id": 537,
+        "name": "Carl Zeiss Biogon T* 28 mm f/2.8 ZM",
+        "url": "https://www.lenstip.com/537-Carl_Zeiss_Biogon_T*_28_mm_f_2.8_ZM-lens_specifications.html"
+      },
+      {
+        "id": 538,
+        "name": "Carl Zeiss Biogon T* 35 mm f/2 ZM",
+        "url": "https://www.lenstip.com/538-Carl_Zeiss_Biogon_T*_35_mm_f_2_ZM-lens_specifications.html"
+      },
+      {
+        "id": 787,
+        "name": "Carl Zeiss C Biogon T* 35 mm f/2.8 ZM",
+        "url": "https://www.lenstip.com/787-Carl_Zeiss_C_Biogon_T*_35_mm_f_2.8_ZM-lens_specifications.html"
+      },
+      {
+        "id": 541,
+        "name": "Carl Zeiss C Sonnar T* 50 mm f/1.5 ZM",
+        "url": "https://www.lenstip.com/541-Carl_Zeiss_C_Sonnar_T*_50_mm_f_1.5_ZM-lens_specifications.html"
+      },
+      {
+        "id": 1244,
+        "name": "Carl Zeiss Distagon T 35 mm f/1.4 ZM",
+        "url": "https://www.lenstip.com/1244-Carl_Zeiss_Distagon_T_35_mm_f_1.4_ZM-lens_specifications.html"
+      },
+      {
+        "id": 1040,
+        "name": "Carl Zeiss Distagon T* 15 mm f/2.8 ZE/ZF.2",
+        "url": "https://www.lenstip.com/1040-Carl_Zeiss_Distagon_T*_15_mm_f_2.8_ZE_ZF.2-lens_specifications.html"
+      },
+      {
+        "id": 534,
+        "name": "Carl Zeiss Distagon T* 15 mm f/2.8 ZM",
+        "url": "https://www.lenstip.com/534-Carl_Zeiss_Distagon_T*_15_mm_f_2.8_ZM-lens_specifications.html"
+      },
+      {
+        "id": 549,
+        "name": "Carl Zeiss Distagon T* 15 mm f/3.5",
+        "url": "https://www.lenstip.com/549-Carl_Zeiss_Distagon_T*_15_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 796,
+        "name": "Carl Zeiss Distagon T* 18 mm f/3.5 ZF/ZK/ZE",
+        "url": "https://www.lenstip.com/796-Carl_Zeiss_Distagon_T*_18_mm_f_3.5_ZF_ZK_ZE-lens_specifications.html"
+      },
+      {
+        "id": 550,
+        "name": "Carl Zeiss Distagon T* 18 mm f/4",
+        "url": "https://www.lenstip.com/550-Carl_Zeiss_Distagon_T*_18_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 544,
+        "name": "Carl Zeiss Distagon T* 21 mm f/2.8",
+        "url": "https://www.lenstip.com/544-Carl_Zeiss_Distagon_T*_21_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 813,
+        "name": "Carl Zeiss Distagon T* 21 mm f/2.8 ZE/ZF/ZK",
+        "url": "https://www.lenstip.com/813-Carl_Zeiss_Distagon_T*_21_mm_f_2.8_ZE_ZF_ZK-lens_specifications.html"
+      },
+      {
+        "id": 1011,
+        "name": "Carl Zeiss Distagon T* 25 mm f/2.0 ZE/ZF.2",
+        "url": "https://www.lenstip.com/1011-Carl_Zeiss_Distagon_T*_25_mm_f_2.0_ZE_ZF.2-lens_specifications.html"
+      },
+      {
+        "id": 545,
+        "name": "Carl Zeiss Distagon T* 25 mm f/2.8",
+        "url": "https://www.lenstip.com/545-Carl_Zeiss_Distagon_T*_25_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 529,
+        "name": "Carl Zeiss Distagon T* 25 mm f/2.8 ZF/ZK/ZS",
+        "url": "https://www.lenstip.com/529-Carl_Zeiss_Distagon_T*_25_mm_f_2.8_ZF_ZK_ZS-lens_specifications.html"
+      },
+      {
+        "id": 654,
+        "name": "Carl Zeiss Distagon T* 28 mm f/2.0 ZF/ZK/ZE",
+        "url": "https://www.lenstip.com/654-Carl_Zeiss_Distagon_T*_28_mm_f_2.0_ZF_ZK_ZE-lens_specifications.html"
+      },
+      {
+        "id": 546,
+        "name": "Carl Zeiss Distagon T* 28 mm f/2.8",
+        "url": "https://www.lenstip.com/546-Carl_Zeiss_Distagon_T*_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 548,
+        "name": "Carl Zeiss Distagon T* 28 mm f/2.8",
+        "url": "https://www.lenstip.com/548-Carl_Zeiss_Distagon_T*_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 543,
+        "name": "Carl Zeiss Distagon T* 35 mm f/1.4",
+        "url": "https://www.lenstip.com/543-Carl_Zeiss_Distagon_T*_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 950,
+        "name": "Carl Zeiss Distagon T* 35 mm f/1.4 ZE/ZF.2",
+        "url": "https://www.lenstip.com/950-Carl_Zeiss_Distagon_T*_35_mm_f_1.4_ZE_ZF.2-lens_specifications.html"
+      },
+      {
+        "id": 530,
+        "name": "Carl Zeiss Distagon T* 35 mm f/2 ZF/ZK/ZS/ZE",
+        "url": "https://www.lenstip.com/530-Carl_Zeiss_Distagon_T*_35_mm_f_2_ZF_ZK_ZS_ZE-lens_specifications.html"
+      },
+      {
+        "id": 547,
+        "name": "Carl Zeiss Distagon T* 35 mm f/2.8",
+        "url": "https://www.lenstip.com/547-Carl_Zeiss_Distagon_T*_35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 791,
+        "name": "Carl Zeiss Distagon T* 50 mm f/4.0 ZV",
+        "url": "https://www.lenstip.com/791-Carl_Zeiss_Distagon_T*_50_mm_f_4.0_ZV-lens_specifications.html"
+      },
+      {
+        "id": 551,
+        "name": "Carl Zeiss F-Distagon T* 16 mm f/2.8",
+        "url": "https://www.lenstip.com/551-Carl_Zeiss_F-Distagon_T*_16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1323,
+        "name": "Carl Zeiss Loxia 21 mm f/2.8",
+        "url": "https://www.lenstip.com/1323-Carl_Zeiss_Loxia_21_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1508,
+        "name": "Carl Zeiss Loxia 25 mm f/2.4",
+        "url": "https://www.lenstip.com/1508-Carl_Zeiss_Loxia_25_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 1217,
+        "name": "Carl Zeiss Loxia 35 mm f/2",
+        "url": "https://www.lenstip.com/1217-Carl_Zeiss_Loxia_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1218,
+        "name": "Carl Zeiss Loxia 50 mm f/2",
+        "url": "https://www.lenstip.com/1218-Carl_Zeiss_Loxia_50_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1394,
+        "name": "Carl Zeiss Loxia 85 mm f/2.4",
+        "url": "https://www.lenstip.com/1394-Carl_Zeiss_Loxia_85_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 533,
+        "name": "Carl Zeiss Makro-Planar T* 100 mm f/2 ZF.2/ZE",
+        "url": "https://www.lenstip.com/533-Carl_Zeiss_Makro-Planar_T*_100_mm_f_2_ZF.2_ZE-lens_specifications.html"
+      },
+      {
+        "id": 554,
+        "name": "Carl Zeiss Makro-Planar T* 100 mm f/2.8",
+        "url": "https://www.lenstip.com/554-Carl_Zeiss_Makro-Planar_T*_100_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 792,
+        "name": "Carl Zeiss Makro-Planar T* 120 mm f/4.0 ZV",
+        "url": "https://www.lenstip.com/792-Carl_Zeiss_Makro-Planar_T*_120_mm_f_4.0_ZV-lens_specifications.html"
+      },
+      {
+        "id": 532,
+        "name": "Carl Zeiss Makro-Planar T* 50 mm f/2 ZF/ZK/ZE",
+        "url": "https://www.lenstip.com/532-Carl_Zeiss_Makro-Planar_T*_50_mm_f_2_ZF_ZK_ZE-lens_specifications.html"
+      },
+      {
+        "id": 553,
+        "name": "Carl Zeiss Makro-Planar T* 60 mm f/2.8",
+        "url": "https://www.lenstip.com/553-Carl_Zeiss_Makro-Planar_T*_60_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 552,
+        "name": "Carl Zeiss Makro-Planar T* 60 mm f/2.8 C",
+        "url": "https://www.lenstip.com/552-Carl_Zeiss_Makro-Planar_T*_60_mm_f_2.8_C-lens_specifications.html"
+      },
+      {
+        "id": 1312,
+        "name": "Carl Zeiss Milvus 100 mm f/2M",
+        "url": "https://www.lenstip.com/1312-Carl_Zeiss_Milvus_100_mm_f_2M-lens_specifications.html"
+      },
+      {
+        "id": 1387,
+        "name": "Carl Zeiss Milvus 135 mm f/2",
+        "url": "https://www.lenstip.com/1387-Carl_Zeiss_Milvus_135_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1386,
+        "name": "Carl Zeiss Milvus 15 mm f/2.8",
+        "url": "https://www.lenstip.com/1386-Carl_Zeiss_Milvus_15_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1388,
+        "name": "Carl Zeiss Milvus 18 mm f/2.8",
+        "url": "https://www.lenstip.com/1388-Carl_Zeiss_Milvus_18_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1310,
+        "name": "Carl Zeiss Milvus 21 mm f/2.8",
+        "url": "https://www.lenstip.com/1310-Carl_Zeiss_Milvus_21_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1488,
+        "name": "Carl Zeiss Milvus 25 mm f/1.4",
+        "url": "https://www.lenstip.com/1488-Carl_Zeiss_Milvus_25_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1470,
+        "name": "Carl Zeiss Milvus 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1470-Carl_Zeiss_Milvus_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1311,
+        "name": "Carl Zeiss Milvus 35 mm f/2",
+        "url": "https://www.lenstip.com/1311-Carl_Zeiss_Milvus_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1313,
+        "name": "Carl Zeiss Milvus 50 mm f/1.4",
+        "url": "https://www.lenstip.com/1313-Carl_Zeiss_Milvus_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1314,
+        "name": "Carl Zeiss Milvus 50 mm f/2M",
+        "url": "https://www.lenstip.com/1314-Carl_Zeiss_Milvus_50_mm_f_2M-lens_specifications.html"
+      },
+      {
+        "id": 1315,
+        "name": "Carl Zeiss Milvus 85 mm f/1.4",
+        "url": "https://www.lenstip.com/1315-Carl_Zeiss_Milvus_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 556,
+        "name": "Carl Zeiss Mirotar 1000 mm f/5.6",
+        "url": "https://www.lenstip.com/556-Carl_Zeiss_Mirotar_1000_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 555,
+        "name": "Carl Zeiss Mirotar 500 mm f/4.5",
+        "url": "https://www.lenstip.com/555-Carl_Zeiss_Mirotar_500_mm_f_4.5-lens_specifications.html"
+      },
+      {
+        "id": 1615,
+        "name": "Carl Zeiss Otus 100 mm f/1.4",
+        "url": "https://www.lenstip.com/1615-Carl_Zeiss_Otus_100_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1325,
+        "name": "Carl Zeiss Otus 28 mm f/1.4",
+        "url": "https://www.lenstip.com/1325-Carl_Zeiss_Otus_28_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1152,
+        "name": "Carl Zeiss Otus 55 mm f/1.4 ZE/ZF.2",
+        "url": "https://www.lenstip.com/1152-Carl_Zeiss_Otus_55_mm_f_1.4_ZE_ZF.2-lens_specifications.html"
+      },
+      {
+        "id": 1222,
+        "name": "Carl Zeiss Otus 85 mm f/1.4",
+        "url": "https://www.lenstip.com/1222-Carl_Zeiss_Otus_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2317,
+        "name": "Carl Zeiss Otus ML 35 mm f/1.4",
+        "url": "https://www.lenstip.com/2317-Carl_Zeiss_Otus_ML_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2210,
+        "name": "Carl Zeiss Otus ML 50 mm f/1.4",
+        "url": "https://www.lenstip.com/2210-Carl_Zeiss_Otus_ML_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2211,
+        "name": "Carl Zeiss Otus ML 85 mm f/1.4",
+        "url": "https://www.lenstip.com/2211-Carl_Zeiss_Otus_ML_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 557,
+        "name": "Carl Zeiss PC-Distagon T* 35 mm f/2.8",
+        "url": "https://www.lenstip.com/557-Carl_Zeiss_PC-Distagon_T*_35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 563,
+        "name": "Carl Zeiss Planar T* 100 mm f/2",
+        "url": "https://www.lenstip.com/563-Carl_Zeiss_Planar_T*_100_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 564,
+        "name": "Carl Zeiss Planar T* 135 mm f/2",
+        "url": "https://www.lenstip.com/564-Carl_Zeiss_Planar_T*_135_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 560,
+        "name": "Carl Zeiss Planar T* 50 mm f/1.4",
+        "url": "https://www.lenstip.com/560-Carl_Zeiss_Planar_T*_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 528,
+        "name": "Carl Zeiss Planar T* 50 mm f/1.4 ZF/ZK/ZE",
+        "url": "https://www.lenstip.com/528-Carl_Zeiss_Planar_T*_50_mm_f_1.4_ZF_ZK_ZE-lens_specifications.html"
+      },
+      {
+        "id": 562,
+        "name": "Carl Zeiss Planar T* 50 mm f/1.7",
+        "url": "https://www.lenstip.com/562-Carl_Zeiss_Planar_T*_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 539,
+        "name": "Carl Zeiss Planar T* 50 mm f/2 ZM",
+        "url": "https://www.lenstip.com/539-Carl_Zeiss_Planar_T*_50_mm_f_2_ZM-lens_specifications.html"
+      },
+      {
+        "id": 558,
+        "name": "Carl Zeiss Planar T* 55 mm f/1.2",
+        "url": "https://www.lenstip.com/558-Carl_Zeiss_Planar_T*_55_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 559,
+        "name": "Carl Zeiss Planar T* 85 mm f/1.2",
+        "url": "https://www.lenstip.com/559-Carl_Zeiss_Planar_T*_85_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 561,
+        "name": "Carl Zeiss Planar T* 85 mm f/1.4",
+        "url": "https://www.lenstip.com/561-Carl_Zeiss_Planar_T*_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 531,
+        "name": "Carl Zeiss Planar T* 85 mm f/1.4 ZF/ZK/ZE",
+        "url": "https://www.lenstip.com/531-Carl_Zeiss_Planar_T*_85_mm_f_1.4_ZF_ZK_ZE-lens_specifications.html"
+      },
+      {
+        "id": 568,
+        "name": "Carl Zeiss S-Planar 100 mm f/4",
+        "url": "https://www.lenstip.com/568-Carl_Zeiss_S-Planar_100_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 566,
+        "name": "Carl Zeiss Sonnar T* 135 mm f/2.8",
+        "url": "https://www.lenstip.com/566-Carl_Zeiss_Sonnar_T*_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 567,
+        "name": "Carl Zeiss Sonnar T* 180 mm f/2.8",
+        "url": "https://www.lenstip.com/567-Carl_Zeiss_Sonnar_T*_180_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 793,
+        "name": "Carl Zeiss Sonnar T* 180 mm f/4 ZV",
+        "url": "https://www.lenstip.com/793-Carl_Zeiss_Sonnar_T*_180_mm_f_4_ZV-lens_specifications.html"
+      },
+      {
+        "id": 565,
+        "name": "Carl Zeiss Sonnar T* 85 mm f/2 8",
+        "url": "https://www.lenstip.com/565-Carl_Zeiss_Sonnar_T*_85_mm_f_2_8-lens_specifications.html"
+      },
+      {
+        "id": 540,
+        "name": "Carl Zeiss Sonnar T* 85 mm f/2 ZM",
+        "url": "https://www.lenstip.com/540-Carl_Zeiss_Sonnar_T*_85_mm_f_2_ZM-lens_specifications.html"
+      },
+      {
+        "id": 571,
+        "name": "Carl Zeiss Tele-Apotessar T* 300 mm f/2.8",
+        "url": "https://www.lenstip.com/571-Carl_Zeiss_Tele-Apotessar_T*_300_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 569,
+        "name": "Carl Zeiss Tele-Apotessar T* 500 mm f/5.6",
+        "url": "https://www.lenstip.com/569-Carl_Zeiss_Tele-Apotessar_T*_500_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 570,
+        "name": "Carl Zeiss Tele-Apotessar T* 800 mm f/8",
+        "url": "https://www.lenstip.com/570-Carl_Zeiss_Tele-Apotessar_T*_800_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 572,
+        "name": "Carl Zeiss Tele-Tessar T* 200 mm f/3.5",
+        "url": "https://www.lenstip.com/572-Carl_Zeiss_Tele-Tessar_T*_200_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 573,
+        "name": "Carl Zeiss Tele-Tessar T* 300 mm f/4",
+        "url": "https://www.lenstip.com/573-Carl_Zeiss_Tele-Tessar_T*_300_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 815,
+        "name": "Carl Zeiss Tele-Tessar T* 85 mm f/4 ZM",
+        "url": "https://www.lenstip.com/815-Carl_Zeiss_Tele-Tessar_T*_85_mm_f_4_ZM-lens_specifications.html"
+      },
+      {
+        "id": 574,
+        "name": "Carl Zeiss Tessar T* 45 mm f/2.8",
+        "url": "https://www.lenstip.com/574-Carl_Zeiss_Tessar_T*_45_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1120,
+        "name": "Carl Zeiss Touit 12 mm f/2.8",
+        "url": "https://www.lenstip.com/1120-Carl_Zeiss_Touit_12_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1121,
+        "name": "Carl Zeiss Touit 32 mm f/1.8",
+        "url": "https://www.lenstip.com/1121-Carl_Zeiss_Touit_32_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1178,
+        "name": "Carl Zeiss Touit M 50 mm f/2.8",
+        "url": "https://www.lenstip.com/1178-Carl_Zeiss_Touit_M_50_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 581,
+        "name": "Carl Zeiss Vario-Sonnar T* 100-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/581-Carl_Zeiss_Vario-Sonnar_T*_100-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 578,
+        "name": "Carl Zeiss Vario-Sonnar T* 28-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/578-Carl_Zeiss_Vario-Sonnar_T*_28-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 575,
+        "name": "Carl Zeiss Vario-Sonnar T* 28-85 mm f/3.3-4",
+        "url": "https://www.lenstip.com/575-Carl_Zeiss_Vario-Sonnar_T*_28-85_mm_f_3.3-4-lens_specifications.html"
+      },
+      {
+        "id": 576,
+        "name": "Carl Zeiss Vario-Sonnar T* 35-135 mm f/3.3-4.5",
+        "url": "https://www.lenstip.com/576-Carl_Zeiss_Vario-Sonnar_T*_35-135_mm_f_3.3-4.5-lens_specifications.html"
+      },
+      {
+        "id": 577,
+        "name": "Carl Zeiss Vario-Sonnar T* 35-70 mm f/3.4",
+        "url": "https://www.lenstip.com/577-Carl_Zeiss_Vario-Sonnar_T*_35-70_mm_f_3.4-lens_specifications.html"
+      },
+      {
+        "id": 579,
+        "name": "Carl Zeiss Vario-Sonnar T* 40-80 mm f/3.5",
+        "url": "https://www.lenstip.com/579-Carl_Zeiss_Vario-Sonnar_T*_40-80_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 580,
+        "name": "Carl Zeiss Vario-Sonnar T* 70-210 mm f/3.5",
+        "url": "https://www.lenstip.com/580-Carl_Zeiss_Vario-Sonnar_T*_70-210_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 582,
+        "name": "Carl Zeiss Vario-Sonnar T* 80-200 mm f/4",
+        "url": "https://www.lenstip.com/582-Carl_Zeiss_Vario-Sonnar_T*_80-200_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1619,
+        "name": "Carl Zeiss Ventum 21 mm f/2.8",
+        "url": "https://www.lenstip.com/1619-Carl_Zeiss_Ventum_21_mm_f_2.8-lens_specifications.html"
+      }
+    ],
+    "CCCP": [
+      {
+        "id": 780,
+        "name": "CCCP Era-6M 50 mm f/1.5",
+        "url": "https://www.lenstip.com/780-CCCP_Era-6M_50_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 1128,
+        "name": "CCCP Helios 40-2 85 mm f/1.5",
+        "url": "https://www.lenstip.com/1128-CCCP_Helios_40-2_85_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 737,
+        "name": "CCCP Helios-103 53 mm f/1.8",
+        "url": "https://www.lenstip.com/737-CCCP_Helios-103_53_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 775,
+        "name": "CCCP Helios-70 52 mm f/1.9",
+        "url": "https://www.lenstip.com/775-CCCP_Helios-70_52_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 738,
+        "name": "CCCP Helios-94 50 mm f/1.8",
+        "url": "https://www.lenstip.com/738-CCCP_Helios-94_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 778,
+        "name": "CCCP Helios-97M 52 mm f/2.0",
+        "url": "https://www.lenstip.com/778-CCCP_Helios-97M_52_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 781,
+        "name": "CCCP Jupiter-3 50 mm f/1.5",
+        "url": "https://www.lenstip.com/781-CCCP_Jupiter-3_50_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 782,
+        "name": "CCCP Jupiter-8 52 mm f/2.0",
+        "url": "https://www.lenstip.com/782-CCCP_Jupiter-8_52_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 784,
+        "name": "CCCP Kaleinar-5N 100 mm f/2.8",
+        "url": "https://www.lenstip.com/784-CCCP_Kaleinar-5N_100_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 744,
+        "name": "CCCP MC APO Telezenitar-K 135 mm f/2.8",
+        "url": "https://www.lenstip.com/744-CCCP_MC_APO_Telezenitar-K_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 745,
+        "name": "CCCP MC APO Telezenitar-K/M 300 mm f/4.5",
+        "url": "https://www.lenstip.com/745-CCCP_MC_APO_Telezenitar-K_M_300_mm_f_4.5-lens_specifications.html"
+      },
+      {
+        "id": 743,
+        "name": "CCCP MC APO Telezenitar-M 135 mm f/2.8",
+        "url": "https://www.lenstip.com/743-CCCP_MC_APO_Telezenitar-M_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 772,
+        "name": "CCCP MC Helios-113 40 mm f/1.8",
+        "url": "https://www.lenstip.com/772-CCCP_MC_Helios-113_40_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 776,
+        "name": "CCCP MC Helios-77M-4 52 mm f/1.8",
+        "url": "https://www.lenstip.com/776-CCCP_MC_Helios-77M-4_52_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 777,
+        "name": "CCCP MC Helios-81N 52 mm f/2.0",
+        "url": "https://www.lenstip.com/777-CCCP_MC_Helios-81N_52_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 761,
+        "name": "CCCP MC Mir-20K 20 mm f/3.5",
+        "url": "https://www.lenstip.com/761-CCCP_MC_Mir-20K_20_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 739,
+        "name": "CCCP MC Mir-20M 20 mm f/3.5",
+        "url": "https://www.lenstip.com/739-CCCP_MC_Mir-20M_20_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 765,
+        "name": "CCCP MC Mir-20N 20 mm f/3.5",
+        "url": "https://www.lenstip.com/765-CCCP_MC_Mir-20N_20_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 762,
+        "name": "CCCP MC Mir-24M 35 mm f/2.0",
+        "url": "https://www.lenstip.com/762-CCCP_MC_Mir-24M_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 771,
+        "name": "CCCP MC Mir-24N 35 mm f/2.0",
+        "url": "https://www.lenstip.com/771-CCCP_MC_Mir-24N_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 769,
+        "name": "CCCP MC Mir-46MA/MK 35 mm f/1.4",
+        "url": "https://www.lenstip.com/769-CCCP_MC_Mir-46MA_MK_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 766,
+        "name": "CCCP MC Mir-47K 20 mm f/2.5",
+        "url": "https://www.lenstip.com/766-CCCP_MC_Mir-47K_20_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 763,
+        "name": "CCCP MC Mir-47M 20 mm f/2.5",
+        "url": "https://www.lenstip.com/763-CCCP_MC_Mir-47M_20_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 764,
+        "name": "CCCP MC Mir-51M 15 mm f/3.5",
+        "url": "https://www.lenstip.com/764-CCCP_MC_Mir-51M_15_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 746,
+        "name": "CCCP MC Variozenitar-K 25-45 mm f/2.8-3.5",
+        "url": "https://www.lenstip.com/746-CCCP_MC_Variozenitar-K_25-45_mm_f_2.8-3.5-lens_specifications.html"
+      },
+      {
+        "id": 754,
+        "name": "CCCP MC Variozenitar-K 35-105 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/754-CCCP_MC_Variozenitar-K_35-105_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 753,
+        "name": "CCCP MC Variozenitar-K 70-210 mm f/4.0",
+        "url": "https://www.lenstip.com/753-CCCP_MC_Variozenitar-K_70-210_mm_f_4.0-lens_specifications.html"
+      },
+      {
+        "id": 752,
+        "name": "CCCP MC Zenitar-1K 85 mm f/1.4",
+        "url": "https://www.lenstip.com/752-CCCP_MC_Zenitar-1K_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 741,
+        "name": "CCCP MC Zenitar-K 16 mm f/2.8 Fish Eye",
+        "url": "https://www.lenstip.com/741-CCCP_MC_Zenitar-K_16_mm_f_2.8_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 751,
+        "name": "CCCP MC Zenitar-K 28 mm f/2.8",
+        "url": "https://www.lenstip.com/751-CCCP_MC_Zenitar-K_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 749,
+        "name": "CCCP MC Zenitar-K 50 mm f/1.4",
+        "url": "https://www.lenstip.com/749-CCCP_MC_Zenitar-K_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 748,
+        "name": "CCCP MC Zenitar-K 50 mm f/2.0 Experimental",
+        "url": "https://www.lenstip.com/748-CCCP_MC_Zenitar-K_50_mm_f_2.0_Experimental-lens_specifications.html"
+      },
+      {
+        "id": 760,
+        "name": "CCCP MC Zenitar-K 85 mm f/1.4",
+        "url": "https://www.lenstip.com/760-CCCP_MC_Zenitar-K_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 750,
+        "name": "CCCP MC Zenitar-K/M 20 mm f/2.8",
+        "url": "https://www.lenstip.com/750-CCCP_MC_Zenitar-K_M_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 747,
+        "name": "CCCP MC Zenitar-K/M 50 mm f/1.9",
+        "url": "https://www.lenstip.com/747-CCCP_MC_Zenitar-K_M_50_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 755,
+        "name": "CCCP MC Zenitar-K/M 50 mm f/2.0",
+        "url": "https://www.lenstip.com/755-CCCP_MC_Zenitar-K_M_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 756,
+        "name": "CCCP MC Zenitar-K2/M2 50 mm f/2.0",
+        "url": "https://www.lenstip.com/756-CCCP_MC_Zenitar-K2_M2_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 742,
+        "name": "CCCP MC Zenitar-M 16 mm f/2.8 Fish Eye",
+        "url": "https://www.lenstip.com/742-CCCP_MC_Zenitar-M_16_mm_f_2.8_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 757,
+        "name": "CCCP MC Zenitar-M 50 mm f/1.7",
+        "url": "https://www.lenstip.com/757-CCCP_MC_Zenitar-M_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 759,
+        "name": "CCCP MC Zenitar-ME1 50 mm f/1.7",
+        "url": "https://www.lenstip.com/759-CCCP_MC_Zenitar-ME1_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 740,
+        "name": "CCCP MC Zenitar-N 16 mm f/2.8 Fish Eye",
+        "url": "https://www.lenstip.com/740-CCCP_MC_Zenitar-N_16_mm_f_2.8_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 768,
+        "name": "CCCP Mir-10A/M 28 mm f/3.5",
+        "url": "https://www.lenstip.com/768-CCCP_Mir-10A_M_28_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 767,
+        "name": "CCCP Mir-32M 24 mm f/2.4",
+        "url": "https://www.lenstip.com/767-CCCP_Mir-32M_24_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 785,
+        "name": "CCCP Oberon-11K 200 mm f/2.8",
+        "url": "https://www.lenstip.com/785-CCCP_Oberon-11K_200_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 779,
+        "name": "CCCP Rekord-4 52 mm f/0.9",
+        "url": "https://www.lenstip.com/779-CCCP_Rekord-4_52_mm_f_0.9-lens_specifications.html"
+      },
+      {
+        "id": 783,
+        "name": "CCCP Vega-13A/M 100 mm f/2.8",
+        "url": "https://www.lenstip.com/783-CCCP_Vega-13A_M_100_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 770,
+        "name": "CCCP Volna-10 35 mm f/1.8",
+        "url": "https://www.lenstip.com/770-CCCP_Volna-10_35_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 774,
+        "name": "CCCP Volna-4 50 mm f/1.4",
+        "url": "https://www.lenstip.com/774-CCCP_Volna-4_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 773,
+        "name": "CCCP Volna-8 50 mm f/1.2",
+        "url": "https://www.lenstip.com/773-CCCP_Volna-8_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 758,
+        "name": "CCCP Zodiak-2M-2 15 mm f/3.5",
+        "url": "https://www.lenstip.com/758-CCCP_Zodiak-2M-2_15_mm_f_3.5-lens_specifications.html"
+      }
+    ],
+    "Cosina": [
+      {
+        "id": 187,
+        "name": "Cosina 100 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/187-Cosina_100_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 189,
+        "name": "Cosina 100-300 mm f/5.6-6.7",
+        "url": "https://www.lenstip.com/189-Cosina_100-300_mm_f_5.6-6.7-lens_specifications.html"
+      },
+      {
+        "id": 190,
+        "name": "Cosina 100-400 mm f/4.5- 6.7",
+        "url": "https://www.lenstip.com/190-Cosina_100-400_mm_f_4.5-_6.7-lens_specifications.html"
+      },
+      {
+        "id": 181,
+        "name": "Cosina 19&#8211;35 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/181-Cosina_19&#8211;35_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 183,
+        "name": "Cosina 28-105 mm f/2.8-3.8",
+        "url": "https://www.lenstip.com/183-Cosina_28-105_mm_f_2.8-3.8-lens_specifications.html"
+      },
+      {
+        "id": 184,
+        "name": "Cosina 28-210 mm asf. f/4.2-6.5",
+        "url": "https://www.lenstip.com/184-Cosina_28-210_mm_asf._f_4.2-6.5-lens_specifications.html"
+      },
+      {
+        "id": 188,
+        "name": "Cosina 28-210 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/188-Cosina_28-210_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 185,
+        "name": "Cosina 28-300 mm f/4-6.3",
+        "url": "https://www.lenstip.com/185-Cosina_28-300_mm_f_4-6.3-lens_specifications.html"
+      },
+      {
+        "id": 182,
+        "name": "Cosina 28-80 mm  f/3.5-5.6",
+        "url": "https://www.lenstip.com/182-Cosina_28-80_mm__f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 191,
+        "name": "Cosina 70-210 mm f/2.8-4",
+        "url": "https://www.lenstip.com/191-Cosina_70-210_mm_f_2.8-4-lens_specifications.html"
+      },
+      {
+        "id": 186,
+        "name": "Cosina 70-210 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/186-Cosina_70-210_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 192,
+        "name": "Cosina 70-300 mm f/2.8-4",
+        "url": "https://www.lenstip.com/192-Cosina_70-300_mm_f_2.8-4-lens_specifications.html"
+      }
+    ],
+    "Falcon": [
+      {
+        "id": 887,
+        "name": "Falcon 14 mm f/2.8 IF ED MC Aspherical",
+        "url": "https://www.lenstip.com/887-Falcon_14_mm_f_2.8_IF_ED_MC_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 905,
+        "name": "Falcon 500 mm Mirror MC f/8",
+        "url": "https://www.lenstip.com/905-Falcon_500_mm_Mirror_MC_f_8_-lens_specifications.html"
+      },
+      {
+        "id": 904,
+        "name": "Falcon 500 mm Mirror f/6.3 DX",
+        "url": "https://www.lenstip.com/904-Falcon_500_mm_Mirror_f_6.3_DX_-lens_specifications.html"
+      },
+      {
+        "id": 886,
+        "name": "Falcon 8 mm f/3.5 ED MC Aspherical Fish-eye",
+        "url": "https://www.lenstip.com/886-Falcon_8_mm_f_3.5_ED_MC_Aspherical_Fish-eye-lens_specifications.html"
+      },
+      {
+        "id": 891,
+        "name": "Falcon 85 mm f/1.4 Aspherical IF",
+        "url": "https://www.lenstip.com/891-Falcon_85_mm_f_1.4_Aspherical_IF-lens_specifications.html"
+      }
+    ],
+    "Fujifilm": [
+      {
+        "id": 1591,
+        "name": "Fujifilm Fujinon GF 100-200 mm f/5.6 R LM OIS WR",
+        "url": "https://www.lenstip.com/1591-Fujifilm_Fujinon_GF_100-200_mm_f_5.6_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1459,
+        "name": "Fujifilm Fujinon GF 110 mm f/2 R LM WR",
+        "url": "https://www.lenstip.com/1459-Fujifilm_Fujinon_GF_110_mm_f_2_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 2076,
+        "name": "Fujifilm Fujinon GF 110 mm f/5.6 T/S Macro",
+        "url": "https://www.lenstip.com/2076-Fujifilm_Fujinon_GF_110_mm_f_5.6_T_S_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1438,
+        "name": "Fujifilm Fujinon GF 120 mm f/4 R LM OIS WR Macro",
+        "url": "https://www.lenstip.com/1438-Fujifilm_Fujinon_GF_120_mm_f_4_R_LM_OIS_WR_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1976,
+        "name": "Fujifilm Fujinon GF 20-35 mm f/4 R WR",
+        "url": "https://www.lenstip.com/1976-Fujifilm_Fujinon_GF_20-35_mm_f_4_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1460,
+        "name": "Fujifilm Fujinon GF 23 mm f/4 R LM WR",
+        "url": "https://www.lenstip.com/1460-Fujifilm_Fujinon_GF_23_mm_f_4_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1437,
+        "name": "Fujifilm Fujinon GF 250 mm f/4 R LM OIS WR",
+        "url": "https://www.lenstip.com/1437-Fujifilm_Fujinon_GF_250_mm_f_4_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1707,
+        "name": "Fujifilm Fujinon GF 30 mm f/3.5 R WR",
+        "url": "https://www.lenstip.com/1707-Fujifilm_Fujinon_GF_30_mm_f_3.5_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 2075,
+        "name": "Fujifilm Fujinon GF 30 mm f/5.6 T/S",
+        "url": "https://www.lenstip.com/2075-Fujifilm_Fujinon_GF_30_mm_f_5.6_T_S-lens_specifications.html"
+      },
+      {
+        "id": 1436,
+        "name": "Fujifilm Fujinon GF 32-64 mm f/4 R LM WR",
+        "url": "https://www.lenstip.com/1436-Fujifilm_Fujinon_GF_32-64_mm_f_4_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 2265,
+        "name": "Fujifilm Fujinon GF 32-90 mm T3.5 PZ OIS WR",
+        "url": "https://www.lenstip.com/2265-Fujifilm_Fujinon_GF_32-90_mm_T3.5_PZ_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1873,
+        "name": "Fujifilm Fujinon GF 35-70 mm f/4.5-5.6 WR",
+        "url": "https://www.lenstip.com/1873-Fujifilm_Fujinon_GF_35-70_mm_f_4.5-5.6_WR-lens_specifications.html"
+      },
+      {
+        "id": 1483,
+        "name": "Fujifilm Fujinon GF 45 mm f/2.8 R WR",
+        "url": "https://www.lenstip.com/1483-Fujifilm_Fujinon_GF_45_mm_f_2.8_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1672,
+        "name": "Fujifilm Fujinon GF 45-100 mm F4 R LM OIS WR",
+        "url": "https://www.lenstip.com/1672-Fujifilm_Fujinon_GF_45-100_mm_F4_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1635,
+        "name": "Fujifilm Fujinon GF 50 mm f/3.5 R LM WR",
+        "url": "https://www.lenstip.com/1635-Fujifilm_Fujinon_GF_50_mm_f_3.5_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 2133,
+        "name": "Fujifilm Fujinon GF 500 mm f/5.6 R LM OIS WR",
+        "url": "https://www.lenstip.com/2133-Fujifilm_Fujinon_GF_500_mm_f_5.6_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 2074,
+        "name": "Fujifilm Fujinon GF 55 mm f/1.7 R WR",
+        "url": "https://www.lenstip.com/2074-Fujifilm_Fujinon_GF_55_mm_f_1.7_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1435,
+        "name": "Fujifilm Fujinon GF 63 mm f/2.8 R WR",
+        "url": "https://www.lenstip.com/1435-Fujifilm_Fujinon_GF_63_mm_f_2.8_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1802,
+        "name": "Fujifilm Fujinon GF 80 mm f/1.7 R WR",
+        "url": "https://www.lenstip.com/1802-Fujifilm_Fujinon_GF_80_mm_f_1.7_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1450,
+        "name": "Fujifilm Fujinon MK 18-55 mm T2.9",
+        "url": "https://www.lenstip.com/1450-Fujifilm_Fujinon_MK_18-55_mm_T2.9-lens_specifications.html"
+      },
+      {
+        "id": 1451,
+        "name": "Fujifilm Fujinon MK 50-135 mm T2.9",
+        "url": "https://www.lenstip.com/1451-Fujifilm_Fujinon_MK_50-135_mm_T2.9-lens_specifications.html"
+      },
+      {
+        "id": 1509,
+        "name": "Fujifilm Fujinon MKX 18-55 mm T2.9",
+        "url": "https://www.lenstip.com/1509-Fujifilm_Fujinon_MKX_18-55_mm_T2.9-lens_specifications.html"
+      },
+      {
+        "id": 1510,
+        "name": "Fujifilm Fujinon MKX 50-135 mm T2.9",
+        "url": "https://www.lenstip.com/1510-Fujifilm_Fujinon_MKX_50-135_mm_T2.9-lens_specifications.html"
+      },
+      {
+        "id": 2285,
+        "name": "Fujifilm Fujinon XC 13-33 mm f/3.5-6.3 OIS",
+        "url": "https://www.lenstip.com/2285-Fujifilm_Fujinon_XC_13-33_mm_f_3.5-6.3_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1506,
+        "name": "Fujifilm Fujinon XC 15-45 mm f/3.5-5.6 OIS PZ",
+        "url": "https://www.lenstip.com/1506-Fujifilm_Fujinon_XC_15-45_mm_f_3.5-5.6_OIS_PZ-lens_specifications.html"
+      },
+      {
+        "id": 1117,
+        "name": "Fujifilm Fujinon XC 16-50 mm f/3.5-5.6 OIS",
+        "url": "https://www.lenstip.com/1117-Fujifilm_Fujinon_XC_16-50_mm_f_3.5-5.6_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1673,
+        "name": "Fujifilm Fujinon XC 35 mm f/2",
+        "url": "https://www.lenstip.com/1673-Fujifilm_Fujinon_XC_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1148,
+        "name": "Fujifilm Fujinon XC 50-230 mm f/4.5-6.7 OIS",
+        "url": "https://www.lenstip.com/1148-Fujifilm_Fujinon_XC_50-230_mm_f_4.5-6.7_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1756,
+        "name": "Fujifilm Fujinon XF 10-24 mm f/4 R OIS WR",
+        "url": "https://www.lenstip.com/1756-Fujifilm_Fujinon_XF_10-24_mm_f_4_R_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1168,
+        "name": "Fujifilm Fujinon XF 10-24 mm f/4R OIS",
+        "url": "https://www.lenstip.com/1168-Fujifilm_Fujinon_XF_10-24_mm_f_4R_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1340,
+        "name": "Fujifilm Fujinon XF 100-400 mm f/4.5-5.6 R LM OIS",
+        "url": "https://www.lenstip.com/1340-Fujifilm_Fujinon_XF_100-400_mm_f_4.5-5.6_R_LM_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1055,
+        "name": "Fujifilm Fujinon XF 14 mm f/2.8 R",
+        "url": "https://www.lenstip.com/1055-Fujifilm_Fujinon_XF_14_mm_f_2.8_R-lens_specifications.html"
+      },
+      {
+        "id": 1950,
+        "name": "Fujifilm Fujinon XF 150-600 mm f/5.6-8 R LM OIS WR",
+        "url": "https://www.lenstip.com/1950-Fujifilm_Fujinon_XF_150-600_mm_f_5.6-8_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1284,
+        "name": "Fujifilm Fujinon XF 16 mm f/1.4 R WR",
+        "url": "https://www.lenstip.com/1284-Fujifilm_Fujinon_XF_16_mm_f_1.4_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1598,
+        "name": "Fujifilm Fujinon XF 16 mm f/2.8 R WR",
+        "url": "https://www.lenstip.com/1598-Fujifilm_Fujinon_XF_16_mm_f_2.8_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 2132,
+        "name": "Fujifilm Fujinon XF 16-50 mm f/2.8-4.8 R LM WR",
+        "url": "https://www.lenstip.com/2132-Fujifilm_Fujinon_XF_16-50_mm_f_2.8-4.8_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1260,
+        "name": "Fujifilm Fujinon XF 16-55 mm f/2.8 R LM WR",
+        "url": "https://www.lenstip.com/1260-Fujifilm_Fujinon_XF_16-55_mm_f_2.8_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 2176,
+        "name": "Fujifilm Fujinon XF 16-55 mm f/2.8 R LM WR II",
+        "url": "https://www.lenstip.com/2176-Fujifilm_Fujinon_XF_16-55_mm_f_2.8_R_LM_WR_II-lens_specifications.html"
+      },
+      {
+        "id": 1636,
+        "name": "Fujifilm Fujinon XF 16-80 mm f/4 R OIS WR",
+        "url": "https://www.lenstip.com/1636-Fujifilm_Fujinon_XF_16-80_mm_f_4_R_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1828,
+        "name": "Fujifilm Fujinon XF 18 mm f/1.4 R LM WR",
+        "url": "https://www.lenstip.com/1828-Fujifilm_Fujinon_XF_18_mm_f_1.4_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1018,
+        "name": "Fujifilm Fujinon XF 18 mm f/2 R",
+        "url": "https://www.lenstip.com/1018-Fujifilm_Fujinon_XF_18_mm_f_2_R-lens_specifications.html"
+      },
+      {
+        "id": 1949,
+        "name": "Fujifilm Fujinon XF 18-120 mm f/4 LM PZ WR",
+        "url": "https://www.lenstip.com/1949-Fujifilm_Fujinon_XF_18-120_mm_f_4_LM_PZ_WR-lens_specifications.html"
+      },
+      {
+        "id": 1208,
+        "name": "Fujifilm Fujinon XF 18-135 mm f/3.5-5.6 R LM OIS WR",
+        "url": "https://www.lenstip.com/1208-Fujifilm_Fujinon_XF_18-135_mm_f_3.5-5.6_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1056,
+        "name": "Fujifilm Fujinon XF 18-55 mm f/2.8-4 OIS",
+        "url": "https://www.lenstip.com/1056-Fujifilm_Fujinon_XF_18-55_mm_f_2.8-4_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1542,
+        "name": "Fujifilm Fujinon XF 200 mm f/2 R LM OIS WR",
+        "url": "https://www.lenstip.com/1542-Fujifilm_Fujinon_XF_200_mm_f_2_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1143,
+        "name": "Fujifilm Fujinon XF 23 mm f/1.4 R",
+        "url": "https://www.lenstip.com/1143-Fujifilm_Fujinon_XF_23_mm_f_1.4_R-lens_specifications.html"
+      },
+      {
+        "id": 1870,
+        "name": "Fujifilm Fujinon XF 23 mm f/1.4 R LM WR",
+        "url": "https://www.lenstip.com/1870-Fujifilm_Fujinon_XF_23_mm_f_1.4_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1378,
+        "name": "Fujifilm Fujinon XF 23 mm f/2 R WR",
+        "url": "https://www.lenstip.com/1378-Fujifilm_Fujinon_XF_23_mm_f_2_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 2236,
+        "name": "Fujifilm Fujinon XF 23 mm f/2.8 R WR",
+        "url": "https://www.lenstip.com/2236-Fujifilm_Fujinon_XF_23_mm_f_2.8_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1129,
+        "name": "Fujifilm Fujinon XF 27 mm f/2.8",
+        "url": "https://www.lenstip.com/1129-Fujifilm_Fujinon_XF_27_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1804,
+        "name": "Fujifilm Fujinon XF 27 mm f/2.8 R WR",
+        "url": "https://www.lenstip.com/1804-Fujifilm_Fujinon_XF_27_mm_f_2.8_R_WR_-lens_specifications.html"
+      },
+      {
+        "id": 1998,
+        "name": "Fujifilm Fujinon XF 30 mm f/2.8 R LM WR Macro",
+        "url": "https://www.lenstip.com/1998-Fujifilm_Fujinon_XF_30_mm_f_2.8_R_LM_WR_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1871,
+        "name": "Fujifilm Fujinon XF 33 mm f/1.4 R LM WR",
+        "url": "https://www.lenstip.com/1871-Fujifilm_Fujinon_XF_33_mm_f_1.4_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1019,
+        "name": "Fujifilm Fujinon XF 35 mm f/1.4 R",
+        "url": "https://www.lenstip.com/1019-Fujifilm_Fujinon_XF_35_mm_f_1.4_R-lens_specifications.html"
+      },
+      {
+        "id": 1322,
+        "name": "Fujifilm Fujinon XF 35 mm f/2 R WR",
+        "url": "https://www.lenstip.com/1322-Fujifilm_Fujinon_XF_35_mm_f_2_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1742,
+        "name": "Fujifilm Fujinon XF 50 mm f/1.0 R WR",
+        "url": "https://www.lenstip.com/1742-Fujifilm_Fujinon_XF_50_mm_f_1.0_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1434,
+        "name": "Fujifilm Fujinon XF 50 mm f/2 R WR",
+        "url": "https://www.lenstip.com/1434-Fujifilm_Fujinon_XF_50_mm_f_2_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1224,
+        "name": "Fujifilm Fujinon XF 50-140 mm f/2.8 R LM OIS WR",
+        "url": "https://www.lenstip.com/1224-Fujifilm_Fujinon_XF_50-140_mm_f_2.8_R_LM_OIS_WR_-lens_specifications.html"
+      },
+      {
+        "id": 2175,
+        "name": "Fujifilm Fujinon XF 500 mm f/5.6 R LM OIS WR",
+        "url": "https://www.lenstip.com/2175-Fujifilm_Fujinon_XF_500_mm_f_5.6_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 1115,
+        "name": "Fujifilm Fujinon XF 55-200 mm f/3.5-4.8 R LM OIS",
+        "url": "https://www.lenstip.com/1115-Fujifilm_Fujinon_XF_55-200_mm_f_3.5-4.8_R_LM_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1065,
+        "name": "Fujifilm Fujinon XF 56 mm f/1.2 R",
+        "url": "https://www.lenstip.com/1065-Fujifilm_Fujinon_XF_56_mm_f_1.2_R-lens_specifications.html"
+      },
+      {
+        "id": 1223,
+        "name": "Fujifilm Fujinon XF 56 mm f/1.2 R APD",
+        "url": "https://www.lenstip.com/1223-Fujifilm_Fujinon_XF_56_mm_f_1.2_R_APD-lens_specifications.html"
+      },
+      {
+        "id": 1977,
+        "name": "Fujifilm Fujinon XF 56 mm f/1.2 R WR",
+        "url": "https://www.lenstip.com/1977-Fujifilm_Fujinon_XF_56_mm_f_1.2_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1020,
+        "name": "Fujifilm Fujinon XF 60 mm f/2.4 R Macro",
+        "url": "https://www.lenstip.com/1020-Fujifilm_Fujinon_XF_60_mm_f_2.4_R_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1803,
+        "name": "Fujifilm Fujinon XF 70-300 mm f/4-5.6 R LM OIS WR",
+        "url": "https://www.lenstip.com/1803-Fujifilm_Fujinon_XF_70-300_mm_f_4-5.6_R_LM_OIS_WR-lens_specifications.html"
+      },
+      {
+        "id": 2054,
+        "name": "Fujifilm Fujinon XF 8 mm f/3.5 R WR",
+        "url": "https://www.lenstip.com/2054-Fujifilm_Fujinon_XF_8_mm_f_3.5_R_WR-lens_specifications.html"
+      },
+      {
+        "id": 1543,
+        "name": "Fujifilm Fujinon XF 8-16 mm f/2.8 R LM WR",
+        "url": "https://www.lenstip.com/1543-Fujifilm_Fujinon_XF_8-16_mm_f_2.8_R_LM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1482,
+        "name": "Fujifilm Fujinon XF 80 mm f/2.8 LM OIS WR Macro",
+        "url": "https://www.lenstip.com/1482-Fujifilm_Fujinon_XF_80_mm_f_2.8_LM_OIS_WR_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1292,
+        "name": "Fujifilm Fujinon XF 90 mm f/2 R LM WR",
+        "url": "https://www.lenstip.com/1292-Fujifilm_Fujinon_XF_90_mm_f_2_R_LM_WR-lens_specifications.html"
+      }
+    ],
+    "Hasselblad": [
+      {
+        "id": 1576,
+        "name": "Hasselblad XCD 135 mm f/2.8",
+        "url": "https://www.lenstip.com/1576-Hasselblad_XCD_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2165,
+        "name": "Hasselblad XCD 20-35 mm f/3.2-4.5 E",
+        "url": "https://www.lenstip.com/2165-Hasselblad_XCD_20-35_mm_f_3.2-4.5_E-lens_specifications.html"
+      },
+      {
+        "id": 1532,
+        "name": "Hasselblad XCD 21 mm f/4",
+        "url": "https://www.lenstip.com/1532-Hasselblad_XCD_21_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 2127,
+        "name": "Hasselblad XCD 25 mm f/2.5 V",
+        "url": "https://www.lenstip.com/2127-Hasselblad_XCD_25_mm_f_2.5_V-lens_specifications.html"
+      },
+      {
+        "id": 2070,
+        "name": "Hasselblad XCD 28 mm f/4 P",
+        "url": "https://www.lenstip.com/2070-Hasselblad_XCD_28_mm_f_4_P-lens_specifications.html"
+      },
+      {
+        "id": 1453,
+        "name": "Hasselblad XCD 30 mm f/3.5",
+        "url": "https://www.lenstip.com/1453-Hasselblad_XCD_30_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 2257,
+        "name": "Hasselblad XCD 35-100 mm f/2.8-4.0 E",
+        "url": "https://www.lenstip.com/2257-Hasselblad_XCD_35-100_mm_f_2.8-4.0_E-lens_specifications.html"
+      },
+      {
+        "id": 1972,
+        "name": "Hasselblad XCD 38 mm f/2.5",
+        "url": "https://www.lenstip.com/1972-Hasselblad_XCD_38_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1454,
+        "name": "Hasselblad XCD 45 mm f/3.5",
+        "url": "https://www.lenstip.com/1454-Hasselblad_XCD_45_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 2033,
+        "name": "Hasselblad XCD 45 mm f/4 P",
+        "url": "https://www.lenstip.com/2033-Hasselblad_XCD_45_mm_f_4_P-lens_specifications.html"
+      },
+      {
+        "id": 1973,
+        "name": "Hasselblad XCD 55 mm f/2.5",
+        "url": "https://www.lenstip.com/1973-Hasselblad_XCD_55_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1575,
+        "name": "Hasselblad XCD 65 mm f/2.8",
+        "url": "https://www.lenstip.com/1575-Hasselblad_XCD_65_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2185,
+        "name": "Hasselblad XCD 75 mm f/3.4 P",
+        "url": "https://www.lenstip.com/2185-Hasselblad_XCD_75_mm_f_3.4_P-lens_specifications.html"
+      },
+      {
+        "id": 1574,
+        "name": "Hasselblad XCD 80 mm f/1.9",
+        "url": "https://www.lenstip.com/1574-Hasselblad_XCD_80_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 1974,
+        "name": "Hasselblad XCD 90 mm f/2.5",
+        "url": "https://www.lenstip.com/1974-Hasselblad_XCD_90_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1455,
+        "name": "Hasselblad XCD 90 mm f/3.2",
+        "url": "https://www.lenstip.com/1455-Hasselblad_XCD_90_mm_f_3.2-lens_specifications.html"
+      }
+    ],
+    "IBE Optics": [
+      {
+        "id": 1166,
+        "name": "IBE Optics  IBELUX 40 mm f/0.85",
+        "url": "https://www.lenstip.com/1166-IBE_Optics__IBELUX_40_mm_f_0.85-lens_specifications.html"
+      },
+      {
+        "id": 1110,
+        "name": "IBE Optics 26 mm f/1.4",
+        "url": "https://www.lenstip.com/1110-IBE_Optics_26_mm_f_1.4-lens_specifications.html"
+      }
+    ],
+    "Irix": [
+      {
+        "id": 1404,
+        "name": "Irix 11 mm f/4 Blackstone",
+        "url": "https://www.lenstip.com/1404-Irix_11_mm_f_4_Blackstone-lens_specifications.html"
+      },
+      {
+        "id": 1405,
+        "name": "Irix 11 mm f/4 Firefly",
+        "url": "https://www.lenstip.com/1405-Irix_11_mm_f_4_Firefly-lens_specifications.html"
+      },
+      {
+        "id": 1384,
+        "name": "Irix 15 mm f/2.4 Blackstone",
+        "url": "https://www.lenstip.com/1384-Irix_15_mm_f_2.4_Blackstone-lens_specifications.html"
+      },
+      {
+        "id": 1385,
+        "name": "Irix 15 mm f/2.4 Firefly",
+        "url": "https://www.lenstip.com/1385-Irix_15_mm_f_2.4_Firefly-lens_specifications.html"
+      },
+      {
+        "id": 1568,
+        "name": "Irix 150 mm f/2.8 MACRO 1:1 Dragonfly",
+        "url": "https://www.lenstip.com/1568-Irix_150_mm_f_2.8_MACRO_1:1_Dragonfly-lens_specifications.html"
+      },
+      {
+        "id": 1930,
+        "name": "Irix 21 mm f/1.4",
+        "url": "https://www.lenstip.com/1930-Irix_21_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1882,
+        "name": "Irix 30 mm f/1.4",
+        "url": "https://www.lenstip.com/1882-Irix_30_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1687,
+        "name": "Irix 45 mm f/1.4",
+        "url": "https://www.lenstip.com/1687-Irix_45_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1795,
+        "name": "Irix 45 mm f/1.4 GFX",
+        "url": "https://www.lenstip.com/1795-Irix_45_mm_f_1.4_GFX-lens_specifications.html"
+      },
+      {
+        "id": 1667,
+        "name": "Irix Cine 11mm T4.3",
+        "url": "https://www.lenstip.com/1667-Irix_Cine_11mm_T4.3-lens_specifications.html"
+      },
+      {
+        "id": 1698,
+        "name": "Irix Cine 15 mm T2.6",
+        "url": "https://www.lenstip.com/1698-Irix_Cine_15_mm_T2.6-lens_specifications.html"
+      },
+      {
+        "id": 1634,
+        "name": "Irix Cine 150 mm T3.0 MACRO 1:1",
+        "url": "https://www.lenstip.com/1634-Irix_Cine_150_mm_T3.0_MACRO_1:1-lens_specifications.html"
+      },
+      {
+        "id": 2009,
+        "name": "Irix Cine 150 mm T3.0 Tele",
+        "url": "https://www.lenstip.com/2009-Irix_Cine_150_mm_T3.0_Tele-lens_specifications.html"
+      },
+      {
+        "id": 1912,
+        "name": "Irix Cine 21 mm T1.5",
+        "url": "https://www.lenstip.com/1912-Irix_Cine_21_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1874,
+        "name": "Irix Cine 30 mm T1.5",
+        "url": "https://www.lenstip.com/1874-Irix_Cine_30_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1666,
+        "name": "Irix Cine 45 mm T1.5",
+        "url": "https://www.lenstip.com/1666-Irix_Cine_45_mm_T1.5-lens_specifications.html"
+      }
+    ],
+    "Kenko": [
+      {
+        "id": 1025,
+        "name": "Kenko Kenko 400 mm f/8 Mirror",
+        "url": "https://www.lenstip.com/1025-Kenko_Kenko_400_mm_f_8_Mirror-lens_specifications.html"
+      },
+      {
+        "id": 1484,
+        "name": "Kenko Tokina 400 mm f/8 N II",
+        "url": "https://www.lenstip.com/1484-Kenko_Tokina_400_mm_f_8_N_II-lens_specifications.html"
+      }
+    ],
+    "Konica Minolta": [
+      {
+        "id": 215,
+        "name": "Konica Minolta AF 100 mm f/2",
+        "url": "https://www.lenstip.com/215-Konica_Minolta_AF_100_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 218,
+        "name": "Konica Minolta AF 100 mm f/2.8 D Macro",
+        "url": "https://www.lenstip.com/218-Konica_Minolta_AF_100_mm_f_2.8_D_Macro-lens_specifications.html"
+      },
+      {
+        "id": 217,
+        "name": "Konica Minolta AF 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/217-Konica_Minolta_AF_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 216,
+        "name": "Konica Minolta AF 100 mm f/2.8 Soft Focus",
+        "url": "https://www.lenstip.com/216-Konica_Minolta_AF_100_mm_f_2.8_Soft_Focus-lens_specifications.html"
+      },
+      {
+        "id": 273,
+        "name": "Konica Minolta AF 100-200 mm f/4.5",
+        "url": "https://www.lenstip.com/273-Konica_Minolta_AF_100-200_mm_f_4.5-lens_specifications.html"
+      },
+      {
+        "id": 275,
+        "name": "Konica Minolta AF 100-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/275-Konica_Minolta_AF_100-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 276,
+        "name": "Konica Minolta AF 100-300 mm f/4.5-5.6 APO",
+        "url": "https://www.lenstip.com/276-Konica_Minolta_AF_100-300_mm_f_4.5-5.6_APO-lens_specifications.html"
+      },
+      {
+        "id": 277,
+        "name": "Konica Minolta AF 100-300 mm f/4.5-5.6 APO (D)",
+        "url": "https://www.lenstip.com/277-Konica_Minolta_AF_100-300_mm_f_4.5-5.6_APO_(D)-lens_specifications.html"
+      },
+      {
+        "id": 274,
+        "name": "Konica Minolta AF 100-300 mm f/4.5-5.6 XI",
+        "url": "https://www.lenstip.com/274-Konica_Minolta_AF_100-300_mm_f_4.5-5.6_XI-lens_specifications.html"
+      },
+      {
+        "id": 278,
+        "name": "Konica Minolta AF 100-400 mm f/4.5-6.7 APO",
+        "url": "https://www.lenstip.com/278-Konica_Minolta_AF_100-400_mm_f_4.5-6.7_APO-lens_specifications.html"
+      },
+      {
+        "id": 219,
+        "name": "Konica Minolta AF 135 mm f/2.8",
+        "url": "https://www.lenstip.com/219-Konica_Minolta_AF_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 200,
+        "name": "Konica Minolta AF 16 mm f/2.8",
+        "url": "https://www.lenstip.com/200-Konica_Minolta_AF_16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 233,
+        "name": "Konica Minolta AF 17-35 mm f/2.8-4 (D)",
+        "url": "https://www.lenstip.com/233-Konica_Minolta_AF_17-35_mm_f_2.8-4_(D)-lens_specifications.html"
+      },
+      {
+        "id": 234,
+        "name": "Konica Minolta AF 17-35 mm f/3.5 G",
+        "url": "https://www.lenstip.com/234-Konica_Minolta_AF_17-35_mm_f_3.5_G-lens_specifications.html"
+      },
+      {
+        "id": 201,
+        "name": "Konica Minolta AF 20 mm f/2.8",
+        "url": "https://www.lenstip.com/201-Konica_Minolta_AF_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 237,
+        "name": "Konica Minolta AF 20-35 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/237-Konica_Minolta_AF_20-35_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 221,
+        "name": "Konica Minolta AF 200 mm f/2.8 APO",
+        "url": "https://www.lenstip.com/221-Konica_Minolta_AF_200_mm_f_2.8_APO-lens_specifications.html"
+      },
+      {
+        "id": 222,
+        "name": "Konica Minolta AF 200 mm f/2.8 APO G",
+        "url": "https://www.lenstip.com/222-Konica_Minolta_AF_200_mm_f_2.8_APO_G-lens_specifications.html"
+      },
+      {
+        "id": 223,
+        "name": "Konica Minolta AF 200 mm f/4 APO G Macro",
+        "url": "https://www.lenstip.com/223-Konica_Minolta_AF_200_mm_f_4_APO_G_Macro-lens_specifications.html"
+      },
+      {
+        "id": 202,
+        "name": "Konica Minolta AF 24 mm f/2.8",
+        "url": "https://www.lenstip.com/202-Konica_Minolta_AF_24_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 240,
+        "name": "Konica Minolta AF 24-105 mm f/ 3.5-4.5",
+        "url": "https://www.lenstip.com/240-Konica_Minolta_AF_24-105_mm_f__3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 238,
+        "name": "Konica Minolta AF 24-50 mm f/4",
+        "url": "https://www.lenstip.com/238-Konica_Minolta_AF_24-50_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 239,
+        "name": "Konica Minolta AF 24-85 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/239-Konica_Minolta_AF_24-85_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 203,
+        "name": "Konica Minolta AF 28 mm f/2",
+        "url": "https://www.lenstip.com/203-Konica_Minolta_AF_28_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 204,
+        "name": "Konica Minolta AF 28 mm f/2.8",
+        "url": "https://www.lenstip.com/204-Konica_Minolta_AF_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 248,
+        "name": "Konica Minolta AF 28-100 mm f/3.5-5.6 D",
+        "url": "https://www.lenstip.com/248-Konica_Minolta_AF_28-100_mm_f_3.5-5.6_D-lens_specifications.html"
+      },
+      {
+        "id": 250,
+        "name": "Konica Minolta AF 28-105 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/250-Konica_Minolta_AF_28-105_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 249,
+        "name": "Konica Minolta AF 28-105 mm f/3.5-4.5 XI",
+        "url": "https://www.lenstip.com/249-Konica_Minolta_AF_28-105_mm_f_3.5-4.5_XI-lens_specifications.html"
+      },
+      {
+        "id": 251,
+        "name": "Konica Minolta AF 28-135 mm f/4-4.5",
+        "url": "https://www.lenstip.com/251-Konica_Minolta_AF_28-135_mm_f_4-4.5-lens_specifications.html"
+      },
+      {
+        "id": 241,
+        "name": "Konica Minolta AF 28-70 mm f/2.8 G",
+        "url": "https://www.lenstip.com/241-Konica_Minolta_AF_28-70_mm_f_2.8_G-lens_specifications.html"
+      },
+      {
+        "id": 242,
+        "name": "Konica Minolta AF 28-75 mm f/2.8 D",
+        "url": "https://www.lenstip.com/242-Konica_Minolta_AF_28-75_mm_f_2.8_D-lens_specifications.html"
+      },
+      {
+        "id": 245,
+        "name": "Konica Minolta AF 28-80 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/245-Konica_Minolta_AF_28-80_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 244,
+        "name": "Konica Minolta AF 28-80 mm f/3.5-5.6 D",
+        "url": "https://www.lenstip.com/244-Konica_Minolta_AF_28-80_mm_f_3.5-5.6_D-lens_specifications.html"
+      },
+      {
+        "id": 246,
+        "name": "Konica Minolta AF 28-80 mm f/4-5.6 MZ",
+        "url": "https://www.lenstip.com/246-Konica_Minolta_AF_28-80_mm_f_4-5.6_MZ-lens_specifications.html"
+      },
+      {
+        "id": 243,
+        "name": "Konica Minolta AF 28-80 mm f/4-5.6 XI",
+        "url": "https://www.lenstip.com/243-Konica_Minolta_AF_28-80_mm_f_4-5.6_XI-lens_specifications.html"
+      },
+      {
+        "id": 247,
+        "name": "Konica Minolta AF 28-85 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/247-Konica_Minolta_AF_28-85_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 224,
+        "name": "Konica Minolta AF 300 mm f/2.8 APO",
+        "url": "https://www.lenstip.com/224-Konica_Minolta_AF_300_mm_f_2.8_APO-lens_specifications.html"
+      },
+      {
+        "id": 225,
+        "name": "Konica Minolta AF 300 mm f/2.8 APO G",
+        "url": "https://www.lenstip.com/225-Konica_Minolta_AF_300_mm_f_2.8_APO_G-lens_specifications.html"
+      },
+      {
+        "id": 226,
+        "name": "Konica Minolta AF 300 mm f/2.8 APO G D SSM",
+        "url": "https://www.lenstip.com/226-Konica_Minolta_AF_300_mm_f_2.8_APO_G_D_SSM-lens_specifications.html"
+      },
+      {
+        "id": 227,
+        "name": "Konica Minolta AF 300 mm f/4 APO G",
+        "url": "https://www.lenstip.com/227-Konica_Minolta_AF_300_mm_f_4_APO_G-lens_specifications.html"
+      },
+      {
+        "id": 205,
+        "name": "Konica Minolta AF 35 mm f/1.4 G",
+        "url": "https://www.lenstip.com/205-Konica_Minolta_AF_35_mm_f_1.4_G-lens_specifications.html"
+      },
+      {
+        "id": 206,
+        "name": "Konica Minolta AF 35 mm f/2",
+        "url": "https://www.lenstip.com/206-Konica_Minolta_AF_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 257,
+        "name": "Konica Minolta AF 35-105 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/257-Konica_Minolta_AF_35-105_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 258,
+        "name": "Konica Minolta AF 35-105 mm f/3.5-4.5 N",
+        "url": "https://www.lenstip.com/258-Konica_Minolta_AF_35-105_mm_f_3.5-4.5_N-lens_specifications.html"
+      },
+      {
+        "id": 259,
+        "name": "Konica Minolta AF 35-200 mm f/4.5-5.6 XI",
+        "url": "https://www.lenstip.com/259-Konica_Minolta_AF_35-200_mm_f_4.5-5.6_XI-lens_specifications.html"
+      },
+      {
+        "id": 252,
+        "name": "Konica Minolta AF 35-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/252-Konica_Minolta_AF_35-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 253,
+        "name": "Konica Minolta AF 35-70 mm f/4",
+        "url": "https://www.lenstip.com/253-Konica_Minolta_AF_35-70_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 255,
+        "name": "Konica Minolta AF 35-80 mm f/4-5.6",
+        "url": "https://www.lenstip.com/255-Konica_Minolta_AF_35-80_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 256,
+        "name": "Konica Minolta AF 35-80 mm f/4-5.6 II",
+        "url": "https://www.lenstip.com/256-Konica_Minolta_AF_35-80_mm_f_4-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 254,
+        "name": "Konica Minolta AF 35-80 mm f/4-5.6 Power Zoom",
+        "url": "https://www.lenstip.com/254-Konica_Minolta_AF_35-80_mm_f_4-5.6_Power_Zoom-lens_specifications.html"
+      },
+      {
+        "id": 918,
+        "name": "Konica Minolta AF 3x-1x f/1.7-2.8 Macro Zoom",
+        "url": "https://www.lenstip.com/918-Konica_Minolta_AF_3x-1x_f_1.7-2.8_Macro_Zoom-lens_specifications.html"
+      },
+      {
+        "id": 228,
+        "name": "Konica Minolta AF 400 mm f/4.5 APO G",
+        "url": "https://www.lenstip.com/228-Konica_Minolta_AF_400_mm_f_4.5_APO_G-lens_specifications.html"
+      },
+      {
+        "id": 207,
+        "name": "Konica Minolta AF 50 mm f/1.4",
+        "url": "https://www.lenstip.com/207-Konica_Minolta_AF_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 208,
+        "name": "Konica Minolta AF 50 mm f/1.7",
+        "url": "https://www.lenstip.com/208-Konica_Minolta_AF_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 210,
+        "name": "Konica Minolta AF 50 mm f/2.8 D Macro",
+        "url": "https://www.lenstip.com/210-Konica_Minolta_AF_50_mm_f_2.8_D_Macro-lens_specifications.html"
+      },
+      {
+        "id": 209,
+        "name": "Konica Minolta AF 50 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/209-Konica_Minolta_AF_50_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 211,
+        "name": "Konica Minolta AF 50 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/211-Konica_Minolta_AF_50_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 229,
+        "name": "Konica Minolta AF 500 mm f/8 Mirror",
+        "url": "https://www.lenstip.com/229-Konica_Minolta_AF_500_mm_f_8_Mirror-lens_specifications.html"
+      },
+      {
+        "id": 230,
+        "name": "Konica Minolta AF 600 mm  f/4",
+        "url": "https://www.lenstip.com/230-Konica_Minolta_AF_600_mm__f_4-lens_specifications.html"
+      },
+      {
+        "id": 231,
+        "name": "Konica Minolta AF 600 mm f/4 G",
+        "url": "https://www.lenstip.com/231-Konica_Minolta_AF_600_mm_f_4_G-lens_specifications.html"
+      },
+      {
+        "id": 260,
+        "name": "Konica Minolta AF 70-200 mm f/2.8 APO G (D) SSM",
+        "url": "https://www.lenstip.com/260-Konica_Minolta_AF_70-200_mm_f_2.8_APO_G_(D)_SSM-lens_specifications.html"
+      },
+      {
+        "id": 262,
+        "name": "Konica Minolta AF 70-210 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/262-Konica_Minolta_AF_70-210_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 261,
+        "name": "Konica Minolta AF 70-210 mm f/4",
+        "url": "https://www.lenstip.com/261-Konica_Minolta_AF_70-210_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 264,
+        "name": "Konica Minolta AF 70-210 mm f/4.5-5.6 II",
+        "url": "https://www.lenstip.com/264-Konica_Minolta_AF_70-210_mm_f_4.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 263,
+        "name": "Konica Minolta AF 70-210 mm f/4.5-5.6 MZ",
+        "url": "https://www.lenstip.com/263-Konica_Minolta_AF_70-210_mm_f_4.5-5.6_MZ-lens_specifications.html"
+      },
+      {
+        "id": 265,
+        "name": "Konica Minolta AF 75-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/265-Konica_Minolta_AF_75-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 268,
+        "name": "Konica Minolta AF 75-300 mm f/4.5-5.6 (D)",
+        "url": "https://www.lenstip.com/268-Konica_Minolta_AF_75-300_mm_f_4.5-5.6_(D)-lens_specifications.html"
+      },
+      {
+        "id": 267,
+        "name": "Konica Minolta AF 75-300 mm f/4.5-5.6 II",
+        "url": "https://www.lenstip.com/267-Konica_Minolta_AF_75-300_mm_f_4.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 266,
+        "name": "Konica Minolta AF 75-300 mm f/4.5-5.6 new",
+        "url": "https://www.lenstip.com/266-Konica_Minolta_AF_75-300_mm_f_4.5-5.6_new-lens_specifications.html"
+      },
+      {
+        "id": 271,
+        "name": "Konica Minolta AF 80-200 mm f/2.8 APO",
+        "url": "https://www.lenstip.com/271-Konica_Minolta_AF_80-200_mm_f_2.8_APO-lens_specifications.html"
+      },
+      {
+        "id": 272,
+        "name": "Konica Minolta AF 80-200 mm f/2.8 APO G",
+        "url": "https://www.lenstip.com/272-Konica_Minolta_AF_80-200_mm_f_2.8_APO_G-lens_specifications.html"
+      },
+      {
+        "id": 270,
+        "name": "Konica Minolta AF 80-200 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/270-Konica_Minolta_AF_80-200_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 269,
+        "name": "Konica Minolta AF 80-200 mm f/4.5-5.6 XI",
+        "url": "https://www.lenstip.com/269-Konica_Minolta_AF_80-200_mm_f_4.5-5.6_XI-lens_specifications.html"
+      },
+      {
+        "id": 212,
+        "name": "Konica Minolta AF 85 mm f/1.4",
+        "url": "https://www.lenstip.com/212-Konica_Minolta_AF_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 213,
+        "name": "Konica Minolta AF 85 mm f/1.4 G",
+        "url": "https://www.lenstip.com/213-Konica_Minolta_AF_85_mm_f_1.4_G-lens_specifications.html"
+      },
+      {
+        "id": 214,
+        "name": "Konica Minolta AF 85 mm f/1.4 G D",
+        "url": "https://www.lenstip.com/214-Konica_Minolta_AF_85_mm_f_1.4_G_D-lens_specifications.html"
+      },
+      {
+        "id": 232,
+        "name": "Konica Minolta AF DT 11-18 mm f/4.5-5.6 (D)",
+        "url": "https://www.lenstip.com/232-Konica_Minolta_AF_DT_11-18_mm_f_4.5-5.6_(D)-lens_specifications.html"
+      },
+      {
+        "id": 236,
+        "name": "Konica Minolta AF DT 18-200 mm f/3.5-6.3 (D)",
+        "url": "https://www.lenstip.com/236-Konica_Minolta_AF_DT_18-200_mm_f_3.5-6.3_(D)-lens_specifications.html"
+      },
+      {
+        "id": 235,
+        "name": "Konica Minolta AF DT 18-70 mm f/3.5-5.6 (D)",
+        "url": "https://www.lenstip.com/235-Konica_Minolta_AF_DT_18-70_mm_f_3.5-5.6_(D)-lens_specifications.html"
+      },
+      {
+        "id": 220,
+        "name": "Konica Minolta STF 135 mm f/2.8 [T f/4.5]",
+        "url": "https://www.lenstip.com/220-Konica_Minolta_STF_135_mm_f_2.8_[T_f_4.5]-lens_specifications.html"
+      }
+    ],
+    "Kowa": [
+      {
+        "id": 1530,
+        "name": "Kowa Prominar 12 mm f/1.8",
+        "url": "https://www.lenstip.com/1530-Kowa_Prominar_12_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1531,
+        "name": "Kowa Prominar 25 mm f/1.8",
+        "url": "https://www.lenstip.com/1531-Kowa_Prominar_25_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1529,
+        "name": "Kowa Prominar 8.5 mm f/2.8",
+        "url": "https://www.lenstip.com/1529-Kowa_Prominar_8.5_mm_f_2.8-lens_specifications.html"
+      }
+    ],
+    "Leica": [
+      {
+        "id": 1239,
+        "name": "Leica APO Vario-Elmar-T 55-135 mm f/3.5-4.5 ASPH.",
+        "url": "https://www.lenstip.com/1239-Leica_APO_Vario-Elmar-T_55-135_mm_f_3.5-4.5_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1818,
+        "name": "Leica APO-Summicron-M 35 mm f/2.0 Asph",
+        "url": "https://www.lenstip.com/1818-Leica_APO-Summicron-M_35_mm_f_2.0_Asph-lens_specifications.html"
+      },
+      {
+        "id": 1811,
+        "name": "Leica APO-Summicron-SL 28 mm f/2 ASPH",
+        "url": "https://www.lenstip.com/1811-Leica_APO-Summicron-SL_28_mm_f_2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1605,
+        "name": "Leica APO-Summicron-SL 35 mm f/2 ASPH.",
+        "url": "https://www.lenstip.com/1605-Leica_APO-Summicron-SL_35_mm_f_2_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1638,
+        "name": "Leica APO-Summicron-SL 50 mm f/2 ASPH",
+        "url": "https://www.lenstip.com/1638-Leica_APO-Summicron-SL_50_mm_f_2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1502,
+        "name": "Leica APO-Summicron-SL 75 mm f/2 ASPH.",
+        "url": "https://www.lenstip.com/1502-Leica_APO-Summicron-SL_75_mm_f_2_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1503,
+        "name": "Leica APO-Summicron-SL 90 mm f/2 ASPH.",
+        "url": "https://www.lenstip.com/1503-Leica_APO-Summicron-SL_90_mm_f_2_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1358,
+        "name": "Leica APO-Vario-Elmarit-SL 90-280 mm f/2.8-4",
+        "url": "https://www.lenstip.com/1358-Leica_APO-Vario-Elmarit-SL_90-280_mm_f_2.8-4-lens_specifications.html"
+      },
+      {
+        "id": 74,
+        "name": "Leica Apo-Elmarit-R 180 mm",
+        "url": "https://www.lenstip.com/74-Leica_Apo-Elmarit-R_180_mm-lens_specifications.html"
+      },
+      {
+        "id": 75,
+        "name": "Leica Apo-Macro-Elmarit-R 100 mm",
+        "url": "https://www.lenstip.com/75-Leica_Apo-Macro-Elmarit-R_100_mm-lens_specifications.html"
+      },
+      {
+        "id": 1383,
+        "name": "Leica Apo-Macro-Elmarit-TL 60 mm f/2.8 ASPH.",
+        "url": "https://www.lenstip.com/1383-Leica_Apo-Macro-Elmarit-TL_60_mm_f_2.8_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 874,
+        "name": "Leica Apo-Macro-Summarit-S 120 mm f/2.5 (CS)",
+        "url": "https://www.lenstip.com/874-Leica_Apo-Macro-Summarit-S_120_mm_f_2.5_(CS)-lens_specifications.html"
+      },
+      {
+        "id": 1043,
+        "name": "Leica Apo-Summicron-M 50 mm f/2.0  Asph",
+        "url": "https://www.lenstip.com/1043-Leica_Apo-Summicron-M_50_mm_f_2.0__Asph-lens_specifications.html"
+      },
+      {
+        "id": 57,
+        "name": "Leica Apo-Summicron-M 75 mm f/2.0  Asph",
+        "url": "https://www.lenstip.com/57-Leica_Apo-Summicron-M_75_mm_f_2.0__Asph-lens_specifications.html"
+      },
+      {
+        "id": 58,
+        "name": "Leica Apo-Summicron-M 90 mm Asph",
+        "url": "https://www.lenstip.com/58-Leica_Apo-Summicron-M_90_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 77,
+        "name": "Leica Apo-Summicron-R 180 mm",
+        "url": "https://www.lenstip.com/77-Leica_Apo-Summicron-R_180_mm-lens_specifications.html"
+      },
+      {
+        "id": 76,
+        "name": "Leica Apo-Summicron-R 90 mm Asph",
+        "url": "https://www.lenstip.com/76-Leica_Apo-Summicron-R_90_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 875,
+        "name": "Leica Apo-Tele-Elmar-S 180 mm f/3.5 (CS)",
+        "url": "https://www.lenstip.com/875-Leica_Apo-Tele-Elmar-S_180_mm_f_3.5_(CS)-lens_specifications.html"
+      },
+      {
+        "id": 60,
+        "name": "Leica Apo-Telyt-M 135 mm",
+        "url": "https://www.lenstip.com/60-Leica_Apo-Telyt-M_135_mm-lens_specifications.html"
+      },
+      {
+        "id": 78,
+        "name": "Leica Apo-Telyt-R 280 mm",
+        "url": "https://www.lenstip.com/78-Leica_Apo-Telyt-R_280_mm-lens_specifications.html"
+      },
+      {
+        "id": 623,
+        "name": "Leica D Summilux 25 mm f/1.4",
+        "url": "https://www.lenstip.com/623-Leica_D_Summilux_25_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 628,
+        "name": "Leica D Vario-Elmar 14-150 mm f/3.5-5.6 Asph. Mega O.I.S.",
+        "url": "https://www.lenstip.com/628-Leica_D_Vario-Elmar_14-150_mm_f_3.5-5.6_Asph._Mega_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 648,
+        "name": "Leica D Vario-Elmar 14-50 mm f/3.8-5.6 Asph. Mega O.I.S.",
+        "url": "https://www.lenstip.com/648-Leica_D_Vario-Elmar_14-50_mm_f_3.8-5.6_Asph._Mega_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 622,
+        "name": "Leica D Vario-Elmarit 14-50 mm f/2.8-3.5 Asph. Mega O.I.S.",
+        "url": "https://www.lenstip.com/622-Leica_D_Vario-Elmarit_14-50_mm_f_2.8-3.5_Asph._Mega_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 811,
+        "name": "Leica Elmar-M 24 mm f/3.8 ASPH.",
+        "url": "https://www.lenstip.com/811-Leica_Elmar-M_24_mm_f_3.8_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 52,
+        "name": "Leica Elmar-M 50 mm",
+        "url": "https://www.lenstip.com/52-Leica_Elmar-M_50_mm-lens_specifications.html"
+      },
+      {
+        "id": 45,
+        "name": "Leica Elmarit-M 21 mm Asph",
+        "url": "https://www.lenstip.com/45-Leica_Elmarit-M_21_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 46,
+        "name": "Leica Elmarit-M 24 mm Asph",
+        "url": "https://www.lenstip.com/46-Leica_Elmarit-M_24_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 47,
+        "name": "Leica Elmarit-M 28 mm ASPH",
+        "url": "https://www.lenstip.com/47-Leica_Elmarit-M_28_mm_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 63,
+        "name": "Leica Elmarit-M 90 mm",
+        "url": "https://www.lenstip.com/63-Leica_Elmarit-M_90_mm-lens_specifications.html"
+      },
+      {
+        "id": 65,
+        "name": "Leica Elmarit-R 19 mm",
+        "url": "https://www.lenstip.com/65-Leica_Elmarit-R_19_mm-lens_specifications.html"
+      },
+      {
+        "id": 66,
+        "name": "Leica Elmarit-R 28 mm",
+        "url": "https://www.lenstip.com/66-Leica_Elmarit-R_28_mm-lens_specifications.html"
+      },
+      {
+        "id": 1012,
+        "name": "Leica Elmarit-S 30 mm f/2.8 ASPH. (CS)",
+        "url": "https://www.lenstip.com/1012-Leica_Elmarit-S_30_mm_f_2.8_ASPH._(CS)-lens_specifications.html"
+      },
+      {
+        "id": 1151,
+        "name": "Leica Elmarit-S 45 mm f/2.8 ASPH. (CS)",
+        "url": "https://www.lenstip.com/1151-Leica_Elmarit-S_45_mm_f_2.8_ASPH._(CS)-lens_specifications.html"
+      },
+      {
+        "id": 1495,
+        "name": "Leica Elmarit-TL 18 mm f/2.8 ASPH.",
+        "url": "https://www.lenstip.com/1495-Leica_Elmarit-TL_18_mm_f_2.8_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 62,
+        "name": "Leica Macro-Elmar-M 90 mm",
+        "url": "https://www.lenstip.com/62-Leica_Macro-Elmar-M_90_mm-lens_specifications.html"
+      },
+      {
+        "id": 1206,
+        "name": "Leica Macro-Elmar-M 90 mm f/4",
+        "url": "https://www.lenstip.com/1206-Leica_Macro-Elmar-M_90_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 71,
+        "name": "Leica Macro-Elmarit-R 60 mm",
+        "url": "https://www.lenstip.com/71-Leica_Macro-Elmarit-R_60_mm-lens_specifications.html"
+      },
+      {
+        "id": 2298,
+        "name": "Leica Noctilux-M 35 mm f/1.2 ASPH.",
+        "url": "https://www.lenstip.com/2298-Leica_Noctilux-M_35_mm_f_1.2_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 53,
+        "name": "Leica Noctilux-M 50 mm",
+        "url": "https://www.lenstip.com/53-Leica_Noctilux-M_50_mm-lens_specifications.html"
+      },
+      {
+        "id": 1805,
+        "name": "Leica Noctilux-M 50 mm f/1.2 ASPH",
+        "url": "https://www.lenstip.com/1805-Leica_Noctilux-M_50_mm_f_1.2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 812,
+        "name": "Leica Noctilux-M 50mm f/0.95 ASPH.",
+        "url": "https://www.lenstip.com/812-Leica_Noctilux-M_50mm_f_0.95_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1496,
+        "name": "Leica Noctilux-M 75 mm f/1.25 ASPH.",
+        "url": "https://www.lenstip.com/1496-Leica_Noctilux-M_75_mm_f_1.25_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 67,
+        "name": "Leica PC-Super-Angulon-R 28 mm",
+        "url": "https://www.lenstip.com/67-Leica_PC-Super-Angulon-R_28_mm-lens_specifications.html"
+      },
+      {
+        "id": 1240,
+        "name": "Leica Summarit-M 35 mm f/2.4 ASPH.",
+        "url": "https://www.lenstip.com/1240-Leica_Summarit-M_35_mm_f_2.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 633,
+        "name": "Leica Summarit-M 35 mm f/2.5",
+        "url": "https://www.lenstip.com/633-Leica_Summarit-M_35_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1241,
+        "name": "Leica Summarit-M 50 mm f/2.4",
+        "url": "https://www.lenstip.com/1241-Leica_Summarit-M_50_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 634,
+        "name": "Leica Summarit-M 50 mm f/2.5",
+        "url": "https://www.lenstip.com/634-Leica_Summarit-M_50_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1242,
+        "name": "Leica Summarit-M 75 mm f/2.4",
+        "url": "https://www.lenstip.com/1242-Leica_Summarit-M_75_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 635,
+        "name": "Leica Summarit-M 75 mm f/2.5",
+        "url": "https://www.lenstip.com/635-Leica_Summarit-M_75_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1243,
+        "name": "Leica Summarit-M 90 mm f/2.4",
+        "url": "https://www.lenstip.com/1243-Leica_Summarit-M_90_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 636,
+        "name": "Leica Summarit-M 90 mm f/2.5",
+        "url": "https://www.lenstip.com/636-Leica_Summarit-M_90_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 872,
+        "name": "Leica Summarit-S 35 mm f/2.5 ASPH. (CS)",
+        "url": "https://www.lenstip.com/872-Leica_Summarit-S_35_mm_f_2.5_ASPH._(CS)-lens_specifications.html"
+      },
+      {
+        "id": 873,
+        "name": "Leica Summarit-S 70 mm f/2.5 ASPH. (CS)",
+        "url": "https://www.lenstip.com/873-Leica_Summarit-S_70_mm_f_2.5_ASPH._(CS)-lens_specifications.html"
+      },
+      {
+        "id": 1411,
+        "name": "Leica Summaron-M 28 mm f/5.6",
+        "url": "https://www.lenstip.com/1411-Leica_Summaron-M_28_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 2091,
+        "name": "Leica Summicron-M 28 mm f/2.0 ASPH (2023)",
+        "url": "https://www.lenstip.com/2091-Leica_Summicron-M_28_mm_f_2.0_ASPH_(2023)-lens_specifications.html"
+      },
+      {
+        "id": 48,
+        "name": "Leica Summicron-M 28 mm f/2.0 Asph",
+        "url": "https://www.lenstip.com/48-Leica_Summicron-M_28_mm_f_2.0_Asph-lens_specifications.html"
+      },
+      {
+        "id": 49,
+        "name": "Leica Summicron-M 35 mm Asph",
+        "url": "https://www.lenstip.com/49-Leica_Summicron-M_35_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 54,
+        "name": "Leica Summicron-M 50 mm f/2.0",
+        "url": "https://www.lenstip.com/54-Leica_Summicron-M_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 68,
+        "name": "Leica Summicron-R 35 mm",
+        "url": "https://www.lenstip.com/68-Leica_Summicron-R_35_mm-lens_specifications.html"
+      },
+      {
+        "id": 72,
+        "name": "Leica Summicron-R 50 mm",
+        "url": "https://www.lenstip.com/72-Leica_Summicron-R_50_mm-lens_specifications.html"
+      },
+      {
+        "id": 2029,
+        "name": "Leica Summicron-SL 35 mm f/2.0 ASPH",
+        "url": "https://www.lenstip.com/2029-Leica_Summicron-SL_35_mm_f_2.0_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2028,
+        "name": "Leica Summicron-SL 50 mm f/2.0 ASPH",
+        "url": "https://www.lenstip.com/2028-Leica_Summicron-SL_50_mm_f_2.0_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1193,
+        "name": "Leica Summicron-T 23 mm f/2 ASPH",
+        "url": "https://www.lenstip.com/1193-Leica_Summicron-T_23_mm_f_2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 809,
+        "name": "Leica Summilux-M 21 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/809-Leica_Summilux-M_21_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 810,
+        "name": "Leica Summilux-M 24 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/810-Leica_Summilux-M_24_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1293,
+        "name": "Leica Summilux-M 28 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/1293-Leica_Summilux-M_28_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 50,
+        "name": "Leica Summilux-M 35 mm Asph",
+        "url": "https://www.lenstip.com/50-Leica_Summilux-M_35_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 921,
+        "name": "Leica Summilux-M 35 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/921-Leica_Summilux-M_35_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 2207,
+        "name": "Leica Summilux-M 50 mm f/1.4",
+        "url": "https://www.lenstip.com/2207-Leica_Summilux-M_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 55,
+        "name": "Leica Summilux-M 50 mm f/1.4 Asph",
+        "url": "https://www.lenstip.com/55-Leica_Summilux-M_50_mm_f_1.4_Asph-lens_specifications.html"
+      },
+      {
+        "id": 64,
+        "name": "Leica Summilux-M 75 mm",
+        "url": "https://www.lenstip.com/64-Leica_Summilux-M_75_mm-lens_specifications.html"
+      },
+      {
+        "id": 1668,
+        "name": "Leica Summilux-M 90 mm f/1.5 ASPH",
+        "url": "https://www.lenstip.com/1668-Leica_Summilux-M_90_mm_f_1.5_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 69,
+        "name": "Leica Summilux-R 35 mm",
+        "url": "https://www.lenstip.com/69-Leica_Summilux-R_35_mm-lens_specifications.html"
+      },
+      {
+        "id": 73,
+        "name": "Leica Summilux-R 50 mm",
+        "url": "https://www.lenstip.com/73-Leica_Summilux-R_50_mm-lens_specifications.html"
+      },
+      {
+        "id": 79,
+        "name": "Leica Summilux-R 80 mm",
+        "url": "https://www.lenstip.com/79-Leica_Summilux-R_80_mm-lens_specifications.html"
+      },
+      {
+        "id": 1427,
+        "name": "Leica Summilux-SL 50 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/1427-Leica_Summilux-SL_50_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1359,
+        "name": "Leica Summilux-TL 35 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/1359-Leica_Summilux-TL_35_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 70,
+        "name": "Leica Super Elmarit-R 15 mm Asph",
+        "url": "https://www.lenstip.com/70-Leica_Super_Elmarit-R_15_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 2090,
+        "name": "Leica Super-APO-Summicron-SL 21 mm f/2 ASPH.",
+        "url": "https://www.lenstip.com/2090-Leica_Super-APO-Summicron-SL_21_mm_f_2_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 836,
+        "name": "Leica Super-Elmar-M 18 mm f/3.8 ASPH",
+        "url": "https://www.lenstip.com/836-Leica_Super-Elmar-M_18_mm_f_3.8_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 986,
+        "name": "Leica Super-Elmar-M 21 mm f/3.4 ASPH",
+        "url": "https://www.lenstip.com/986-Leica_Super-Elmar-M_21_mm_f_3.4_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1087,
+        "name": "Leica Super-Elmar-S 24 mm f/3.5 ASPH.",
+        "url": "https://www.lenstip.com/1087-Leica_Super-Elmar-S_24_mm_f_3.5_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1523,
+        "name": "Leica Super-Vario-Elmar-SL 16-35 mm f/3.5-4.5 ASPH.",
+        "url": "https://www.lenstip.com/1523-Leica_Super-Vario-Elmar-SL_16-35_mm_f_3.5-4.5_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1238,
+        "name": "Leica Super-Vario-Elmar-T 11-23 mm f/3.5-4.5 ASPH.",
+        "url": "https://www.lenstip.com/1238-Leica_Super-Vario-Elmar-T_11-23_mm_f_3.5-4.5_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 2089,
+        "name": "Leica Super-Vario-Elmarit-SL 14-24 mm f/2.8 ASPH.",
+        "url": "https://www.lenstip.com/2089-Leica_Super-Vario-Elmarit-SL_14-24_mm_f_2.8_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1089,
+        "name": "Leica TS-APO-Elmar-S 120 mm f/5.6 ASPH.",
+        "url": "https://www.lenstip.com/1089-Leica_TS-APO-Elmar-S_120_mm_f_5.6_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1489,
+        "name": "Leica Thambar-M 90 mm f/2.2",
+        "url": "https://www.lenstip.com/1489-Leica_Thambar-M_90_mm_f_2.2-lens_specifications.html"
+      },
+      {
+        "id": 51,
+        "name": "Leica Tri-Elmar-M 16-18-21 mm Asph",
+        "url": "https://www.lenstip.com/51-Leica_Tri-Elmar-M_16-18-21_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 56,
+        "name": "Leica Tri-Elmar-M 28-35-50 mm Asph",
+        "url": "https://www.lenstip.com/56-Leica_Tri-Elmar-M_28-35-50_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 1088,
+        "name": "Leica Vario Elmar-S 30-90 mm f/3.5-5.6 ASPH.",
+        "url": "https://www.lenstip.com/1088-Leica_Vario_Elmar-S_30-90_mm_f_3.5-5.6_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 80,
+        "name": "Leica Vario-Apo-Elmarit-R 70-180 mm",
+        "url": "https://www.lenstip.com/80-Leica_Vario-Apo-Elmarit-R_70-180_mm-lens_specifications.html"
+      },
+      {
+        "id": 82,
+        "name": "Leica Vario-Elmar-R 21-35 mm Asph",
+        "url": "https://www.lenstip.com/82-Leica_Vario-Elmar-R_21-35_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 83,
+        "name": "Leica Vario-Elmar-R 35-70 mm",
+        "url": "https://www.lenstip.com/83-Leica_Vario-Elmar-R_35-70_mm-lens_specifications.html"
+      },
+      {
+        "id": 84,
+        "name": "Leica Vario-Elmar-R 80-200 mm",
+        "url": "https://www.lenstip.com/84-Leica_Vario-Elmar-R_80-200_mm-lens_specifications.html"
+      },
+      {
+        "id": 2036,
+        "name": "Leica Vario-Elmar-SL 100-400 mm f/5-6.3",
+        "url": "https://www.lenstip.com/2036-Leica_Vario-Elmar-SL_100-400_mm_f_5-6.3-lens_specifications.html"
+      },
+      {
+        "id": 1192,
+        "name": "Leica Vario-Elmar-T 18-56 mm f/3.5-5.6 ASPH",
+        "url": "https://www.lenstip.com/1192-Leica_Vario-Elmar-T_18-56_mm_f_3.5-5.6_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 81,
+        "name": "Leica Vario-Elmarit-R 28-90 mm Asph",
+        "url": "https://www.lenstip.com/81-Leica_Vario-Elmarit-R_28-90_mm_Asph-lens_specifications.html"
+      },
+      {
+        "id": 1839,
+        "name": "Leica Vario-Elmarit-SL 24-70 mm f/2.8 ASPH",
+        "url": "https://www.lenstip.com/1839-Leica_Vario-Elmarit-SL_24-70_mm_f_2.8_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1327,
+        "name": "Leica Vario-Elmarit-SL 24-90 mm f/2.8-4 ASPH.",
+        "url": "https://www.lenstip.com/1327-Leica_Vario-Elmarit-SL_24-90_mm_f_2.8-4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 2237,
+        "name": "Leica Vario-Elmarit-SL 28-70 mm f/2.8 ASPH.",
+        "url": "https://www.lenstip.com/2237-Leica_Vario-Elmarit-SL_28-70_mm_f_2.8_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 2163,
+        "name": "Leica Vario-Elmarit-SL 70-200 mm f/2.8 ASPH.",
+        "url": "https://www.lenstip.com/2163-Leica_Vario-Elmarit-SL_70-200_mm_f_2.8_ASPH.-lens_specifications.html"
+      }
+    ],
+    "Mamiya": [
+      {
+        "id": 913,
+        "name": "Mamiya Sekor AF 110 mm f/2.8 D LS",
+        "url": "https://www.lenstip.com/913-Mamiya_Sekor_AF_110_mm_f_2.8_D_LS-lens_specifications.html"
+      },
+      {
+        "id": 789,
+        "name": "Mamiya Sekor AF 150 mm f/2.8 IF D",
+        "url": "https://www.lenstip.com/789-Mamiya_Sekor_AF_150_mm_f_2.8_IF_D-lens_specifications.html"
+      },
+      {
+        "id": 817,
+        "name": "Mamiya Sekor AF 45 mm f/2.8 D",
+        "url": "https://www.lenstip.com/817-Mamiya_Sekor_AF_45_mm_f_2.8_D-lens_specifications.html"
+      },
+      {
+        "id": 790,
+        "name": "Mamiya Sekor AF 45-90 mm f/4.5 D Aspherical",
+        "url": "https://www.lenstip.com/790-Mamiya_Sekor_AF_45-90_mm_f_4.5_D_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 914,
+        "name": "Mamiya Sekor AF 55 mm f/2.8 D LS",
+        "url": "https://www.lenstip.com/914-Mamiya_Sekor_AF_55_mm_f_2.8_D_LS-lens_specifications.html"
+      },
+      {
+        "id": 788,
+        "name": "Mamiya Sekor AF 80 mm f/2.8 D",
+        "url": "https://www.lenstip.com/788-Mamiya_Sekor_AF_80_mm_f_2.8_D-lens_specifications.html"
+      },
+      {
+        "id": 816,
+        "name": "Mamiya Sekor AF 80 mm f/2.8 D LS",
+        "url": "https://www.lenstip.com/816-Mamiya_Sekor_AF_80_mm_f_2.8_D_LS-lens_specifications.html"
+      }
+    ],
+    "Meike": [
+      {
+        "id": 1937,
+        "name": "Meike 10 mm T2.2 Cine",
+        "url": "https://www.lenstip.com/1937-Meike_10_mm_T2.2_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1960,
+        "name": "Meike 10 mm f/2.0",
+        "url": "https://www.lenstip.com/1960-Meike_10_mm_f_2.0_-lens_specifications.html"
+      },
+      {
+        "id": 1898,
+        "name": "Meike 105 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1898-Meike_105_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1419,
+        "name": "Meike 12 mm f/2.8",
+        "url": "https://www.lenstip.com/1419-Meike_12_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1952,
+        "name": "Meike 12mm f/2",
+        "url": "https://www.lenstip.com/1952-Meike_12mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1969,
+        "name": "Meike 135 mm T2.4 Cine",
+        "url": "https://www.lenstip.com/1969-Meike_135_mm_T2.4_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1957,
+        "name": "Meike 16 mm T2.5 Cine",
+        "url": "https://www.lenstip.com/1957-Meike_16_mm_T2.5_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1979,
+        "name": "Meike 18 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1979-Meike_18_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 2293,
+        "name": "Meike 23 mm f/1.4 AF",
+        "url": "https://www.lenstip.com/2293-Meike_23_mm_f_1.4_AF-lens_specifications.html"
+      },
+      {
+        "id": 1867,
+        "name": "Meike 24 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1867-Meike_24_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 2251,
+        "name": "Meike 24 mm f/1.4 AF",
+        "url": "https://www.lenstip.com/2251-Meike_24_mm_f_1.4_AF-lens_specifications.html"
+      },
+      {
+        "id": 1556,
+        "name": "Meike 25 mm T2.2 Cine",
+        "url": "https://www.lenstip.com/1556-Meike_25_mm_T2.2_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1423,
+        "name": "Meike 25 mm f/0.95",
+        "url": "https://www.lenstip.com/1423-Meike_25_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 2003,
+        "name": "Meike 25 mm f/0.95 (APS-C)",
+        "url": "https://www.lenstip.com/2003-Meike_25_mm_f_0.95_(APS-C)-lens_specifications.html"
+      },
+      {
+        "id": 1738,
+        "name": "Meike 25 mm f/1.8",
+        "url": "https://www.lenstip.com/1738-Meike_25_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1420,
+        "name": "Meike 28 mm f/2.8",
+        "url": "https://www.lenstip.com/1420-Meike_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1709,
+        "name": "Meike 3.5 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1709-Meike_3.5_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2152,
+        "name": "Meike 33 mm f/1.4 AF",
+        "url": "https://www.lenstip.com/2152-Meike_33_mm_f_1.4_AF-lens_specifications.html"
+      },
+      {
+        "id": 1743,
+        "name": "Meike 35 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1743-Meike_35_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1989,
+        "name": "Meike 35 mm f/0.95",
+        "url": "https://www.lenstip.com/1989-Meike_35_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1610,
+        "name": "Meike 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1610-Meike_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1421,
+        "name": "Meike 35 mm f/1.7",
+        "url": "https://www.lenstip.com/1421-Meike_35_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 2243,
+        "name": "Meike 35 mm f/1.8 AF Pro",
+        "url": "https://www.lenstip.com/2243-Meike_35_mm_f_1.8_AF_Pro-lens_specifications.html"
+      },
+      {
+        "id": 2168,
+        "name": "Meike 35 mm f/2 AF",
+        "url": "https://www.lenstip.com/2168-Meike_35_mm_f_2_AF-lens_specifications.html"
+      },
+      {
+        "id": 1816,
+        "name": "Meike 50 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1816-Meike_50_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1956,
+        "name": "Meike 50 mm f/0.95",
+        "url": "https://www.lenstip.com/1956-Meike_50_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1719,
+        "name": "Meike 50 mm f/1.2",
+        "url": "https://www.lenstip.com/1719-Meike_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1534,
+        "name": "Meike 50 mm f/1.7",
+        "url": "https://www.lenstip.com/1534-Meike_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 2110,
+        "name": "Meike 50 mm f/1.8 AF",
+        "url": "https://www.lenstip.com/2110-Meike_50_mm_f_1.8_AF-lens_specifications.html"
+      },
+      {
+        "id": 1422,
+        "name": "Meike 50 mm f/2.0",
+        "url": "https://www.lenstip.com/1422-Meike_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 2118,
+        "name": "Meike 55 mm f/1.4 AF",
+        "url": "https://www.lenstip.com/2118-Meike_55_mm_f_1.4_AF-lens_specifications.html"
+      },
+      {
+        "id": 2177,
+        "name": "Meike 55 mm f/1.8 AF Pro",
+        "url": "https://www.lenstip.com/2177-Meike_55_mm_f_1.8_AF_Pro-lens_specifications.html"
+      },
+      {
+        "id": 2325,
+        "name": "Meike 56 mm f/1.7 AF Air",
+        "url": "https://www.lenstip.com/2325-Meike_56_mm_f_1.7_AF_Air-lens_specifications.html"
+      },
+      {
+        "id": 1578,
+        "name": "Meike 6-11 mm f/3.5 Fisheye",
+        "url": "https://www.lenstip.com/1578-Meike_6-11_mm_f_3.5_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1424,
+        "name": "Meike 6.5 mm f/2.0",
+        "url": "https://www.lenstip.com/1424-Meike_6.5_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 2034,
+        "name": "Meike 60 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/2034-Meike_60_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1706,
+        "name": "Meike 65 mm T2.2 Cine",
+        "url": "https://www.lenstip.com/1706-Meike_65_mm_T2.2_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1948,
+        "name": "Meike 7.5 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1948-Meike_7.5_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1883,
+        "name": "Meike 75 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1883-Meike_75_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1755,
+        "name": "Meike 8 mm T2.9 Mini-Prime Cine",
+        "url": "https://www.lenstip.com/1755-Meike_8_mm_T2.9_Mini-Prime_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1953,
+        "name": "Meike 8 mm f/2.8",
+        "url": "https://www.lenstip.com/1953-Meike_8_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1425,
+        "name": "Meike 8 mm f/3.5",
+        "url": "https://www.lenstip.com/1425-Meike_8_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 1824,
+        "name": "Meike 85 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1824-Meike_85_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1705,
+        "name": "Meike 85 mm T2.2 Cine",
+        "url": "https://www.lenstip.com/1705-Meike_85_mm_T2.2_Cine-lens_specifications.html"
+      },
+      {
+        "id": 2079,
+        "name": "Meike 85 mm f/1.4 FF STM",
+        "url": "https://www.lenstip.com/2079-Meike_85_mm_f_1.4_FF_STM-lens_specifications.html"
+      },
+      {
+        "id": 1608,
+        "name": "Meike 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1608-Meike_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1528,
+        "name": "Meike 85 mm f/1.8 AF",
+        "url": "https://www.lenstip.com/1528-Meike_85_mm_f_1.8_AF-lens_specifications.html"
+      },
+      {
+        "id": 2187,
+        "name": "Meike 85 mm f/1.8 AF Pro",
+        "url": "https://www.lenstip.com/2187-Meike_85_mm_f_1.8_AF_Pro-lens_specifications.html"
+      },
+      {
+        "id": 2288,
+        "name": "Meike 85 mm f/1.8 AF SE II",
+        "url": "https://www.lenstip.com/2288-Meike_85_mm_f_1.8_AF_SE_II-lens_specifications.html"
+      },
+      {
+        "id": 1954,
+        "name": "Meike 85 mm f/1.8 FF STM",
+        "url": "https://www.lenstip.com/1954-Meike_85_mm_f_1.8_FF_STM-lens_specifications.html"
+      },
+      {
+        "id": 1481,
+        "name": "Meike 85 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/1481-Meike_85_mm_f_2.8_Macro-lens_specifications.html"
+      }
+    ],
+    "Mitakon": [
+      {
+        "id": 1428,
+        "name": "Mitakon 20 mm f/2.0 4.5x Super Macro",
+        "url": "https://www.lenstip.com/1428-Mitakon_20_mm_f_2.0_4.5x_Super_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1252,
+        "name": "Mitakon 24 mm f/1.7",
+        "url": "https://www.lenstip.com/1252-Mitakon_24_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 1253,
+        "name": "Mitakon 42.5 mm f/1.2",
+        "url": "https://www.lenstip.com/1253-Mitakon_42.5_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1665,
+        "name": "Mitakon 85 mm f/2.8 1-5X Super Macro Lens",
+        "url": "https://www.lenstip.com/1665-Mitakon_85_mm_f_2.8_1-5X_Super_Macro_Lens-lens_specifications.html"
+      },
+      {
+        "id": 2063,
+        "name": "Mitakon APO 200 mm f/4 MACRO 1x",
+        "url": "https://www.lenstip.com/2063-Mitakon_APO_200_mm_f_4_MACRO_1x-lens_specifications.html"
+      },
+      {
+        "id": 1872,
+        "name": "Mitakon Creator 135 mm f/2.5",
+        "url": "https://www.lenstip.com/1872-Mitakon_Creator_135_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1418,
+        "name": "Mitakon Creator 135 mm f/2.8 II",
+        "url": "https://www.lenstip.com/1418-Mitakon_Creator_135_mm_f_2.8_II-lens_specifications.html"
+      },
+      {
+        "id": 2038,
+        "name": "Mitakon Creator 28 mm f/5.6",
+        "url": "https://www.lenstip.com/2038-Mitakon_Creator_28_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 1265,
+        "name": "Mitakon Creator 35 mm f/2",
+        "url": "https://www.lenstip.com/1265-Mitakon_Creator_35_mm_f_2_-lens_specifications.html"
+      },
+      {
+        "id": 1357,
+        "name": "Mitakon Creator 85 mm f/2",
+        "url": "https://www.lenstip.com/1357-Mitakon_Creator_85_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1407,
+        "name": "Mitakon Speedmaster 135 mm f/1.4",
+        "url": "https://www.lenstip.com/1407-Mitakon_Speedmaster_135_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1745,
+        "name": "Mitakon Speedmaster 17 mm f/0.95",
+        "url": "https://www.lenstip.com/1745-Mitakon_Speedmaster_17_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 2161,
+        "name": "Mitakon Speedmaster 20 mm f/0.95",
+        "url": "https://www.lenstip.com/2161-Mitakon_Speedmaster_20_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1316,
+        "name": "Mitakon Speedmaster 25 mm f/0.95",
+        "url": "https://www.lenstip.com/1316-Mitakon_Speedmaster_25_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1266,
+        "name": "Mitakon Speedmaster 35 mm f/0.95",
+        "url": "https://www.lenstip.com/1266-Mitakon_Speedmaster_35_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1406,
+        "name": "Mitakon Speedmaster 35 mm f/0.95 Mark II",
+        "url": "https://www.lenstip.com/1406-Mitakon_Speedmaster_35_mm_f_0.95_Mark_II-lens_specifications.html"
+      },
+      {
+        "id": 1201,
+        "name": "Mitakon Speedmaster 50 mm f/0.95",
+        "url": "https://www.lenstip.com/1201-Mitakon_Speedmaster_50_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1694,
+        "name": "Mitakon Speedmaster 50 mm f/0.95 EF",
+        "url": "https://www.lenstip.com/1694-Mitakon_Speedmaster_50_mm_f_0.95_EF-lens_specifications.html"
+      },
+      {
+        "id": 1614,
+        "name": "Mitakon Speedmaster 50 mm f/0.95 Mark III",
+        "url": "https://www.lenstip.com/1614-Mitakon_Speedmaster_50_mm_f_0.95_Mark_III-lens_specifications.html"
+      },
+      {
+        "id": 1801,
+        "name": "Mitakon Speedmaster 50 mm f/0.95 Mark III (Leica M)",
+        "url": "https://www.lenstip.com/1801-Mitakon_Speedmaster_50_mm_f_0.95_Mark_III_(Leica_M)-lens_specifications.html"
+      },
+      {
+        "id": 1589,
+        "name": "Mitakon Speedmaster 65 mm f/1.4",
+        "url": "https://www.lenstip.com/1589-Mitakon_Speedmaster_65_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2145,
+        "name": "Mitakon Speedmaster 80 mm f/1.6",
+        "url": "https://www.lenstip.com/2145-Mitakon_Speedmaster_80_mm_f_1.6-lens_specifications.html"
+      },
+      {
+        "id": 1285,
+        "name": "Mitakon Speedmaster 85 mm f/1.2",
+        "url": "https://www.lenstip.com/1285-Mitakon_Speedmaster_85_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1908,
+        "name": "Mitakon Speedmaster 90 mm f/1.5",
+        "url": "https://www.lenstip.com/1908-Mitakon_Speedmaster_90_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 1833,
+        "name": "Mitakon Speedmaster Cinema Lens 17 mm T1.0",
+        "url": "https://www.lenstip.com/1833-Mitakon_Speedmaster_Cinema_Lens_17_mm_T1.0-lens_specifications.html"
+      },
+      {
+        "id": 2067,
+        "name": "Mitakon Speedmaster Cinema Lens 20 mm T1.0 S35",
+        "url": "https://www.lenstip.com/2067-Mitakon_Speedmaster_Cinema_Lens_20_mm_T1.0_S35-lens_specifications.html"
+      },
+      {
+        "id": 1832,
+        "name": "Mitakon Speedmaster Cinema Lens 25 mm T1.0",
+        "url": "https://www.lenstip.com/1832-Mitakon_Speedmaster_Cinema_Lens_25_mm_T1.0-lens_specifications.html"
+      },
+      {
+        "id": 1831,
+        "name": "Mitakon Speedmaster Cinema Lens 35 mm T1.0 S35",
+        "url": "https://www.lenstip.com/1831-Mitakon_Speedmaster_Cinema_Lens_35_mm_T1.0_S35-lens_specifications.html"
+      },
+      {
+        "id": 1830,
+        "name": "Mitakon Speedmaster Cinema Lens 50 mm T1.0 FF",
+        "url": "https://www.lenstip.com/1830-Mitakon_Speedmaster_Cinema_Lens_50_mm_T1.0_FF-lens_specifications.html"
+      },
+      {
+        "id": 1987,
+        "name": "Mitakon Speedmaster Cinema Lens 50 mm T1.0 MFT",
+        "url": "https://www.lenstip.com/1987-Mitakon_Speedmaster_Cinema_Lens_50_mm_T1.0_MFT-lens_specifications.html"
+      },
+      {
+        "id": 2068,
+        "name": "Mitakon Speedmaster Cinema Lens 50 mm T1.0 S35",
+        "url": "https://www.lenstip.com/2068-Mitakon_Speedmaster_Cinema_Lens_50_mm_T1.0_S35-lens_specifications.html"
+      }
+    ],
+    "Nikon Nikkor": [
+      {
+        "id": 1004,
+        "name": "Nikon Nikkor 1 10 mm f/2.8",
+        "url": "https://www.lenstip.com/1004-Nikon_Nikkor_1_10_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1095,
+        "name": "Nikon Nikkor 1 10-100 mm f/4.0-5.6 VR",
+        "url": "https://www.lenstip.com/1095-Nikon_Nikkor_1_10-100_mm_f_4.0-5.6_VR-lens_specifications.html"
+      },
+      {
+        "id": 1007,
+        "name": "Nikon Nikkor 1 10-100 mm f/4.5-5.6 VR PD-ZOOM",
+        "url": "https://www.lenstip.com/1007-Nikon_Nikkor_1_10-100_mm_f_4.5-5.6_VR_PD-ZOOM-lens_specifications.html"
+      },
+      {
+        "id": 1005,
+        "name": "Nikon Nikkor 1 10-30 mm f/3.5-5.6 VR",
+        "url": "https://www.lenstip.com/1005-Nikon_Nikkor_1_10-30_mm_f_3.5-5.6_VR-lens_specifications.html"
+      },
+      {
+        "id": 1186,
+        "name": "Nikon Nikkor 1 10-30 mm f/3.5-5.6 VR PD-ZOOM",
+        "url": "https://www.lenstip.com/1186-Nikon_Nikkor_1_10-30_mm_f_3.5-5.6_VR_PD-ZOOM-lens_specifications.html"
+      },
+      {
+        "id": 936,
+        "name": "Nikon Nikkor 1 11-27.5 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/936-Nikon_Nikkor_1_11-27.5_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1076,
+        "name": "Nikon Nikkor 1 18.5 mm f/1.8",
+        "url": "https://www.lenstip.com/1076-Nikon_Nikkor_1_18.5_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1006,
+        "name": "Nikon Nikkor 1 30-110 mm f/3.8-5.6 VR",
+        "url": "https://www.lenstip.com/1006-Nikon_Nikkor_1_30-110_mm_f_3.8-5.6_VR-lens_specifications.html"
+      },
+      {
+        "id": 1122,
+        "name": "Nikon Nikkor 1 32 mm f/1.2",
+        "url": "https://www.lenstip.com/1122-Nikon_Nikkor_1_32_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1094,
+        "name": "Nikon Nikkor 1 6.7-13 mm f/3.5-5.6 VR",
+        "url": "https://www.lenstip.com/1094-Nikon_Nikkor_1_6.7-13_mm_f_3.5-5.6_VR-lens_specifications.html"
+      },
+      {
+        "id": 1187,
+        "name": "Nikon Nikkor 1 70-300 mm f/4.5-5.6 VR",
+        "url": "https://www.lenstip.com/1187-Nikon_Nikkor_1_70-300_mm_f_4.5-5.6_VR-lens_specifications.html"
+      },
+      {
+        "id": 1150,
+        "name": "Nikon Nikkor 1 AW 10 mm f/2.8",
+        "url": "https://www.lenstip.com/1150-Nikon_Nikkor_1_AW_10_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1149,
+        "name": "Nikon Nikkor 1 AW 11-27.5 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/1149-Nikon_Nikkor_1_AW_11-27.5_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 346,
+        "name": "Nikon Nikkor AF 14 mm f/2.8D ED",
+        "url": "https://www.lenstip.com/346-Nikon_Nikkor_AF_14_mm_f_2.8D_ED-lens_specifications.html"
+      },
+      {
+        "id": 345,
+        "name": "Nikon Nikkor AF 16 mm f/2.8D Fish Eye",
+        "url": "https://www.lenstip.com/345-Nikon_Nikkor_AF_16_mm_f_2.8D_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 384,
+        "name": "Nikon Nikkor AF 18 mm f/2.8D",
+        "url": "https://www.lenstip.com/384-Nikon_Nikkor_AF_18_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 368,
+        "name": "Nikon Nikkor AF 18-35 mm f/3.5-4.5D IF-ED",
+        "url": "https://www.lenstip.com/368-Nikon_Nikkor_AF_18-35_mm_f_3.5-4.5D_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 355,
+        "name": "Nikon Nikkor AF 180 mm f/2.8D IF-ED",
+        "url": "https://www.lenstip.com/355-Nikon_Nikkor_AF_180_mm_f_2.8D_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 44,
+        "name": "Nikon Nikkor AF 20 mm f/2.8D",
+        "url": "https://www.lenstip.com/44-Nikon_Nikkor_AF_20_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 347,
+        "name": "Nikon Nikkor AF 24 mm f/2.8D",
+        "url": "https://www.lenstip.com/347-Nikon_Nikkor_AF_24_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 383,
+        "name": "Nikon Nikkor AF 24-50 mm f/3.3-4.5D",
+        "url": "https://www.lenstip.com/383-Nikon_Nikkor_AF_24-50_mm_f_3.3-4.5D-lens_specifications.html"
+      },
+      {
+        "id": 370,
+        "name": "Nikon Nikkor AF 24-85 mm f/2.8-4D IF",
+        "url": "https://www.lenstip.com/370-Nikon_Nikkor_AF_24-85_mm_f_2.8-4D_IF-lens_specifications.html"
+      },
+      {
+        "id": 385,
+        "name": "Nikon Nikkor AF 28 mm f/1.4D",
+        "url": "https://www.lenstip.com/385-Nikon_Nikkor_AF_28_mm_f_1.4D-lens_specifications.html"
+      },
+      {
+        "id": 348,
+        "name": "Nikon Nikkor AF 28 mm f/2.8D",
+        "url": "https://www.lenstip.com/348-Nikon_Nikkor_AF_28_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 378,
+        "name": "Nikon Nikkor AF 28-100 mm f/3.5-5.6G",
+        "url": "https://www.lenstip.com/378-Nikon_Nikkor_AF_28-100_mm_f_3.5-5.6G-lens_specifications.html"
+      },
+      {
+        "id": 379,
+        "name": "Nikon Nikkor AF 28-105 mm f/3.5-4.5D IF",
+        "url": "https://www.lenstip.com/379-Nikon_Nikkor_AF_28-105_mm_f_3.5-4.5D_IF-lens_specifications.html"
+      },
+      {
+        "id": 380,
+        "name": "Nikon Nikkor AF 28-200 mm f/3.5-5.6G IF-ED",
+        "url": "https://www.lenstip.com/380-Nikon_Nikkor_AF_28-200_mm_f_3.5-5.6G_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 377,
+        "name": "Nikon Nikkor AF 28-80 mm f/3.3-5.6G",
+        "url": "https://www.lenstip.com/377-Nikon_Nikkor_AF_28-80_mm_f_3.3-5.6G-lens_specifications.html"
+      },
+      {
+        "id": 349,
+        "name": "Nikon Nikkor AF 35 mm f/2D",
+        "url": "https://www.lenstip.com/349-Nikon_Nikkor_AF_35_mm_f_2D-lens_specifications.html"
+      },
+      {
+        "id": 381,
+        "name": "Nikon Nikkor AF 35-70 mm f/2.8D",
+        "url": "https://www.lenstip.com/381-Nikon_Nikkor_AF_35-70_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 350,
+        "name": "Nikon Nikkor AF 50 mm f/1.4D",
+        "url": "https://www.lenstip.com/350-Nikon_Nikkor_AF_50_mm_f_1.4D-lens_specifications.html"
+      },
+      {
+        "id": 351,
+        "name": "Nikon Nikkor AF 50 mm f/1.8D",
+        "url": "https://www.lenstip.com/351-Nikon_Nikkor_AF_50_mm_f_1.8D-lens_specifications.html"
+      },
+      {
+        "id": 28,
+        "name": "Nikon Nikkor AF 70-300 mm f/4-5.6D ED",
+        "url": "https://www.lenstip.com/28-Nikon_Nikkor_AF_70-300_mm_f_4-5.6D_ED-lens_specifications.html"
+      },
+      {
+        "id": 374,
+        "name": "Nikon Nikkor AF 70-300 mm f/4-5.6G",
+        "url": "https://www.lenstip.com/374-Nikon_Nikkor_AF_70-300_mm_f_4-5.6G-lens_specifications.html"
+      },
+      {
+        "id": 364,
+        "name": "Nikon Nikkor AF 80-200 mm f/2.8D ED",
+        "url": "https://www.lenstip.com/364-Nikon_Nikkor_AF_80-200_mm_f_2.8D_ED-lens_specifications.html"
+      },
+      {
+        "id": 375,
+        "name": "Nikon Nikkor AF 80-400 mm f/4.5-5.6D ED VR",
+        "url": "https://www.lenstip.com/375-Nikon_Nikkor_AF_80-400_mm_f_4.5-5.6D_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 352,
+        "name": "Nikon Nikkor AF 85 mm f/1.4D IF",
+        "url": "https://www.lenstip.com/352-Nikon_Nikkor_AF_85_mm_f_1.4D_IF-lens_specifications.html"
+      },
+      {
+        "id": 143,
+        "name": "Nikon Nikkor AF 85 mm f/1.8D",
+        "url": "https://www.lenstip.com/143-Nikon_Nikkor_AF_85_mm_f_1.8D-lens_specifications.html"
+      },
+      {
+        "id": 353,
+        "name": "Nikon Nikkor AF DC 105 mm f/2D",
+        "url": "https://www.lenstip.com/353-Nikon_Nikkor_AF_DC_105_mm_f_2D-lens_specifications.html"
+      },
+      {
+        "id": 354,
+        "name": "Nikon Nikkor AF DC 135 mm f/2D",
+        "url": "https://www.lenstip.com/354-Nikon_Nikkor_AF_DC_135_mm_f_2D-lens_specifications.html"
+      },
+      {
+        "id": 360,
+        "name": "Nikon Nikkor AF DX 10.5 mm f/2.8G ED Fisheye",
+        "url": "https://www.lenstip.com/360-Nikon_Nikkor_AF_DX_10.5_mm_f_2.8G_ED_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 387,
+        "name": "Nikon Nikkor AF Micro 105 mm f/2.8D",
+        "url": "https://www.lenstip.com/387-Nikon_Nikkor_AF_Micro_105_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 388,
+        "name": "Nikon Nikkor AF Micro 200 mm f/4D IF-ED",
+        "url": "https://www.lenstip.com/388-Nikon_Nikkor_AF_Micro_200_mm_f_4D_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 386,
+        "name": "Nikon Nikkor AF Micro 60 mm f/2.8D",
+        "url": "https://www.lenstip.com/386-Nikon_Nikkor_AF_Micro_60_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 389,
+        "name": "Nikon Nikkor AF Micro 70-180 mm f/4.5-5.6D ED",
+        "url": "https://www.lenstip.com/389-Nikon_Nikkor_AF_Micro_70-180_mm_f_4.5-5.6D_ED-lens_specifications.html"
+      },
+      {
+        "id": 1473,
+        "name": "Nikon Nikkor AF-P 70-300 mm f/4.5-5.6E ED VR",
+        "url": "https://www.lenstip.com/1473-Nikon_Nikkor_AF-P_70-300_mm_f_4.5-5.6E_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1468,
+        "name": "Nikon Nikkor AF-P DX 10-20 mm f/4.5-5.6G VR",
+        "url": "https://www.lenstip.com/1468-Nikon_Nikkor_AF-P_DX_10-20_mm_f_4.5-5.6G_VR-lens_specifications.html"
+      },
+      {
+        "id": 1336,
+        "name": "Nikon Nikkor AF-P DX 18-55 mm f/3.5-5.6G",
+        "url": "https://www.lenstip.com/1336-Nikon_Nikkor_AF-P_DX_18-55_mm_f_3.5-5.6G-lens_specifications.html"
+      },
+      {
+        "id": 1335,
+        "name": "Nikon Nikkor AF-P DX 18-55 mm f/3.5-5.6G VR",
+        "url": "https://www.lenstip.com/1335-Nikon_Nikkor_AF-P_DX_18-55_mm_f_3.5-5.6G_VR-lens_specifications.html"
+      },
+      {
+        "id": 1377,
+        "name": "Nikon Nikkor AF-P DX 70-300 mm f/4.5-6.3G ED",
+        "url": "https://www.lenstip.com/1377-Nikon_Nikkor_AF-P_DX_70-300_mm_f_4.5-6.3G_ED-lens_specifications.html"
+      },
+      {
+        "id": 1376,
+        "name": "Nikon Nikkor AF-P DX 70-300 mm f/4.5-6.3G ED VR",
+        "url": "https://www.lenstip.com/1376-Nikon_Nikkor_AF-P_DX_70-300_mm_f_4.5-6.3G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1371,
+        "name": "Nikon Nikkor AF-S 105 mm f/1.4E ED",
+        "url": "https://www.lenstip.com/1371-Nikon_Nikkor_AF-S_105_mm_f_1.4E_ED-lens_specifications.html"
+      },
+      {
+        "id": 1670,
+        "name": "Nikon Nikkor AF-S 120-300 mm f/2.8E FL ED SR VR",
+        "url": "https://www.lenstip.com/1670-Nikon_Nikkor_AF-S_120-300_mm_f_2.8E_FL_ED_SR_VR-lens_specifications.html"
+      },
+      {
+        "id": 640,
+        "name": "Nikon Nikkor AF-S 14-24 mm f/2.8G ED",
+        "url": "https://www.lenstip.com/640-Nikon_Nikkor_AF-S_14-24_mm_f_2.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 903,
+        "name": "Nikon Nikkor AF-S 16-35 mm f/4G ED VR",
+        "url": "https://www.lenstip.com/903-Nikon_Nikkor_AF-S_16-35_mm_f_4G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 367,
+        "name": "Nikon Nikkor AF-S 17-35 mm f/2.8D ED-IF",
+        "url": "https://www.lenstip.com/367-Nikon_Nikkor_AF-S_17-35_mm_f_2.8D_ED-IF-lens_specifications.html"
+      },
+      {
+        "id": 1096,
+        "name": "Nikon Nikkor AF-S 18-35 mm f/3.5-4.5G ED",
+        "url": "https://www.lenstip.com/1096-Nikon_Nikkor_AF-S_18-35_mm_f_3.5-4.5G_ED-lens_specifications.html"
+      },
+      {
+        "id": 1501,
+        "name": "Nikon Nikkor AF-S 180-400 mm f/4E TC1.4 FL ED VR",
+        "url": "https://www.lenstip.com/1501-Nikon_Nikkor_AF-S_180-400_mm_f_4E_TC1.4_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1226,
+        "name": "Nikon Nikkor AF-S 20 mm f/1.8G ED",
+        "url": "https://www.lenstip.com/1226-Nikon_Nikkor_AF-S_20_mm_f_1.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 955,
+        "name": "Nikon Nikkor AF-S 200 mm f/2G ED VRII",
+        "url": "https://www.lenstip.com/955-Nikon_Nikkor_AF-S_200_mm_f_2G_ED_VRII-lens_specifications.html"
+      },
+      {
+        "id": 361,
+        "name": "Nikon Nikkor AF-S 200 mm f/2G IF-ED VR",
+        "url": "https://www.lenstip.com/361-Nikon_Nikkor_AF-S_200_mm_f_2G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1298,
+        "name": "Nikon Nikkor AF-S 200&#8211;500 mm f/5.6E ED VR",
+        "url": "https://www.lenstip.com/1298-Nikon_Nikkor_AF-S_200&#8211;500_mm_f_5.6E_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 922,
+        "name": "Nikon Nikkor AF-S 200-400 mm f/4G ED VR II",
+        "url": "https://www.lenstip.com/922-Nikon_Nikkor_AF-S_200-400_mm_f_4G_ED_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 376,
+        "name": "Nikon Nikkor AF-S 200-400 mm f/4G IF-ED VR",
+        "url": "https://www.lenstip.com/376-Nikon_Nikkor_AF-S_200-400_mm_f_4G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 902,
+        "name": "Nikon Nikkor AF-S 24 mm f/1.4G ED",
+        "url": "https://www.lenstip.com/902-Nikon_Nikkor_AF-S_24_mm_f_1.4G_ED-lens_specifications.html"
+      },
+      {
+        "id": 1297,
+        "name": "Nikon Nikkor AF-S 24 mm f/1.8G ED",
+        "url": "https://www.lenstip.com/1297-Nikon_Nikkor_AF-S_24_mm_f_1.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 371,
+        "name": "Nikon Nikkor AF-S 24-120 mm f/3.5-5.6D IF VR",
+        "url": "https://www.lenstip.com/371-Nikon_Nikkor_AF-S_24-120_mm_f_3.5-5.6D_IF_VR-lens_specifications.html"
+      },
+      {
+        "id": 932,
+        "name": "Nikon Nikkor AF-S 24-120 mm f/4G ED VR",
+        "url": "https://www.lenstip.com/932-Nikon_Nikkor_AF-S_24-120_mm_f_4G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1296,
+        "name": "Nikon Nikkor AF-S 24-70 mm f/2.8E ED VR",
+        "url": "https://www.lenstip.com/1296-Nikon_Nikkor_AF-S_24-70_mm_f_2.8E_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 641,
+        "name": "Nikon Nikkor AF-S 24-70 mm f/2.8G ED",
+        "url": "https://www.lenstip.com/641-Nikon_Nikkor_AF-S_24-70_mm_f_2.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 1052,
+        "name": "Nikon Nikkor AF-S 24-85 mm f/3.5-4.5G ED VR",
+        "url": "https://www.lenstip.com/1052-Nikon_Nikkor_AF-S_24-85_mm_f_3.5-4.5G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 369,
+        "name": "Nikon Nikkor AF-S 24-85 mm f/3.5-4.5G IF-ED",
+        "url": "https://www.lenstip.com/369-Nikon_Nikkor_AF-S_24-85_mm_f_3.5-4.5G_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 1467,
+        "name": "Nikon Nikkor AF-S 28 mm f/1.4E ED",
+        "url": "https://www.lenstip.com/1467-Nikon_Nikkor_AF-S_28_mm_f_1.4E_ED-lens_specifications.html"
+      },
+      {
+        "id": 1042,
+        "name": "Nikon Nikkor AF-S 28 mm f/1.8G",
+        "url": "https://www.lenstip.com/1042-Nikon_Nikkor_AF-S_28_mm_f_1.8G-lens_specifications.html"
+      },
+      {
+        "id": 935,
+        "name": "Nikon Nikkor AF-S 28-300 mm f/3.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/935-Nikon_Nikkor_AF-S_28-300_mm_f_3.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 372,
+        "name": "Nikon Nikkor AF-S 28-70 mm f/2.8D IF-ED",
+        "url": "https://www.lenstip.com/372-Nikon_Nikkor_AF-S_28-70_mm_f_2.8D_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 896,
+        "name": "Nikon Nikkor AF-S 300 mm f/2.8G ED VR II",
+        "url": "https://www.lenstip.com/896-Nikon_Nikkor_AF-S_300_mm_f_2.8G_ED_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 356,
+        "name": "Nikon Nikkor AF-S 300 mm f/2.8G IF-ED VR",
+        "url": "https://www.lenstip.com/356-Nikon_Nikkor_AF-S_300_mm_f_2.8G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 15,
+        "name": "Nikon Nikkor AF-S 300 mm f/4D IF-ED",
+        "url": "https://www.lenstip.com/15-Nikon_Nikkor_AF-S_300_mm_f_4D_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 1262,
+        "name": "Nikon Nikkor AF-S 300 mm f/4E PF ED VR",
+        "url": "https://www.lenstip.com/1262-Nikon_Nikkor_AF-S_300_mm_f_4E_PF_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 954,
+        "name": "Nikon Nikkor AF-S 35 mm f/1.4G",
+        "url": "https://www.lenstip.com/954-Nikon_Nikkor_AF-S_35_mm_f_1.4G-lens_specifications.html"
+      },
+      {
+        "id": 1173,
+        "name": "Nikon Nikkor AF-S 35 mm f/1.8G ED",
+        "url": "https://www.lenstip.com/1173-Nikon_Nikkor_AF-S_35_mm_f_1.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 357,
+        "name": "Nikon Nikkor AF-S 400 mm f/2.8D IF-ED II",
+        "url": "https://www.lenstip.com/357-Nikon_Nikkor_AF-S_400_mm_f_2.8D_IF-ED_II-lens_specifications.html"
+      },
+      {
+        "id": 1204,
+        "name": "Nikon Nikkor AF-S 400 mm f/2.8E FL ED VR",
+        "url": "https://www.lenstip.com/1204-Nikon_Nikkor_AF-S_400_mm_f_2.8E_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 642,
+        "name": "Nikon Nikkor AF-S 400 mm f/2.8G ED VR",
+        "url": "https://www.lenstip.com/642-Nikon_Nikkor_AF-S_400_mm_f_2.8G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 823,
+        "name": "Nikon Nikkor AF-S 50 mm f/1.4G",
+        "url": "https://www.lenstip.com/823-Nikon_Nikkor_AF-S_50_mm_f_1.4G-lens_specifications.html"
+      },
+      {
+        "id": 982,
+        "name": "Nikon Nikkor AF-S 50 mm f/1.8G",
+        "url": "https://www.lenstip.com/982-Nikon_Nikkor_AF-S_50_mm_f_1.8G-lens_specifications.html"
+      },
+      {
+        "id": 1162,
+        "name": "Nikon Nikkor AF-S 50 mm f/1.8G (SE)",
+        "url": "https://www.lenstip.com/1162-Nikon_Nikkor_AF-S_50_mm_f_1.8G_(SE)-lens_specifications.html"
+      },
+      {
+        "id": 358,
+        "name": "Nikon Nikkor AF-S 500 mm f/4D IF-ED II",
+        "url": "https://www.lenstip.com/358-Nikon_Nikkor_AF-S_500_mm_f_4D_IF-ED_II-lens_specifications.html"
+      },
+      {
+        "id": 1300,
+        "name": "Nikon Nikkor AF-S 500 mm f/4E FL ED VR",
+        "url": "https://www.lenstip.com/1300-Nikon_Nikkor_AF-S_500_mm_f_4E_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 643,
+        "name": "Nikon Nikkor AF-S 500 mm f/4G ED VR",
+        "url": "https://www.lenstip.com/643-Nikon_Nikkor_AF-S_500_mm_f_4G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1552,
+        "name": "Nikon Nikkor AF-S 500 mm f/5.6E PF ED VR",
+        "url": "https://www.lenstip.com/1552-Nikon_Nikkor_AF-S_500_mm_f_5.6E_PF_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1160,
+        "name": "Nikon Nikkor AF-S 58 mm f/1.4G",
+        "url": "https://www.lenstip.com/1160-Nikon_Nikkor_AF-S_58_mm_f_1.4G-lens_specifications.html"
+      },
+      {
+        "id": 359,
+        "name": "Nikon Nikkor AF-S 600 mm f/4D IF-ED II",
+        "url": "https://www.lenstip.com/359-Nikon_Nikkor_AF-S_600_mm_f_4D_IF-ED_II-lens_specifications.html"
+      },
+      {
+        "id": 1301,
+        "name": "Nikon Nikkor AF-S 600 mm f/4E FL ED VR",
+        "url": "https://www.lenstip.com/1301-Nikon_Nikkor_AF-S_600_mm_f_4E_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 644,
+        "name": "Nikon Nikkor AF-S 600 mm f/4G ED VR",
+        "url": "https://www.lenstip.com/644-Nikon_Nikkor_AF-S_600_mm_f_4G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1409,
+        "name": "Nikon Nikkor AF-S 70-200 mm f/2.8E FL ED VR",
+        "url": "https://www.lenstip.com/1409-Nikon_Nikkor_AF-S_70-200_mm_f_2.8E_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 871,
+        "name": "Nikon Nikkor AF-S 70-200 mm f/2.8G ED VR II",
+        "url": "https://www.lenstip.com/871-Nikon_Nikkor_AF-S_70-200_mm_f_2.8G_ED_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 373,
+        "name": "Nikon Nikkor AF-S 70-200 mm f/2.8G IF-ED VR",
+        "url": "https://www.lenstip.com/373-Nikon_Nikkor_AF-S_70-200_mm_f_2.8G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 804,
+        "name": "Nikon Nikkor AF-S 70-200 mm f/4.0G ED VR",
+        "url": "https://www.lenstip.com/804-Nikon_Nikkor_AF-S_70-200_mm_f_4.0G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 382,
+        "name": "Nikon Nikkor AF-S 70-300 mm f/4.5-5.6G IF-ED VR",
+        "url": "https://www.lenstip.com/382-Nikon_Nikkor_AF-S_70-300_mm_f_4.5-5.6G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 669,
+        "name": "Nikon Nikkor AF-S 80-200 mm f/2.8D",
+        "url": "https://www.lenstip.com/669-Nikon_Nikkor_AF-S_80-200_mm_f_2.8D-lens_specifications.html"
+      },
+      {
+        "id": 1114,
+        "name": "Nikon Nikkor AF-S 80-400 mm f/4.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/1114-Nikon_Nikkor_AF-S_80-400_mm_f_4.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1100,
+        "name": "Nikon Nikkor AF-S 800 mm f/5.6E FL ED VR",
+        "url": "https://www.lenstip.com/1100-Nikon_Nikkor_AF-S_800_mm_f_5.6E_FL_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 933,
+        "name": "Nikon Nikkor AF-S 85 mm f/1.4G",
+        "url": "https://www.lenstip.com/933-Nikon_Nikkor_AF-S_85_mm_f_1.4G-lens_specifications.html"
+      },
+      {
+        "id": 1017,
+        "name": "Nikon Nikkor AF-S 85 mm f/1.8G",
+        "url": "https://www.lenstip.com/1017-Nikon_Nikkor_AF-S_85_mm_f_1.8G_-lens_specifications.html"
+      },
+      {
+        "id": 856,
+        "name": "Nikon Nikkor AF-S DX 10-24 mm f/3.5-4.5G ED",
+        "url": "https://www.lenstip.com/856-Nikon_Nikkor_AF-S_DX_10-24_mm_f_3.5-4.5G_ED-lens_specifications.html"
+      },
+      {
+        "id": 362,
+        "name": "Nikon Nikkor AF-S DX 12-24 mm f/4G IF-ED",
+        "url": "https://www.lenstip.com/362-Nikon_Nikkor_AF-S_DX_12-24_mm_f_4G_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 1299,
+        "name": "Nikon Nikkor AF-S DX 16-80 mm f/2.8-4E ED VR",
+        "url": "https://www.lenstip.com/1299-Nikon_Nikkor_AF-S_DX_16-80_mm_f_2.8-4E_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 679,
+        "name": "Nikon Nikkor AF-S DX 16-85 mm f/3.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/679-Nikon_Nikkor_AF-S_DX_16-85_mm_f_3.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 363,
+        "name": "Nikon Nikkor AF-S DX 17-55 mm f/2.8G IF-ED",
+        "url": "https://www.lenstip.com/363-Nikon_Nikkor_AF-S_DX_17-55_mm_f_2.8G_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 803,
+        "name": "Nikon Nikkor AF-S DX 18-105 mm f/3.5-5.6 VR ED",
+        "url": "https://www.lenstip.com/803-Nikon_Nikkor_AF-S_DX_18-105_mm_f_3.5-5.6_VR_ED-lens_specifications.html"
+      },
+      {
+        "id": 41,
+        "name": "Nikon Nikkor AF-S DX 18-135 mm f/3.5-5.6G ED-IF",
+        "url": "https://www.lenstip.com/41-Nikon_Nikkor_AF-S_DX_18-135_mm_f_3.5-5.6G_ED-IF-lens_specifications.html"
+      },
+      {
+        "id": 1133,
+        "name": "Nikon Nikkor AF-S DX 18-140 mm f/3.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/1133-Nikon_Nikkor_AF-S_DX_18-140_mm_f_3.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 870,
+        "name": "Nikon Nikkor AF-S DX 18-200 mm f/3.5-5.6G ED VR II",
+        "url": "https://www.lenstip.com/870-Nikon_Nikkor_AF-S_DX_18-200_mm_f_3.5-5.6G_ED_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 366,
+        "name": "Nikon Nikkor AF-S DX 18-200 mm f/3.5-5.6G IF-ED VR",
+        "url": "https://www.lenstip.com/366-Nikon_Nikkor_AF-S_DX_18-200_mm_f_3.5-5.6G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1041,
+        "name": "Nikon Nikkor AF-S DX 18-300 mm f/3.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/1041-Nikon_Nikkor_AF-S_DX_18-300_mm_f_3.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1191,
+        "name": "Nikon Nikkor AF-S DX 18-300 mm f/3.5-6.3G ED VR",
+        "url": "https://www.lenstip.com/1191-Nikon_Nikkor_AF-S_DX_18-300_mm_f_3.5-6.3G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 21,
+        "name": "Nikon Nikkor AF-S DX 18-55 mm f/3.5-5.6G ED",
+        "url": "https://www.lenstip.com/21-Nikon_Nikkor_AF-S_DX_18-55_mm_f_3.5-5.6G_ED-lens_specifications.html"
+      },
+      {
+        "id": 365,
+        "name": "Nikon Nikkor AF-S DX 18-55 mm f/3.5-5.6G ED II",
+        "url": "https://www.lenstip.com/365-Nikon_Nikkor_AF-S_DX_18-55_mm_f_3.5-5.6G_ED_II-lens_specifications.html"
+      },
+      {
+        "id": 666,
+        "name": "Nikon Nikkor AF-S DX 18-55 mm f/3.5-5.6G VR",
+        "url": "https://www.lenstip.com/666-Nikon_Nikkor_AF-S_DX_18-55_mm_f_3.5-5.6G_VR-lens_specifications.html"
+      },
+      {
+        "id": 1174,
+        "name": "Nikon Nikkor AF-S DX 18-55 mm f/3.5-5.6G VR II",
+        "url": "https://www.lenstip.com/1174-Nikon_Nikkor_AF-S_DX_18-55_mm_f_3.5-5.6G_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 19,
+        "name": "Nikon Nikkor AF-S DX 18-70 mm f/3.5-4.5 IF-ED",
+        "url": "https://www.lenstip.com/19-Nikon_Nikkor_AF-S_DX_18-70_mm_f_3.5-4.5_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 833,
+        "name": "Nikon Nikkor AF-S DX 35 mm f/1.8G",
+        "url": "https://www.lenstip.com/833-Nikon_Nikkor_AF-S_DX_35_mm_f_1.8G-lens_specifications.html"
+      },
+      {
+        "id": 14,
+        "name": "Nikon Nikkor AF-S DX 55-200 mm f/4-5.6G ED",
+        "url": "https://www.lenstip.com/14-Nikon_Nikkor_AF-S_DX_55-200_mm_f_4-5.6G_ED-lens_specifications.html"
+      },
+      {
+        "id": 1261,
+        "name": "Nikon Nikkor AF-S DX 55-200 mm f/4-5.6G ED VR II",
+        "url": "https://www.lenstip.com/1261-Nikon_Nikkor_AF-S_DX_55-200_mm_f_4-5.6G_ED_VR_II-lens_specifications.html"
+      },
+      {
+        "id": 624,
+        "name": "Nikon Nikkor AF-S DX 55-200 mm f/4-5.6G IF-ED VR",
+        "url": "https://www.lenstip.com/624-Nikon_Nikkor_AF-S_DX_55-200_mm_f_4-5.6G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 934,
+        "name": "Nikon Nikkor AF-S DX 55-300 mm f/4.5-5.6G ED VR",
+        "url": "https://www.lenstip.com/934-Nikon_Nikkor_AF-S_DX_55-300_mm_f_4.5-5.6G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 995,
+        "name": "Nikon Nikkor AF-S DX Micro 40 mm f/2.8G",
+        "url": "https://www.lenstip.com/995-Nikon_Nikkor_AF-S_DX_Micro_40_mm_f_2.8G-lens_specifications.html"
+      },
+      {
+        "id": 888,
+        "name": "Nikon Nikkor AF-S DX Micro 85 mm f/3.5G ED VR",
+        "url": "https://www.lenstip.com/888-Nikon_Nikkor_AF-S_DX_Micro_85_mm_f_3.5G_ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 1466,
+        "name": "Nikon Nikkor AF-S Fisheye 8-15 mm f/3.5-4.5E ED",
+        "url": "https://www.lenstip.com/1466-Nikon_Nikkor_AF-S_Fisheye_8-15_mm_f_3.5-4.5E_ED-lens_specifications.html"
+      },
+      {
+        "id": 616,
+        "name": "Nikon Nikkor AF-S Micro 105 mm f/2.8G IF-ED VR",
+        "url": "https://www.lenstip.com/616-Nikon_Nikkor_AF-S_Micro_105_mm_f_2.8G_IF-ED_VR-lens_specifications.html"
+      },
+      {
+        "id": 678,
+        "name": "Nikon Nikkor AF-S Micro 60 mm f/2.8G ED",
+        "url": "https://www.lenstip.com/678-Nikon_Nikkor_AF-S_Micro_60_mm_f_2.8G_ED-lens_specifications.html"
+      },
+      {
+        "id": 583,
+        "name": "Nikon Nikkor MF 1000 mm f/11 Reflex",
+        "url": "https://www.lenstip.com/583-Nikon_Nikkor_MF_1000_mm_f_11_Reflex-lens_specifications.html"
+      },
+      {
+        "id": 584,
+        "name": "Nikon Nikkor MF 105 mm f/1.8",
+        "url": "https://www.lenstip.com/584-Nikon_Nikkor_MF_105_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 585,
+        "name": "Nikon Nikkor MF 105 mm f/2.5",
+        "url": "https://www.lenstip.com/585-Nikon_Nikkor_MF_105_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 586,
+        "name": "Nikon Nikkor MF 105 mm f/2.8 Micro",
+        "url": "https://www.lenstip.com/586-Nikon_Nikkor_MF_105_mm_f_2.8_Micro-lens_specifications.html"
+      },
+      {
+        "id": 588,
+        "name": "Nikon Nikkor MF 135 mm f/2",
+        "url": "https://www.lenstip.com/588-Nikon_Nikkor_MF_135_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 587,
+        "name": "Nikon Nikkor MF 135 mm f/2.8",
+        "url": "https://www.lenstip.com/587-Nikon_Nikkor_MF_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 589,
+        "name": "Nikon Nikkor MF 15 mm f/3.5",
+        "url": "https://www.lenstip.com/589-Nikon_Nikkor_MF_15_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 591,
+        "name": "Nikon Nikkor MF 18 mm f/3.5",
+        "url": "https://www.lenstip.com/591-Nikon_Nikkor_MF_18_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 590,
+        "name": "Nikon Nikkor MF 180 mm f/2.8 ED",
+        "url": "https://www.lenstip.com/590-Nikon_Nikkor_MF_180_mm_f_2.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 594,
+        "name": "Nikon Nikkor MF 20 mm f/2.8",
+        "url": "https://www.lenstip.com/594-Nikon_Nikkor_MF_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 592,
+        "name": "Nikon Nikkor MF 200 mm f/2 IF ED",
+        "url": "https://www.lenstip.com/592-Nikon_Nikkor_MF_200_mm_f_2_IF_ED-lens_specifications.html"
+      },
+      {
+        "id": 593,
+        "name": "Nikon Nikkor MF 200 mm f/4 IF Macro",
+        "url": "https://www.lenstip.com/593-Nikon_Nikkor_MF_200_mm_f_4_IF_Macro-lens_specifications.html"
+      },
+      {
+        "id": 596,
+        "name": "Nikon Nikkor MF 24 mm f/2",
+        "url": "https://www.lenstip.com/596-Nikon_Nikkor_MF_24_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 595,
+        "name": "Nikon Nikkor MF 24 mm f/2.8",
+        "url": "https://www.lenstip.com/595-Nikon_Nikkor_MF_24_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 599,
+        "name": "Nikon Nikkor MF 28 mm f/2",
+        "url": "https://www.lenstip.com/599-Nikon_Nikkor_MF_28_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 600,
+        "name": "Nikon Nikkor MF 28 mm f/3.5 PC",
+        "url": "https://www.lenstip.com/600-Nikon_Nikkor_MF_28_mm_f_3.5_PC-lens_specifications.html"
+      },
+      {
+        "id": 597,
+        "name": "Nikon Nikkor MF 28-85 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/597-Nikon_Nikkor_MF_28-85_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 602,
+        "name": "Nikon Nikkor MF 35 mm f/1.4s",
+        "url": "https://www.lenstip.com/602-Nikon_Nikkor_MF_35_mm_f_1.4s-lens_specifications.html"
+      },
+      {
+        "id": 603,
+        "name": "Nikon Nikkor MF 35 mm f/2",
+        "url": "https://www.lenstip.com/603-Nikon_Nikkor_MF_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 601,
+        "name": "Nikon Nikkor MF 35-200 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/601-Nikon_Nikkor_MF_35-200_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 604,
+        "name": "Nikon Nikkor MF 400 mm f/2.8 IF-ED",
+        "url": "https://www.lenstip.com/604-Nikon_Nikkor_MF_400_mm_f_2.8_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 605,
+        "name": "Nikon Nikkor MF 400 mm f/3.5 IF-ED",
+        "url": "https://www.lenstip.com/605-Nikon_Nikkor_MF_400_mm_f_3.5_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 606,
+        "name": "Nikon Nikkor MF 45 mm f/2.8 P",
+        "url": "https://www.lenstip.com/606-Nikon_Nikkor_MF_45_mm_f_2.8_P-lens_specifications.html"
+      },
+      {
+        "id": 608,
+        "name": "Nikon Nikkor MF 50 mm f/1.2",
+        "url": "https://www.lenstip.com/608-Nikon_Nikkor_MF_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 609,
+        "name": "Nikon Nikkor MF 50 mm f/1.4",
+        "url": "https://www.lenstip.com/609-Nikon_Nikkor_MF_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 610,
+        "name": "Nikon Nikkor MF 50 mm f/1.8",
+        "url": "https://www.lenstip.com/610-Nikon_Nikkor_MF_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 607,
+        "name": "Nikon Nikkor MF 500 mm f/8 Reflex",
+        "url": "https://www.lenstip.com/607-Nikon_Nikkor_MF_500_mm_f_8_Reflex-lens_specifications.html"
+      },
+      {
+        "id": 611,
+        "name": "Nikon Nikkor MF 55 mm f/2.8 Micro",
+        "url": "https://www.lenstip.com/611-Nikon_Nikkor_MF_55_mm_f_2.8_Micro-lens_specifications.html"
+      },
+      {
+        "id": 612,
+        "name": "Nikon Nikkor MF 600 mm f/5.6 IF-ED",
+        "url": "https://www.lenstip.com/612-Nikon_Nikkor_MF_600_mm_f_5.6_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 613,
+        "name": "Nikon Nikkor MF 70-210 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/613-Nikon_Nikkor_MF_70-210_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 614,
+        "name": "Nikon Nikkor MF 800 mm f/5.6 IF-ED",
+        "url": "https://www.lenstip.com/614-Nikon_Nikkor_MF_800_mm_f_5.6_IF-ED-lens_specifications.html"
+      },
+      {
+        "id": 615,
+        "name": "Nikon Nikkor MF 85 mm f/1.4",
+        "url": "https://www.lenstip.com/615-Nikon_Nikkor_MF_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 598,
+        "name": "Nikon Nikkor Mf 28 mm f/2.8",
+        "url": "https://www.lenstip.com/598-Nikon_Nikkor_Mf_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1181,
+        "name": "Nikon Nikkor Noct 58 mm f/1.2",
+        "url": "https://www.lenstip.com/1181-Nikon_Nikkor_Noct_58_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 859,
+        "name": "Nikon Nikkor P 10.5 cm f/2.5",
+        "url": "https://www.lenstip.com/859-Nikon_Nikkor_P_10.5_cm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 1410,
+        "name": "Nikon Nikkor PC 19 mm f/4E ED",
+        "url": "https://www.lenstip.com/1410-Nikon_Nikkor_PC_19_mm_f_4E_ED-lens_specifications.html"
+      },
+      {
+        "id": 677,
+        "name": "Nikon Nikkor PC-E 24 mm f/3.5D ED",
+        "url": "https://www.lenstip.com/677-Nikon_Nikkor_PC-E_24_mm_f_3.5D_ED-lens_specifications.html"
+      },
+      {
+        "id": 797,
+        "name": "Nikon Nikkor PC-E Micro 45 mm f/2.8D ED",
+        "url": "https://www.lenstip.com/797-Nikon_Nikkor_PC-E_Micro_45_mm_f_2.8D_ED_-lens_specifications.html"
+      },
+      {
+        "id": 798,
+        "name": "Nikon Nikkor PC-E Micro 85 mm f/2.8D",
+        "url": "https://www.lenstip.com/798-Nikon_Nikkor_PC-E_Micro_85_mm_f_2.8D_-lens_specifications.html"
+      },
+      {
+        "id": 858,
+        "name": "Nikon Nikkor S 5 cm f/2",
+        "url": "https://www.lenstip.com/858-Nikon_Nikkor_S_5_cm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 857,
+        "name": "Nikon Nikkor S 5.8 cm f/1.4",
+        "url": "https://www.lenstip.com/857-Nikon_Nikkor_S_5.8_cm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1897,
+        "name": "Nikon Nikkor Z 100-400 mm f/4.5-5.6 VR S",
+        "url": "https://www.lenstip.com/1897-Nikon_Nikkor_Z_100-400_mm_f_4.5-5.6_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 2080,
+        "name": "Nikon Nikkor Z 135 mm f/1.8 S Plena",
+        "url": "https://www.lenstip.com/2080-Nikon_Nikkor_Z_135_mm_f_1.8_S_Plena-lens_specifications.html"
+      },
+      {
+        "id": 1747,
+        "name": "Nikon Nikkor Z 14-24 mm f/2.8 S",
+        "url": "https://www.lenstip.com/1747-Nikon_Nikkor_Z_14-24_mm_f_2.8_S-lens_specifications.html"
+      },
+      {
+        "id": 1590,
+        "name": "Nikon Nikkor Z 14-30 mm f/4 S",
+        "url": "https://www.lenstip.com/1590-Nikon_Nikkor_Z_14-30_mm_f_4_S-lens_specifications.html"
+      },
+      {
+        "id": 1981,
+        "name": "Nikon Nikkor Z 17-28 mm f/2.8",
+        "url": "https://www.lenstip.com/1981-Nikon_Nikkor_Z_17-28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2060,
+        "name": "Nikon Nikkor Z 180-600 mm f/5.6-6.3 VR",
+        "url": "https://www.lenstip.com/2060-Nikon_Nikkor_Z_180-600_mm_f_5.6-6.3_VR-lens_specifications.html"
+      },
+      {
+        "id": 1678,
+        "name": "Nikon Nikkor Z 20 mm f/1.8 S",
+        "url": "https://www.lenstip.com/1678-Nikon_Nikkor_Z_20_mm_f_1.8_S-lens_specifications.html"
+      },
+      {
+        "id": 1646,
+        "name": "Nikon Nikkor Z 24 mm f/1.8 S",
+        "url": "https://www.lenstip.com/1646-Nikon_Nikkor_Z_24_mm_f_1.8_S-lens_specifications.html"
+      },
+      {
+        "id": 2295,
+        "name": "Nikon Nikkor Z 24-105 mm f/4-7.1",
+        "url": "https://www.lenstip.com/2295-Nikon_Nikkor_Z_24-105_mm_f_4-7.1-lens_specifications.html"
+      },
+      {
+        "id": 1896,
+        "name": "Nikon Nikkor Z 24-120 mm f/4 S",
+        "url": "https://www.lenstip.com/1896-Nikon_Nikkor_Z_24-120_mm_f_4_S-lens_specifications.html"
+      },
+      {
+        "id": 1679,
+        "name": "Nikon Nikkor Z 24-200 mm f/4-6.3 VR",
+        "url": "https://www.lenstip.com/1679-Nikon_Nikkor_Z_24-200_mm_f_4-6.3_VR-lens_specifications.html"
+      },
+      {
+        "id": 1720,
+        "name": "Nikon Nikkor Z 24-50 mm f/4-6.3",
+        "url": "https://www.lenstip.com/1720-Nikon_Nikkor_Z_24-50_mm_f_4-6.3-lens_specifications.html"
+      },
+      {
+        "id": 1597,
+        "name": "Nikon Nikkor Z 24-70 mm f/2.8 S",
+        "url": "https://www.lenstip.com/1597-Nikon_Nikkor_Z_24-70_mm_f_2.8_S-lens_specifications.html"
+      },
+      {
+        "id": 2256,
+        "name": "Nikon Nikkor Z 24-70 mm f/2.8 S II",
+        "url": "https://www.lenstip.com/2256-Nikon_Nikkor_Z_24-70_mm_f_2.8_S_II-lens_specifications.html"
+      },
+      {
+        "id": 1553,
+        "name": "Nikon Nikkor Z 24-70 mm f/4 S",
+        "url": "https://www.lenstip.com/1553-Nikon_Nikkor_Z_24-70_mm_f_4_S-lens_specifications.html"
+      },
+      {
+        "id": 2024,
+        "name": "Nikon Nikkor Z 26 mm f/2.8",
+        "url": "https://www.lenstip.com/2024-Nikon_Nikkor_Z_26_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1852,
+        "name": "Nikon Nikkor Z 28 mm f/2.8 (SE)",
+        "url": "https://www.lenstip.com/1852-Nikon_Nikkor_Z_28_mm_f_2.8_(SE)-lens_specifications.html"
+      },
+      {
+        "id": 2203,
+        "name": "Nikon Nikkor Z 28&#8209;135 mm f/4 PZ",
+        "url": "https://www.lenstip.com/2203-Nikon_Nikkor_Z_28&#8209;135_mm_f_4_PZ-lens_specifications.html"
+      },
+      {
+        "id": 2121,
+        "name": "Nikon Nikkor Z 28-400 mm f/4-8 VR",
+        "url": "https://www.lenstip.com/2121-Nikon_Nikkor_Z_28-400_mm_f_4-8_VR-lens_specifications.html"
+      },
+      {
+        "id": 1910,
+        "name": "Nikon Nikkor Z 28-75 mm f/2.8",
+        "url": "https://www.lenstip.com/1910-Nikon_Nikkor_Z_28-75_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2199,
+        "name": "Nikon Nikkor Z 35 mm f/1.2 S",
+        "url": "https://www.lenstip.com/2199-Nikon_Nikkor_Z_35_mm_f_1.2_S-lens_specifications.html"
+      },
+      {
+        "id": 2144,
+        "name": "Nikon Nikkor Z 35 mm f/1.4",
+        "url": "https://www.lenstip.com/2144-Nikon_Nikkor_Z_35_mm_f_1.4_-lens_specifications.html"
+      },
+      {
+        "id": 1555,
+        "name": "Nikon Nikkor Z 35 mm f/1.8 S",
+        "url": "https://www.lenstip.com/1555-Nikon_Nikkor_Z_35_mm_f_1.8_S-lens_specifications.html"
+      },
+      {
+        "id": 1877,
+        "name": "Nikon Nikkor Z 40 mm f/2.0",
+        "url": "https://www.lenstip.com/1877-Nikon_Nikkor_Z_40_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 1913,
+        "name": "Nikon Nikkor Z 400 mm f/2.8 TC VR S",
+        "url": "https://www.lenstip.com/1913-Nikon_Nikkor_Z_400_mm_f_2.8_TC_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 1955,
+        "name": "Nikon Nikkor Z 400 mm f/4.5 VR S",
+        "url": "https://www.lenstip.com/1955-Nikon_Nikkor_Z_400_mm_f_4.5_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 1746,
+        "name": "Nikon Nikkor Z 50 mm f/1.2 S",
+        "url": "https://www.lenstip.com/1746-Nikon_Nikkor_Z_50_mm_f_1.2_S-lens_specifications.html"
+      },
+      {
+        "id": 2164,
+        "name": "Nikon Nikkor Z 50 mm f/1.4",
+        "url": "https://www.lenstip.com/2164-Nikon_Nikkor_Z_50_mm_f_1.4_-lens_specifications.html"
+      },
+      {
+        "id": 1554,
+        "name": "Nikon Nikkor Z 50 mm f/1.8 S",
+        "url": "https://www.lenstip.com/1554-Nikon_Nikkor_Z_50_mm_f_1.8_S-lens_specifications.html"
+      },
+      {
+        "id": 1675,
+        "name": "Nikon Nikkor Z 58mm f/0.95 S Noct",
+        "url": "https://www.lenstip.com/1675-Nikon_Nikkor_Z_58mm_f_0.95_S_Noct-lens_specifications.html"
+      },
+      {
+        "id": 1996,
+        "name": "Nikon Nikkor Z 600 mm f/4 TC VR S",
+        "url": "https://www.lenstip.com/1996-Nikon_Nikkor_Z_600_mm_f_4_TC_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 2085,
+        "name": "Nikon Nikkor Z 600 mm f/6.3 VR S",
+        "url": "https://www.lenstip.com/2085-Nikon_Nikkor_Z_600_mm_f_6.3_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 2059,
+        "name": "Nikon Nikkor Z 70-180 mm f/2.8",
+        "url": "https://www.lenstip.com/2059-Nikon_Nikkor_Z_70-180_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1669,
+        "name": "Nikon Nikkor Z 70-200 mm f/2.8 VR S",
+        "url": "https://www.lenstip.com/1669-Nikon_Nikkor_Z_70-200_mm_f_2.8_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 2316,
+        "name": "Nikon Nikkor Z 70-200 mm f/2.8 VR S II",
+        "url": "https://www.lenstip.com/2316-Nikon_Nikkor_Z_70-200_mm_f_2.8_VR_S_II-lens_specifications.html"
+      },
+      {
+        "id": 1935,
+        "name": "Nikon Nikkor Z 800 mm f/6.3 VR S",
+        "url": "https://www.lenstip.com/1935-Nikon_Nikkor_Z_800_mm_f_6.3_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 2025,
+        "name": "Nikon Nikkor Z 85 mm f/1.2 S",
+        "url": "https://www.lenstip.com/2025-Nikon_Nikkor_Z_85_mm_f_1.2_S-lens_specifications.html"
+      },
+      {
+        "id": 1637,
+        "name": "Nikon Nikkor Z 85 mm f/1.8 S",
+        "url": "https://www.lenstip.com/1637-Nikon_Nikkor_Z_85_mm_f_1.8_S-lens_specifications.html"
+      },
+      {
+        "id": 2046,
+        "name": "Nikon Nikkor Z DX 12-28 mm f/3.5-5.6 PZ VR",
+        "url": "https://www.lenstip.com/2046-Nikon_Nikkor_Z_DX_12-28_mm_f_3.5-5.6_PZ_VR-lens_specifications.html"
+      },
+      {
+        "id": 2280,
+        "name": "Nikon Nikkor Z DX 16-50 mm f/2.8 VR",
+        "url": "https://www.lenstip.com/2280-Nikon_Nikkor_Z_DX_16-50_mm_f_2.8_VR-lens_specifications.html"
+      },
+      {
+        "id": 1650,
+        "name": "Nikon Nikkor Z DX 16-50 mm f/3.5-6.3 VR",
+        "url": "https://www.lenstip.com/1650-Nikon_Nikkor_Z_DX_16-50_mm_f_3.5-6.3_VR-lens_specifications.html"
+      },
+      {
+        "id": 1888,
+        "name": "Nikon Nikkor Z DX 18-140 mm f/3.5-6.3 VR",
+        "url": "https://www.lenstip.com/1888-Nikon_Nikkor_Z_DX_18-140_mm_f_3.5-6.3_VR-lens_specifications.html"
+      },
+      {
+        "id": 2056,
+        "name": "Nikon Nikkor Z DX 24 mm f/1.7",
+        "url": "https://www.lenstip.com/2056-Nikon_Nikkor_Z_DX_24_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 1651,
+        "name": "Nikon Nikkor Z DX 50-250 mm f/4.5-6.3 VR",
+        "url": "https://www.lenstip.com/1651-Nikon_Nikkor_Z_DX_50-250_mm_f_4.5-6.3_VR-lens_specifications.html"
+      },
+      {
+        "id": 2279,
+        "name": "Nikon Nikkor Z DX MC 35 mm f/1.7",
+        "url": "https://www.lenstip.com/2279-Nikon_Nikkor_Z_DX_MC_35_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 1849,
+        "name": "Nikon Nikkor Z MC 105 mm f/2.8 VR S",
+        "url": "https://www.lenstip.com/1849-Nikon_Nikkor_Z_MC_105_mm_f_2.8_VR_S-lens_specifications.html"
+      },
+      {
+        "id": 1848,
+        "name": "Nikon Nikkor Z MC 50 mm f/2.8",
+        "url": "https://www.lenstip.com/1848-Nikon_Nikkor_Z_MC_50_mm_f_2.8-lens_specifications.html"
+      }
+    ],
+    "Olympus": [
+      {
+        "id": 869,
+        "name": "Olympus F.Zuiko AUTO-S 50 mm f/1.8",
+        "url": "https://www.lenstip.com/869-Olympus_F.Zuiko_AUTO-S_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 994,
+        "name": "Olympus M.Zuiko Digital 12 mm f/2.0 ED",
+        "url": "https://www.lenstip.com/994-Olympus_M.Zuiko_Digital_12_mm_f_2.0_ED-lens_specifications.html"
+      },
+      {
+        "id": 1146,
+        "name": "Olympus M.Zuiko Digital 12-40 mm f/2.8 ED PRO",
+        "url": "https://www.lenstip.com/1146-Olympus_M.Zuiko_Digital_12-40_mm_f_2.8_ED_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1015,
+        "name": "Olympus M.Zuiko Digital 12-50 mm f/3.5-6.3 ED EZ",
+        "url": "https://www.lenstip.com/1015-Olympus_M.Zuiko_Digital_12-50_mm_f_3.5-6.3_ED_EZ-lens_specifications.html"
+      },
+      {
+        "id": 894,
+        "name": "Olympus M.Zuiko Digital 14-150 mm f/4.0-5.6 ED",
+        "url": "https://www.lenstip.com/894-Olympus_M.Zuiko_Digital_14-150_mm_f_4.0-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 1269,
+        "name": "Olympus M.Zuiko Digital 14-150 mm f/4.0-5.6 ED II",
+        "url": "https://www.lenstip.com/1269-Olympus_M.Zuiko_Digital_14-150_mm_f_4.0-5.6_ED_II-lens_specifications.html"
+      },
+      {
+        "id": 867,
+        "name": "Olympus M.Zuiko Digital 14-42 mm f/3.5-5.6 ED",
+        "url": "https://www.lenstip.com/867-Olympus_M.Zuiko_Digital_14-42_mm_f_3.5-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 1176,
+        "name": "Olympus M.Zuiko Digital 14-42 mm f/3.5-5.6 ED EZ",
+        "url": "https://www.lenstip.com/1176-Olympus_M.Zuiko_Digital_14-42_mm_f_3.5-5.6_ED_EZ_-lens_specifications.html"
+      },
+      {
+        "id": 966,
+        "name": "Olympus M.Zuiko Digital 14-42 mm f/3.5-5.6 II",
+        "url": "https://www.lenstip.com/966-Olympus_M.Zuiko_Digital_14-42_mm_f_3.5-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 1009,
+        "name": "Olympus M.Zuiko Digital 14-42 mm f/3.5-5.6 II R",
+        "url": "https://www.lenstip.com/1009-Olympus_M.Zuiko_Digital_14-42_mm_f_3.5-5.6_II_R-lens_specifications.html"
+      },
+      {
+        "id": 1092,
+        "name": "Olympus M.Zuiko Digital 17 mm f/1.8",
+        "url": "https://www.lenstip.com/1092-Olympus_M.Zuiko_Digital_17_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 868,
+        "name": "Olympus M.Zuiko Digital 17 mm f/2.8",
+        "url": "https://www.lenstip.com/868-Olympus_M.Zuiko_Digital_17_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1175,
+        "name": "Olympus M.Zuiko Digital 25 mm f/1.8",
+        "url": "https://www.lenstip.com/1175-Olympus_M.Zuiko_Digital_25_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1338,
+        "name": "Olympus M.Zuiko Digital 300 mm f/4.0 ED IS PRO",
+        "url": "https://www.lenstip.com/1338-Olympus_M.Zuiko_Digital_300_mm_f_4.0_ED_IS_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1147,
+        "name": "Olympus M.Zuiko Digital 40-150 mm f/2.8 ED PRO",
+        "url": "https://www.lenstip.com/1147-Olympus_M.Zuiko_Digital_40-150_mm_f_2.8_ED_PRO-lens_specifications.html"
+      },
+      {
+        "id": 948,
+        "name": "Olympus M.Zuiko Digital 40-150 mm f/4.0-5.6 ED",
+        "url": "https://www.lenstip.com/948-Olympus_M.Zuiko_Digital_40-150_mm_f_4.0-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 1010,
+        "name": "Olympus M.Zuiko Digital 40-150 mm f/4.0-5.6 ED R",
+        "url": "https://www.lenstip.com/1010-Olympus_M.Zuiko_Digital_40-150_mm_f_4.0-5.6_ED_R-lens_specifications.html"
+      },
+      {
+        "id": 993,
+        "name": "Olympus M.Zuiko Digital 45 mm f/1.8",
+        "url": "https://www.lenstip.com/993-Olympus_M.Zuiko_Digital_45_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1028,
+        "name": "Olympus M.Zuiko Digital 60 mm f/2.8 ED Macro",
+        "url": "https://www.lenstip.com/1028-Olympus_M.Zuiko_Digital_60_mm_f_2.8_ED_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1182,
+        "name": "Olympus M.Zuiko Digital 7-14 mm f/2.8 ED PRO",
+        "url": "https://www.lenstip.com/1182-Olympus_M.Zuiko_Digital_7-14_mm_f_2.8_ED_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1027,
+        "name": "Olympus M.Zuiko Digital 75 mm f/1.8 ED",
+        "url": "https://www.lenstip.com/1027-Olympus_M.Zuiko_Digital_75_mm_f_1.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 949,
+        "name": "Olympus M.Zuiko Digital 75-300 mm f/4.8-6.7 ED",
+        "url": "https://www.lenstip.com/949-Olympus_M.Zuiko_Digital_75-300_mm_f_4.8-6.7_ED-lens_specifications.html"
+      },
+      {
+        "id": 1099,
+        "name": "Olympus M.Zuiko Digital 75-300 mm f/4.8-6.7 ED II",
+        "url": "https://www.lenstip.com/1099-Olympus_M.Zuiko_Digital_75-300_mm_f_4.8-6.7_ED_II-lens_specifications.html"
+      },
+      {
+        "id": 1303,
+        "name": "Olympus M.Zuiko Digital 8 mm f/1.8 ED PRO Fisheye",
+        "url": "https://www.lenstip.com/1303-Olympus_M.Zuiko_Digital_8_mm_f_1.8_ED_PRO_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1177,
+        "name": "Olympus M.Zuiko Digital 9 mm f/8.0 Fisheye",
+        "url": "https://www.lenstip.com/1177-Olympus_M.Zuiko_Digital_9_mm_f_8.0_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 893,
+        "name": "Olympus M.Zuiko Digital 9-18 mm f/4.0-5.6 ED",
+        "url": "https://www.lenstip.com/893-Olympus_M.Zuiko_Digital_9-18_mm_f_4.0-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 1721,
+        "name": "Olympus M.Zuiko Digital ED 100-400 mm f/5.0-6.3 IS",
+        "url": "https://www.lenstip.com/1721-Olympus_M.Zuiko_Digital_ED_100-400_mm_f_5.0-6.3_IS-lens_specifications.html"
+      },
+      {
+        "id": 1397,
+        "name": "Olympus M.Zuiko Digital ED 12-100 mm f/4 IS PRO",
+        "url": "https://www.lenstip.com/1397-Olympus_M.Zuiko_Digital_ED_12-100_mm_f_4_IS_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1596,
+        "name": "Olympus M.Zuiko Digital ED 12-200 mm f/3.5-6.3",
+        "url": "https://www.lenstip.com/1596-Olympus_M.Zuiko_Digital_ED_12-200_mm_f_3.5-6.3-lens_specifications.html"
+      },
+      {
+        "id": 1676,
+        "name": "Olympus M.Zuiko Digital ED 12-45 mm f/4.0 PRO",
+        "url": "https://www.lenstip.com/1676-Olympus_M.Zuiko_Digital_ED_12-45_mm_f_4.0_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1770,
+        "name": "Olympus M.Zuiko Digital ED 150-400 mm f/4.5 TC1.25x IS PRO",
+        "url": "https://www.lenstip.com/1770-Olympus_M.Zuiko_Digital_ED_150-400_mm_f_4.5_TC1.25x_IS_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1492,
+        "name": "Olympus M.Zuiko Digital ED 17 mm f/1.2 PRO",
+        "url": "https://www.lenstip.com/1492-Olympus_M.Zuiko_Digital_ED_17_mm_f_1.2_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1399,
+        "name": "Olympus M.Zuiko Digital ED 25 mm f/1.2 PRO",
+        "url": "https://www.lenstip.com/1399-Olympus_M.Zuiko_Digital_ED_25_mm_f_1.2_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1398,
+        "name": "Olympus M.Zuiko Digital ED 30 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/1398-Olympus_M.Zuiko_Digital_ED_30_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1493,
+        "name": "Olympus M.Zuiko Digital ED 45 mm f/1.2 PRO",
+        "url": "https://www.lenstip.com/1493-Olympus_M.Zuiko_Digital_ED_45_mm_f_1.2_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1850,
+        "name": "Olympus M.Zuiko Digital ED 8-25 mm f/4 PRO",
+        "url": "https://www.lenstip.com/1850-Olympus_M.Zuiko_Digital_ED_8-25_mm_f_4_PRO-lens_specifications.html"
+      },
+      {
+        "id": 1079,
+        "name": "Olympus Obiektyw-zaпїЅlepka bagnetu 15 mm f/8",
+        "url": "https://www.lenstip.com/1079-Olympus_Obiektyw-za&#347;lepka_bagnetu_15_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 61,
+        "name": "Olympus Zuiko Digital 11-22 mm f/2.8-3.5",
+        "url": "https://www.lenstip.com/61-Olympus_Zuiko_Digital_11-22_mm_f_2.8-3.5-lens_specifications.html"
+      },
+      {
+        "id": 129,
+        "name": "Olympus Zuiko Digital 14-45 mm f/3.5-5.6 EZ",
+        "url": "https://www.lenstip.com/129-Olympus_Zuiko_Digital_14-45_mm_f_3.5-5.6_EZ-lens_specifications.html"
+      },
+      {
+        "id": 130,
+        "name": "Olympus Zuiko Digital 14-54 mm f/2.8-3.5",
+        "url": "https://www.lenstip.com/130-Olympus_Zuiko_Digital_14-54_mm_f_2.8-3.5-lens_specifications.html"
+      },
+      {
+        "id": 831,
+        "name": "Olympus Zuiko Digital 14-54 mm f/2.8-3.5 II",
+        "url": "https://www.lenstip.com/831-Olympus_Zuiko_Digital_14-54_mm_f_2.8-3.5_II-lens_specifications.html"
+      },
+      {
+        "id": 131,
+        "name": "Olympus Zuiko Digital 150 mm f/2",
+        "url": "https://www.lenstip.com/131-Olympus_Zuiko_Digital_150_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 854,
+        "name": "Olympus Zuiko Digital 17.5-45 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/854-Olympus_Zuiko_Digital_17.5-45_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 132,
+        "name": "Olympus Zuiko Digital 18-180 mm f/3.5-6.3 ED",
+        "url": "https://www.lenstip.com/132-Olympus_Zuiko_Digital_18-180_mm_f_3.5-6.3_ED-lens_specifications.html"
+      },
+      {
+        "id": 687,
+        "name": "Olympus Zuiko Digital 25 mm f/2.8",
+        "url": "https://www.lenstip.com/687-Olympus_Zuiko_Digital_25_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 133,
+        "name": "Olympus Zuiko Digital 300 mm f/2.8 ED",
+        "url": "https://www.lenstip.com/133-Olympus_Zuiko_Digital_300_mm_f_2.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 134,
+        "name": "Olympus Zuiko Digital 35 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/134-Olympus_Zuiko_Digital_35_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 135,
+        "name": "Olympus Zuiko Digital 35-100 mm f/2.0",
+        "url": "https://www.lenstip.com/135-Olympus_Zuiko_Digital_35-100_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 136,
+        "name": "Olympus Zuiko Digital 40-150 mm f/3.5-4.5 EZ",
+        "url": "https://www.lenstip.com/136-Olympus_Zuiko_Digital_40-150_mm_f_3.5-4.5_EZ-lens_specifications.html"
+      },
+      {
+        "id": 1210,
+        "name": "Olympus Zuiko Digital 40-150 mm f/4.0-5.6 ED",
+        "url": "https://www.lenstip.com/1210-Olympus_Zuiko_Digital_40-150_mm_f_4.0-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 137,
+        "name": "Olympus Zuiko Digital 50 mm f/2.0 Macro ED",
+        "url": "https://www.lenstip.com/137-Olympus_Zuiko_Digital_50_mm_f_2.0_Macro_ED-lens_specifications.html"
+      },
+      {
+        "id": 138,
+        "name": "Olympus Zuiko Digital 50-200 mm f/2.8-3.5 ED",
+        "url": "https://www.lenstip.com/138-Olympus_Zuiko_Digital_50-200_mm_f_2.8-3.5_ED-lens_specifications.html"
+      },
+      {
+        "id": 139,
+        "name": "Olympus Zuiko Digital 7-14 mm f/4.0 ED",
+        "url": "https://www.lenstip.com/139-Olympus_Zuiko_Digital_7-14_mm_f_4.0_ED-lens_specifications.html"
+      },
+      {
+        "id": 140,
+        "name": "Olympus Zuiko Digital 8 mm f/3.5 ED Fish-Eye",
+        "url": "https://www.lenstip.com/140-Olympus_Zuiko_Digital_8_mm_f_3.5_ED_Fish-Eye-lens_specifications.html"
+      },
+      {
+        "id": 658,
+        "name": "Olympus Zuiko Digital 9-18 mm f/4-5.6 ED",
+        "url": "https://www.lenstip.com/658-Olympus_Zuiko_Digital_9-18_mm_f_4-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 141,
+        "name": "Olympus Zuiko Digital 90-250 mm f/2.8 ED",
+        "url": "https://www.lenstip.com/141-Olympus_Zuiko_Digital_90-250_mm_f_2.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 656,
+        "name": "Olympus Zuiko Digital ED 12-60 mm f/2.8-4.0 SWD",
+        "url": "https://www.lenstip.com/656-Olympus_Zuiko_Digital_ED_12-60_mm_f_2.8-4.0_SWD-lens_specifications.html"
+      },
+      {
+        "id": 659,
+        "name": "Olympus Zuiko Digital ED 14-35 mm f/2.0 SWD",
+        "url": "https://www.lenstip.com/659-Olympus_Zuiko_Digital_ED_14-35_mm_f_2.0_SWD-lens_specifications.html"
+      },
+      {
+        "id": 649,
+        "name": "Olympus Zuiko Digital ED 14-42 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/649-Olympus_Zuiko_Digital_ED_14-42_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 657,
+        "name": "Olympus Zuiko Digital ED 50-200 mm f/2.8-3.5 SWD",
+        "url": "https://www.lenstip.com/657-Olympus_Zuiko_Digital_ED_50-200_mm_f_2.8-3.5_SWD-lens_specifications.html"
+      },
+      {
+        "id": 632,
+        "name": "Olympus Zuiko Digital ED 70-300 mm f/4.0-5.6",
+        "url": "https://www.lenstip.com/632-Olympus_Zuiko_Digital_ED_70-300_mm_f_4.0-5.6-lens_specifications.html"
+      }
+    ],
+    "OM System": [
+      {
+        "id": 2200,
+        "name": "OM System M.Zuiko Digital 17 mm f/1.8 II",
+        "url": "https://www.lenstip.com/2200-OM_System_M.Zuiko_Digital_17_mm_f_1.8_II-lens_specifications.html"
+      },
+      {
+        "id": 1899,
+        "name": "OM System M.Zuiko Digital 20 mm f/1.4 PRO",
+        "url": "https://www.lenstip.com/1899-OM_System_M.Zuiko_Digital_20_mm_f_1.4_PRO-lens_specifications.html"
+      },
+      {
+        "id": 2201,
+        "name": "OM System M.Zuiko Digital 25 mm f/1.8 II",
+        "url": "https://www.lenstip.com/2201-OM_System_M.Zuiko_Digital_25_mm_f_1.8_II-lens_specifications.html"
+      },
+      {
+        "id": 2202,
+        "name": "OM System M.Zuiko Digital ED 100-400 mm f/5.0-6.3 IS II",
+        "url": "https://www.lenstip.com/2202-OM_System_M.Zuiko_Digital_ED_100-400_mm_f_5.0-6.3_IS_II-lens_specifications.html"
+      },
+      {
+        "id": 1917,
+        "name": "OM System M.Zuiko Digital ED 12-40 mm f/2.8 PRO II",
+        "url": "https://www.lenstip.com/1917-OM_System_M.Zuiko_Digital_ED_12-40_mm_f_2.8_PRO_II-lens_specifications.html"
+      },
+      {
+        "id": 2111,
+        "name": "OM System M.Zuiko Digital ED 150-600 mm f/5.0-6.3 IS",
+        "url": "https://www.lenstip.com/2111-OM_System_M.Zuiko_Digital_ED_150-600_mm_f_5.0-6.3_IS-lens_specifications.html"
+      },
+      {
+        "id": 1918,
+        "name": "OM System M.Zuiko Digital ED 40-150 mm f/4.0 PRO",
+        "url": "https://www.lenstip.com/1918-OM_System_M.Zuiko_Digital_ED_40-150_mm_f_4.0_PRO-lens_specifications.html"
+      },
+      {
+        "id": 2264,
+        "name": "OM System M.Zuiko Digital ED 50-200 mm f/2.8 IS PRO",
+        "url": "https://www.lenstip.com/2264-OM_System_M.Zuiko_Digital_ED_50-200_mm_f_2.8_IS_PRO-lens_specifications.html"
+      },
+      {
+        "id": 2112,
+        "name": "OM System M.Zuiko Digital ED 9-18 mm f/4.0-5.6 II",
+        "url": "https://www.lenstip.com/2112-OM_System_M.Zuiko_Digital_ED_9-18_mm_f_4.0-5.6_II-lens_specifications.html"
+      },
+      {
+        "id": 2021,
+        "name": "OM System M.Zuiko Digital ED 90 mm f/3.5 Macro IS PRO",
+        "url": "https://www.lenstip.com/2021-OM_System_M.Zuiko_Digital_ED_90_mm_f_3.5_Macro_IS_PRO-lens_specifications.html"
+      }
+    ],
+    "Panasonic": [
+      {
+        "id": 965,
+        "name": "Panasonic G 12.5 mm f/12",
+        "url": "https://www.lenstip.com/965-Panasonic_G_12.5_mm_f_12-lens_specifications.html"
+      },
+      {
+        "id": 956,
+        "name": "Panasonic G 14 mm f/2.5 ASPH.",
+        "url": "https://www.lenstip.com/956-Panasonic_G_14_mm_f_2.5_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1237,
+        "name": "Panasonic G 14 mm f/2.5 II ASPH",
+        "url": "https://www.lenstip.com/1237-Panasonic_G_14_mm_f_2.5_II_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 882,
+        "name": "Panasonic G 20 mm f/1.7 ASPH.",
+        "url": "https://www.lenstip.com/882-Panasonic_G_20_mm_f_1.7_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1130,
+        "name": "Panasonic G 20 mm f/1.7 II ASPH.",
+        "url": "https://www.lenstip.com/1130-Panasonic_G_20_mm_f_1.7_II_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1277,
+        "name": "Panasonic G 42.5 mm f/1.7 ASPH. POWER O.I.S.",
+        "url": "https://www.lenstip.com/1277-Panasonic_G_42.5_mm_f_1.7_ASPH._POWER_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 926,
+        "name": "Panasonic G FISHEYE 8 mm f/3.5",
+        "url": "https://www.lenstip.com/926-Panasonic_G_FISHEYE_8_mm_f_3.5_-lens_specifications.html"
+      },
+      {
+        "id": 1276,
+        "name": "Panasonic G Macro 30 mm f/2.8 ASPH. MEGA O.I.S.",
+        "url": "https://www.lenstip.com/1276-Panasonic_G_Macro_30_mm_f_2.8_ASPH._MEGA_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 964,
+        "name": "Panasonic G VARIO 100-300 mm f/4.0-5.6 M.O.I.S",
+        "url": "https://www.lenstip.com/964-Panasonic_G_VARIO_100-300_mm_f_4.0-5.6_M.O.I.S-lens_specifications.html"
+      },
+      {
+        "id": 1161,
+        "name": "Panasonic G VARIO 12-32 mm f/3.5-5.6 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/1161-Panasonic_G_VARIO_12-32_mm_f_3.5-5.6_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1119,
+        "name": "Panasonic G VARIO 14-140 mm f/3.5-5.6 ASPH. P.O.I.S.",
+        "url": "https://www.lenstip.com/1119-Panasonic_G_VARIO_14-140_mm_f_3.5-5.6_ASPH._P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1612,
+        "name": "Panasonic G VARIO 14-140 mm f/3.5-5.6 II ASPH. P.O.I.S.",
+        "url": "https://www.lenstip.com/1612-Panasonic_G_VARIO_14-140_mm_f_3.5-5.6_II_ASPH._P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 850,
+        "name": "Panasonic G VARIO 14-140 mm f/4.0-5.8 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/850-Panasonic_G_VARIO_14-140_mm_f_4.0-5.8_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 915,
+        "name": "Panasonic G VARIO 14-42 mm f/3.5-5.6 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/915-Panasonic_G_VARIO_14-42_mm_f_3.5-5.6_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1101,
+        "name": "Panasonic G VARIO 14-42 mm f/3.5-5.6 II ASPH. M.O.I.S",
+        "url": "https://www.lenstip.com/1101-Panasonic_G_VARIO_14-42_mm_f_3.5-5.6_II_ASPH._M.O.I.S-lens_specifications.html"
+      },
+      {
+        "id": 808,
+        "name": "Panasonic G VARIO 14-45 mm f/3.5-5.6 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/808-Panasonic_G_VARIO_14-45_mm_f_3.5-5.6_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1236,
+        "name": "Panasonic G VARIO 35-100 mm f/4.0-5.6 ASPH",
+        "url": "https://www.lenstip.com/1236-Panasonic_G_VARIO_35-100_mm_f_4.0-5.6_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1057,
+        "name": "Panasonic G VARIO 45-150 mm f/4.0-5.6 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/1057-Panasonic_G_VARIO_45-150_mm_f_4.0-5.6_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 807,
+        "name": "Panasonic G VARIO 45-200 mm f/4-5.6 M.O.I.S.",
+        "url": "https://www.lenstip.com/807-Panasonic_G_VARIO_45-200_mm_f_4-5.6_M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 851,
+        "name": "Panasonic G VARIO 7-14 mm f/4.0 ASPH.",
+        "url": "https://www.lenstip.com/851-Panasonic_G_VARIO_7-14_mm_f_4.0_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1047,
+        "name": "Panasonic G X VARIO 12-35 mm f/2.8 ASPH. P.O.I.S",
+        "url": "https://www.lenstip.com/1047-Panasonic_G_X_VARIO_12-35_mm_f_2.8_ASPH._P.O.I.S-lens_specifications.html"
+      },
+      {
+        "id": 1081,
+        "name": "Panasonic G X VARIO 35-100 mm f/2.8 P.O.I.S.",
+        "url": "https://www.lenstip.com/1081-Panasonic_G_X_VARIO_35-100_mm_f_2.8_P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1001,
+        "name": "Panasonic G X VARIO PZ 14-42 mm f/3.5-5.6 ASPH. P.O.I.S.",
+        "url": "https://www.lenstip.com/1001-Panasonic_G_X_VARIO_PZ_14-42_mm_f_3.5-5.6_ASPH._P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1002,
+        "name": "Panasonic G X VARIO PZ 45-175 mm f/4.0-5.6 ASPH. P.O.I.S.",
+        "url": "https://www.lenstip.com/1002-Panasonic_G_X_VARIO_PZ_45-175_mm_f_4.0-5.6_ASPH._P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1494,
+        "name": "Panasonic Leica DG Elmarit 200 mm f/2.8 POWER O.I.S.",
+        "url": "https://www.lenstip.com/1494-Panasonic_Leica_DG_Elmarit_200_mm_f_2.8_POWER_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 881,
+        "name": "Panasonic Leica DG Macro-Elmarit 45 mm f/2.8 ASPH. M.O.I.S.",
+        "url": "https://www.lenstip.com/881-Panasonic_Leica_DG_Macro-Elmarit_45_mm_f_2.8_ASPH._M.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1132,
+        "name": "Panasonic Leica DG Nocticron 42.5 mm f/1.2 Asph. P.O.I.S.",
+        "url": "https://www.lenstip.com/1132-Panasonic_Leica_DG_Nocticron_42.5_mm_f_1.2_Asph._P.O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1365,
+        "name": "Panasonic Leica DG Summilux 12 mm f/1.4 ASPH",
+        "url": "https://www.lenstip.com/1365-Panasonic_Leica_DG_Summilux_12_mm_f_1.4_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1209,
+        "name": "Panasonic Leica DG Summilux 15 mm f/1.7 ASPH",
+        "url": "https://www.lenstip.com/1209-Panasonic_Leica_DG_Summilux_15_mm_f_1.7_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 984,
+        "name": "Panasonic Leica DG Summilux 25 mm f/1.4 ASPH.",
+        "url": "https://www.lenstip.com/984-Panasonic_Leica_DG_Summilux_25_mm_f_1.4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1641,
+        "name": "Panasonic Leica DG Summilux 25 mm f/1.4 II ASPH",
+        "url": "https://www.lenstip.com/1641-Panasonic_Leica_DG_Summilux_25_mm_f_1.4_II_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1944,
+        "name": "Panasonic Leica DG Summilux 9 mm f/1.7 ASPH",
+        "url": "https://www.lenstip.com/1944-Panasonic_Leica_DG_Summilux_9_mm_f_1.7_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2073,
+        "name": "Panasonic Leica DG Vario-Elmar 100-400 mm f/4-6.3 II ASPH. Power O.I.S.",
+        "url": "https://www.lenstip.com/2073-Panasonic_Leica_DG_Vario-Elmar_100-400_mm_f_4-6.3_II_ASPH._Power_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1337,
+        "name": "Panasonic Leica DG Vario-Elmar 100-400 mm f/4.0-6.3 ASPH. POWER O.I.S.",
+        "url": "https://www.lenstip.com/1337-Panasonic_Leica_DG_Vario-Elmar_100-400_mm_f_4.0-6.3_ASPH._POWER_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 2011,
+        "name": "Panasonic Leica DG Vario-Elmarit 12-35 mm f/2.8 ASPH. Power O.I.S.",
+        "url": "https://www.lenstip.com/2011-Panasonic_Leica_DG_Vario-Elmarit_12-35_mm_f_2.8_ASPH._Power_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1429,
+        "name": "Panasonic Leica DG Vario-Elmarit 12-60 mm f/2.8-4 ASPH. POWER O.I.S.",
+        "url": "https://www.lenstip.com/1429-Panasonic_Leica_DG_Vario-Elmarit_12-60_mm_f_2.8-4_ASPH._POWER_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 2072,
+        "name": "Panasonic Leica DG Vario-Elmarit 35-100 mm f/2.8 Power O.I.S.",
+        "url": "https://www.lenstip.com/2072-Panasonic_Leica_DG_Vario-Elmarit_35-100_mm_f_2.8_Power_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1519,
+        "name": "Panasonic Leica DG Vario-Elmarit 50-200 mm f/2.8-4 ASPH.",
+        "url": "https://www.lenstip.com/1519-Panasonic_Leica_DG_Vario-Elmarit_50-200_mm_f_2.8-4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1461,
+        "name": "Panasonic Leica DG Vario-Elmarit 8-18 mm f/2.8-4 ASPH.",
+        "url": "https://www.lenstip.com/1461-Panasonic_Leica_DG_Vario-Elmarit_8-18_mm_f_2.8-4_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1623,
+        "name": "Panasonic Leica DG Vario-Summilux 10-25 mm f/1.7 ASPH",
+        "url": "https://www.lenstip.com/1623-Panasonic_Leica_DG_Vario-Summilux_10-25_mm_f_1.7_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1854,
+        "name": "Panasonic Leica DG Vario-Summilux 25-50 mm f/1.7 ASPH",
+        "url": "https://www.lenstip.com/1854-Panasonic_Leica_DG_Vario-Summilux_25-50_mm_f_1.7_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1356,
+        "name": "Panasonic Lumix G 12-60 mm f/3.5-5.6 ASPH. POWER O.I.S.",
+        "url": "https://www.lenstip.com/1356-Panasonic_Lumix_G_12-60_mm_f_3.5-5.6_ASPH._POWER_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1339,
+        "name": "Panasonic Lumix G 25 mm f/1.7 ASPH.",
+        "url": "https://www.lenstip.com/1339-Panasonic_Lumix_G_25_mm_f_1.7_ASPH.-lens_specifications.html"
+      },
+      {
+        "id": 1431,
+        "name": "Panasonic Lumix G VARIO 100-300 mm f/4.0-5.6 II POWER O.I.S.",
+        "url": "https://www.lenstip.com/1431-Panasonic_Lumix_G_VARIO_100-300_mm_f_4.0-5.6_II_POWER_O.I.S._-lens_specifications.html"
+      },
+      {
+        "id": 1432,
+        "name": "Panasonic Lumix G VARIO 45-200 mm f/4.0-5.6 II POWER O.I.S.",
+        "url": "https://www.lenstip.com/1432-Panasonic_Lumix_G_VARIO_45-200_mm_f_4.0-5.6_II_POWER_O.I.S._-lens_specifications.html"
+      },
+      {
+        "id": 1430,
+        "name": "Panasonic Lumix G X VARIO 12-35 mm f/2.8 II ASPH. POWER O.I.S.",
+        "url": "https://www.lenstip.com/1430-Panasonic_Lumix_G_X_VARIO_12-35_mm_f_2.8_II_ASPH._POWER_O.I.S._-lens_specifications.html"
+      },
+      {
+        "id": 1433,
+        "name": "Panasonic Lumix G X VARIO 35-100 mm f/2.8 II POWER O.I.S.",
+        "url": "https://www.lenstip.com/1433-Panasonic_Lumix_G_X_VARIO_35-100_mm_f_2.8_II_POWER_O.I.S._-lens_specifications.html"
+      },
+      {
+        "id": 2106,
+        "name": "Panasonic Lumix S 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/2106-Panasonic_Lumix_S_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2271,
+        "name": "Panasonic Lumix S 100-500 mm f/5-7.1 O.I.S.",
+        "url": "https://www.lenstip.com/2271-Panasonic_Lumix_S_100-500_mm_f_5-7.1_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 2016,
+        "name": "Panasonic Lumix S 14-28 mm f/4-5.6 Macro",
+        "url": "https://www.lenstip.com/2016-Panasonic_Lumix_S_14-28_mm_f_4-5.6_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1975,
+        "name": "Panasonic Lumix S 18 mm f/1.8",
+        "url": "https://www.lenstip.com/1975-Panasonic_Lumix_S_18_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2174,
+        "name": "Panasonic Lumix S 18-40 mm f/4.5-6.3",
+        "url": "https://www.lenstip.com/2174-Panasonic_Lumix_S_18-40_mm_f_4.5-6.3-lens_specifications.html"
+      },
+      {
+        "id": 1699,
+        "name": "Panasonic Lumix S 20-60 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/1699-Panasonic_Lumix_S_20-60_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1866,
+        "name": "Panasonic Lumix S 24 mm f/1.8",
+        "url": "https://www.lenstip.com/1866-Panasonic_Lumix_S_24_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1595,
+        "name": "Panasonic Lumix S 24-105 mm f/4 MACRO O.I.S.",
+        "url": "https://www.lenstip.com/1595-Panasonic_Lumix_S_24-105_mm_f_4_MACRO_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 2229,
+        "name": "Panasonic Lumix S 24-60 mm f/2.8",
+        "url": "https://www.lenstip.com/2229-Panasonic_Lumix_S_24-60_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2134,
+        "name": "Panasonic Lumix S 26 mm f/8",
+        "url": "https://www.lenstip.com/2134-Panasonic_Lumix_S_26_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 2116,
+        "name": "Panasonic Lumix S 28-200 mm f/4-7.1 Macro",
+        "url": "https://www.lenstip.com/2116-Panasonic_Lumix_S_28-200_mm_f_4-7.1_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1901,
+        "name": "Panasonic Lumix S 35 mm f/1.8",
+        "url": "https://www.lenstip.com/1901-Panasonic_Lumix_S_35_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2328,
+        "name": "Panasonic Lumix S 40 mm f/2",
+        "url": "https://www.lenstip.com/2328-Panasonic_Lumix_S_40_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1847,
+        "name": "Panasonic Lumix S 50 mm f/1.8",
+        "url": "https://www.lenstip.com/1847-Panasonic_Lumix_S_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1810,
+        "name": "Panasonic Lumix S 70-300 mm f/4.5-5.6 Macro O.I.S.",
+        "url": "https://www.lenstip.com/1810-Panasonic_Lumix_S_70-300_mm_f_4.5-5.6_Macro_O.I.S.-lens_specifications.html"
+      },
+      {
+        "id": 1766,
+        "name": "Panasonic Lumix S 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1766-Panasonic_Lumix_S_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1662,
+        "name": "Panasonic Lumix S Pro 16-35 mm f/4",
+        "url": "https://www.lenstip.com/1662-Panasonic_Lumix_S_Pro_16-35_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1642,
+        "name": "Panasonic Lumix S Pro 24-70 mm f/2.8",
+        "url": "https://www.lenstip.com/1642-Panasonic_Lumix_S_Pro_24-70_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1593,
+        "name": "Panasonic Lumix S Pro 50 mm f/1.4",
+        "url": "https://www.lenstip.com/1593-Panasonic_Lumix_S_Pro_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1663,
+        "name": "Panasonic Lumix S Pro 70-200 mm f/2.8",
+        "url": "https://www.lenstip.com/1663-Panasonic_Lumix_S_Pro_70-200_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1594,
+        "name": "Panasonic Lumix S Pro 70-200 mm f/4 O.I.S.",
+        "url": "https://www.lenstip.com/1594-Panasonic_Lumix_S_Pro_70-200_mm_f_4_O.I.S.-lens_specifications.html"
+      }
+    ],
+    "Pentax": [
+      {
+        "id": 1350,
+        "name": "Pentax D HD FA 15-30 mm f/2.8ED SDM WR",
+        "url": "https://www.lenstip.com/1350-Pentax_D_HD_FA_15-30_mm_f_2.8ED_SDM_WR_-lens_specifications.html"
+      },
+      {
+        "id": 1267,
+        "name": "Pentax D HD FA 150-450 mm f/4.5-5.6 ED DC AW",
+        "url": "https://www.lenstip.com/1267-Pentax_D_HD_FA_150-450_mm_f_4.5-5.6_ED_DC_AW-lens_specifications.html"
+      },
+      {
+        "id": 1889,
+        "name": "Pentax D HD FA 21 mm f/2.4 ED Limited DC WR",
+        "url": "https://www.lenstip.com/1889-Pentax_D_HD_FA_21_mm_f_2.4_ED_Limited_DC_WR-lens_specifications.html"
+      },
+      {
+        "id": 1321,
+        "name": "Pentax D HD FA 24-70 mm f/2.8ED SDM WR",
+        "url": "https://www.lenstip.com/1321-Pentax_D_HD_FA_24-70_mm_f_2.8ED_SDM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1351,
+        "name": "Pentax D HD FA 28-105 mm f/3.5-5.6ED DC WR",
+        "url": "https://www.lenstip.com/1351-Pentax_D_HD_FA_28-105_mm_f_3.5-5.6ED_DC_WR_-lens_specifications.html"
+      },
+      {
+        "id": 1504,
+        "name": "Pentax D HD FA 50 mm f/1.4 SDM AW",
+        "url": "https://www.lenstip.com/1504-Pentax_D_HD_FA_50_mm_f_1.4_SDM_AW-lens_specifications.html"
+      },
+      {
+        "id": 1268,
+        "name": "Pentax D HD FA 70-200 mm f/2.8 ED DC AW",
+        "url": "https://www.lenstip.com/1268-Pentax_D_HD_FA_70-200_mm_f_2.8_ED_DC_AW-lens_specifications.html"
+      },
+      {
+        "id": 1988,
+        "name": "Pentax D HD FA Macro 100 mm f/2.8 ED AW",
+        "url": "https://www.lenstip.com/1988-Pentax_D_HD_FA_Macro_100_mm_f_2.8_ED_AW-lens_specifications.html"
+      },
+      {
+        "id": 1629,
+        "name": "Pentax HD DA 10-17 mm f/3.5-4.5 ED Fish Eye",
+        "url": "https://www.lenstip.com/1629-Pentax_HD_DA_10-17_mm_f_3.5-4.5_ED_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 1505,
+        "name": "Pentax HD DA 11-18 mm f/2.8 ED DC AW",
+        "url": "https://www.lenstip.com/1505-Pentax_HD_DA_11-18_mm_f_2.8_ED_DC_AW-lens_specifications.html"
+      },
+      {
+        "id": 1138,
+        "name": "Pentax HD DA 15 mm f/4 ED AL Limited",
+        "url": "https://www.lenstip.com/1138-Pentax_HD_DA_15_mm_f_4_ED_AL_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1857,
+        "name": "Pentax HD DA 16-50 mm f/2.8 ED PLM AW",
+        "url": "https://www.lenstip.com/1857-Pentax_HD_DA_16-50_mm_f_2.8_ED_PLM_AW-lens_specifications.html"
+      },
+      {
+        "id": 1254,
+        "name": "Pentax HD DA 16-85 mm f/3.5-5.6 ED DC WR",
+        "url": "https://www.lenstip.com/1254-Pentax_HD_DA_16-85_mm_f_3.5-5.6_ED_DC_WR-lens_specifications.html"
+      },
+      {
+        "id": 1271,
+        "name": "Pentax HD DA 18-50 mm f/4-5.6 DC WR RE",
+        "url": "https://www.lenstip.com/1271-Pentax_HD_DA_18-50_mm_f_4-5.6_DC_WR_RE-lens_specifications.html"
+      },
+      {
+        "id": 1164,
+        "name": "Pentax HD DA 20-40 mm f/2.8-4.0 ED Limited DC WR",
+        "url": "https://www.lenstip.com/1164-Pentax_HD_DA_20-40_mm_f_2.8-4.0_ED_Limited_DC_WR-lens_specifications.html"
+      },
+      {
+        "id": 1139,
+        "name": "Pentax HD DA 21 mm f/3.2 AL Limited",
+        "url": "https://www.lenstip.com/1139-Pentax_HD_DA_21_mm_f_3.2_AL_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1140,
+        "name": "Pentax HD DA 35 mm f/2.8 Macro Limited",
+        "url": "https://www.lenstip.com/1140-Pentax_HD_DA_35_mm_f_2.8_Macro_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1141,
+        "name": "Pentax HD DA 40 mm f.2.8 Limited",
+        "url": "https://www.lenstip.com/1141-Pentax_HD_DA_40_mm_f.2.8_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1364,
+        "name": "Pentax HD DA 55-300mm F4.5-6.3 ED PLM WR RE",
+        "url": "https://www.lenstip.com/1364-Pentax_HD_DA_55-300mm_F4.5-6.3_ED_PLM_WR_RE-lens_specifications.html"
+      },
+      {
+        "id": 1214,
+        "name": "Pentax HD DA 645 28-45 mm f/4.5 ED AW SR",
+        "url": "https://www.lenstip.com/1214-Pentax_HD_DA_645_28-45_mm_f_4.5_ED_AW_SR-lens_specifications.html"
+      },
+      {
+        "id": 1142,
+        "name": "Pentax HD DA 70 mm f/2.4 AL Limited",
+        "url": "https://www.lenstip.com/1142-Pentax_HD_DA_70_mm_f_2.4_AL_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1813,
+        "name": "Pentax HD FA 31 mm f/1.8 Limited",
+        "url": "https://www.lenstip.com/1813-Pentax_HD_FA_31_mm_f_1.8_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1592,
+        "name": "Pentax HD FA 35 mm f/2",
+        "url": "https://www.lenstip.com/1592-Pentax_HD_FA_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1814,
+        "name": "Pentax HD FA 43 mm f/1.9 Limited",
+        "url": "https://www.lenstip.com/1814-Pentax_HD_FA_43_mm_f_1.9_Limited-lens_specifications.html"
+      },
+      {
+        "id": 2050,
+        "name": "Pentax HD FA 50 mm f/1.4",
+        "url": "https://www.lenstip.com/2050-Pentax_HD_FA_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1710,
+        "name": "Pentax HD FA 70-210 mm f/4 ED SDM WR",
+        "url": "https://www.lenstip.com/1710-Pentax_HD_FA_70-210_mm_f_4_ED_SDM_WR-lens_specifications.html"
+      },
+      {
+        "id": 1815,
+        "name": "Pentax HD FA 77 mm f/1.8 Limited",
+        "url": "https://www.lenstip.com/1815-Pentax_HD_FA_77_mm_f_1.8_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1684,
+        "name": "Pentax HD FA 85 mm f/1.4 ED SDM AW",
+        "url": "https://www.lenstip.com/1684-Pentax_HD_FA_85_mm_f_1.4_ED_SDM_AW-lens_specifications.html"
+      },
+      {
+        "id": 987,
+        "name": "Pentax Q-01 Standard Prime 8.5 mm f/1.9",
+        "url": "https://www.lenstip.com/987-Pentax_Q-01_Standard_Prime_8.5_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 988,
+        "name": "Pentax Q-02 Standard Zoom 5-15 mm f/2.8-4.5",
+        "url": "https://www.lenstip.com/988-Pentax_Q-02_Standard_Zoom_5-15_mm_f_2.8-4.5-lens_specifications.html"
+      },
+      {
+        "id": 989,
+        "name": "Pentax Q-03 Fish-Eye 3.2 mm f/5.6",
+        "url": "https://www.lenstip.com/989-Pentax_Q-03_Fish-Eye_3.2_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 990,
+        "name": "Pentax Q-04 Toy Lens Wide 6.3 mm f/7.1",
+        "url": "https://www.lenstip.com/990-Pentax_Q-04_Toy_Lens_Wide_6.3_mm_f_7.1-lens_specifications.html"
+      },
+      {
+        "id": 991,
+        "name": "Pentax Q-05 Toy Lens Telephoto 18 mm f/8",
+        "url": "https://www.lenstip.com/991-Pentax_Q-05_Toy_Lens_Telephoto_18_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 1068,
+        "name": "Pentax Q-06 Telephoto Zoom 15-45 mm f/2.8 ED IF",
+        "url": "https://www.lenstip.com/1068-Pentax_Q-06_Telephoto_Zoom_15-45_mm_f_2.8_ED_IF-lens_specifications.html"
+      },
+      {
+        "id": 1125,
+        "name": "Pentax Q-07 Mount Shield Lens",
+        "url": "https://www.lenstip.com/1125-Pentax_Q-07_Mount_Shield_Lens-lens_specifications.html"
+      },
+      {
+        "id": 1163,
+        "name": "Pentax Q-08 Wide Zoom",
+        "url": "https://www.lenstip.com/1163-Pentax_Q-08_Wide_Zoom-lens_specifications.html"
+      },
+      {
+        "id": 335,
+        "name": "Pentax smc A 1200 mm f/8 ED (IF)",
+        "url": "https://www.lenstip.com/335-Pentax_smc_A_1200_mm_f_8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 284,
+        "name": "Pentax smc A 15 mm f/3.5",
+        "url": "https://www.lenstip.com/284-Pentax_smc_A_15_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 285,
+        "name": "Pentax smc A 20 mm f/2.8",
+        "url": "https://www.lenstip.com/285-Pentax_smc_A_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 330,
+        "name": "Pentax smc A 200 mm f/2.8 ED",
+        "url": "https://www.lenstip.com/330-Pentax_smc_A_200_mm_f_2.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 331,
+        "name": "Pentax smc A 300 mm f/2.8 ED (IF)",
+        "url": "https://www.lenstip.com/331-Pentax_smc_A_300_mm_f_2.8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 314,
+        "name": "Pentax smc A 35-80 mm f/4-5.6",
+        "url": "https://www.lenstip.com/314-Pentax_smc_A_35-80_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 332,
+        "name": "Pentax smc A 400 mm f/2.8 ED (IF)",
+        "url": "https://www.lenstip.com/332-Pentax_smc_A_400_mm_f_2.8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 333,
+        "name": "Pentax smc A 400 mm f/5.6",
+        "url": "https://www.lenstip.com/333-Pentax_smc_A_400_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 291,
+        "name": "Pentax smc A 50 mm f/1.2",
+        "url": "https://www.lenstip.com/291-Pentax_smc_A_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 290,
+        "name": "Pentax smc A 50 mm f/2",
+        "url": "https://www.lenstip.com/290-Pentax_smc_A_50_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 334,
+        "name": "Pentax smc A 600 mm f/5.6 ED",
+        "url": "https://www.lenstip.com/334-Pentax_smc_A_600_mm_f_5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 315,
+        "name": "Pentax smc A 80-200 mm f/4.7-5.6",
+        "url": "https://www.lenstip.com/315-Pentax_smc_A_80-200_mm_f_4.7-5.6-lens_specifications.html"
+      },
+      {
+        "id": 341,
+        "name": "Pentax smc D FA 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/341-Pentax_smc_D_FA_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 895,
+        "name": "Pentax smc D FA 100 mm f/2.8 Macro WR",
+        "url": "https://www.lenstip.com/895-Pentax_smc_D_FA_100_mm_f_2.8_Macro_WR-lens_specifications.html"
+      },
+      {
+        "id": 340,
+        "name": "Pentax smc D FA 50 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/340-Pentax_smc_D_FA_50_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 972,
+        "name": "Pentax smc D FA 645 25 mm f/4 AL[IF] SDM AW",
+        "url": "https://www.lenstip.com/972-Pentax_smc_D_FA_645_25_mm_f_4_AL[IF]_SDM_AW-lens_specifications.html"
+      },
+      {
+        "id": 917,
+        "name": "Pentax smc D FA 645 55 mm f/2.8 AL[IF] SDM AW",
+        "url": "https://www.lenstip.com/917-Pentax_smc_D_FA_645_55_mm_f_2.8_AL[IF]_SDM_AW_-lens_specifications.html"
+      },
+      {
+        "id": 1070,
+        "name": "Pentax smc D FA 645 90 mm f/2.8 MACRO ED AW SR",
+        "url": "https://www.lenstip.com/1070-Pentax_smc_D_FA_645_90_mm_f_2.8_MACRO_ED_AW_SR-lens_specifications.html"
+      },
+      {
+        "id": 316,
+        "name": "Pentax smc DA 10-17 mm f/3.5-4.5 ED (IF) Fish Eye",
+        "url": "https://www.lenstip.com/316-Pentax_smc_DA_10-17_mm_f_3.5-4.5_ED_(IF)_Fish_Eye-lens_specifications.html"
+      },
+      {
+        "id": 317,
+        "name": "Pentax smc DA 12-24 mm f/4 ED AL (IF)",
+        "url": "https://www.lenstip.com/317-Pentax_smc_DA_12-24_mm_f_4_ED_AL_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 287,
+        "name": "Pentax smc DA 14 mm f/2.8",
+        "url": "https://www.lenstip.com/287-Pentax_smc_DA_14_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 822,
+        "name": "Pentax smc DA 15 mm f/4 ED AL Limited",
+        "url": "https://www.lenstip.com/822-Pentax_smc_DA_15_mm_f_4_ED_AL_Limited_-lens_specifications.html"
+      },
+      {
+        "id": 318,
+        "name": "Pentax smc DA 16-45 mm f/4 ED AL",
+        "url": "https://www.lenstip.com/318-Pentax_smc_DA_16-45_mm_f_4_ED_AL-lens_specifications.html"
+      },
+      {
+        "id": 795,
+        "name": "Pentax smc DA 17-70 mm f/4.0 AL [IF] SDM",
+        "url": "https://www.lenstip.com/795-Pentax_smc_DA_17-70_mm_f_4.0_AL_[IF]_SDM-lens_specifications.html"
+      },
+      {
+        "id": 958,
+        "name": "Pentax smc DA 18-135 mm f/3.5-5.6 ED AL [IF] DC WR",
+        "url": "https://www.lenstip.com/958-Pentax_smc_DA_18-135_mm_f_3.5-5.6_ED_AL_[IF]_DC_WR-lens_specifications.html"
+      },
+      {
+        "id": 655,
+        "name": "Pentax smc DA 18-250 mm f/3.5-6.3 ED AL [IF]",
+        "url": "https://www.lenstip.com/655-Pentax_smc_DA_18-250_mm_f_3.5-6.3_ED_AL_[IF]-lens_specifications.html"
+      },
+      {
+        "id": 1069,
+        "name": "Pentax smc DA 18-270 mm f/3.5-6.3 ED SDM",
+        "url": "https://www.lenstip.com/1069-Pentax_smc_DA_18-270_mm_f_3.5-6.3_ED_SDM-lens_specifications.html"
+      },
+      {
+        "id": 319,
+        "name": "Pentax smc DA 18-55 mm f/3.5-5.6 AL",
+        "url": "https://www.lenstip.com/319-Pentax_smc_DA_18-55_mm_f_3.5-5.6_AL-lens_specifications.html"
+      },
+      {
+        "id": 673,
+        "name": "Pentax smc DA 18-55 mm f/3.5-5.6 AL II",
+        "url": "https://www.lenstip.com/673-Pentax_smc_DA_18-55_mm_f_3.5-5.6_AL_II-lens_specifications.html"
+      },
+      {
+        "id": 864,
+        "name": "Pentax smc DA 18-55 mm f/3.5-5.6 AL WR",
+        "url": "https://www.lenstip.com/864-Pentax_smc_DA_18-55_mm_f_3.5-5.6_AL_WR-lens_specifications.html"
+      },
+      {
+        "id": 286,
+        "name": "Pentax smc DA 21 mm f/3.2 AL Limited",
+        "url": "https://www.lenstip.com/286-Pentax_smc_DA_21_mm_f_3.2_AL_Limited-lens_specifications.html"
+      },
+      {
+        "id": 951,
+        "name": "Pentax smc DA 35 mm f/2.4 AL",
+        "url": "https://www.lenstip.com/951-Pentax_smc_DA_35_mm_f_2.4_AL-lens_specifications.html"
+      },
+      {
+        "id": 672,
+        "name": "Pentax smc DA 35 mm f/2.8 Macro Limited",
+        "url": "https://www.lenstip.com/672-Pentax_smc_DA_35_mm_f_2.8_Macro_Limited-lens_specifications.html"
+      },
+      {
+        "id": 292,
+        "name": "Pentax smc DA 40 mm f/2.8 Limited",
+        "url": "https://www.lenstip.com/292-Pentax_smc_DA_40_mm_f_2.8_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1026,
+        "name": "Pentax smc DA 40 mm f/2.8 XS",
+        "url": "https://www.lenstip.com/1026-Pentax_smc_DA_40_mm_f_2.8_XS-lens_specifications.html"
+      },
+      {
+        "id": 1048,
+        "name": "Pentax smc DA 50 mm f/1.8",
+        "url": "https://www.lenstip.com/1048-Pentax_smc_DA_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 320,
+        "name": "Pentax smc DA 50-200 mm f/4-5.6 ED",
+        "url": "https://www.lenstip.com/320-Pentax_smc_DA_50-200_mm_f_4-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 865,
+        "name": "Pentax smc DA 50-200 mm f/4-5.6 ED WR",
+        "url": "https://www.lenstip.com/865-Pentax_smc_DA_50-200_mm_f_4-5.6_ED_WR-lens_specifications.html"
+      },
+      {
+        "id": 674,
+        "name": "Pentax smc DA 55-300 mm f/4.0-5.8 ED",
+        "url": "https://www.lenstip.com/674-Pentax_smc_DA_55-300_mm_f_4.0-5.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 336,
+        "name": "Pentax smc DA 70 mm f/2.4 Limited",
+        "url": "https://www.lenstip.com/336-Pentax_smc_DA_70_mm_f_2.4_Limited-lens_specifications.html"
+      },
+      {
+        "id": 1153,
+        "name": "Pentax smc DA HD 55-300 mm f/4.0-5.8 ED WR",
+        "url": "https://www.lenstip.com/1153-Pentax_smc_DA_HD_55-300_mm_f_4.0-5.8_ED_WR-lens_specifications.html"
+      },
+      {
+        "id": 1071,
+        "name": "Pentax smc DA HD 560 mm f/5.6 ED AW",
+        "url": "https://www.lenstip.com/1071-Pentax_smc_DA_HD_560_mm_f_5.6_ED_AW-lens_specifications.html"
+      },
+      {
+        "id": 821,
+        "name": "Pentax smc DA L 18-55 mm f/3.5-5.6 AL",
+        "url": "https://www.lenstip.com/821-Pentax_smc_DA_L_18-55_mm_f_3.5-5.6_AL-lens_specifications.html"
+      },
+      {
+        "id": 824,
+        "name": "Pentax smc DA L 50-200 mm f/4-5.6 ED",
+        "url": "https://www.lenstip.com/824-Pentax_smc_DA_L_50-200_mm_f_4-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 884,
+        "name": "Pentax smc DA L 55-300 mm f/4-5.8 ED",
+        "url": "https://www.lenstip.com/884-Pentax_smc_DA_L_55-300_mm_f_4-5.8_ED-lens_specifications.html"
+      },
+      {
+        "id": 620,
+        "name": "Pentax smc DA* 16-50 mm f/2.8 AL ED IF SDM",
+        "url": "https://www.lenstip.com/620-Pentax_smc_DA*_16-50_mm_f_2.8_AL_ED_IF_SDM-lens_specifications.html"
+      },
+      {
+        "id": 671,
+        "name": "Pentax smc DA* 200 mm f/2.8 ED [IF] SDM",
+        "url": "https://www.lenstip.com/671-Pentax_smc_DA*_200_mm_f_2.8_ED_[IF]_SDM-lens_specifications.html"
+      },
+      {
+        "id": 670,
+        "name": "Pentax smc DA* 300 mm f/4 ED [IF] SDM",
+        "url": "https://www.lenstip.com/670-Pentax_smc_DA*_300_mm_f_4_ED_[IF]_SDM-lens_specifications.html"
+      },
+      {
+        "id": 621,
+        "name": "Pentax smc DA* 50-135 mm f/2.8 ED IF SDM",
+        "url": "https://www.lenstip.com/621-Pentax_smc_DA*_50-135_mm_f_2.8_ED_IF_SDM-lens_specifications.html"
+      },
+      {
+        "id": 820,
+        "name": "Pentax smc DA* 55 mm f/1.4 SDM",
+        "url": "https://www.lenstip.com/820-Pentax_smc_DA*_55_mm_f_1.4_SDM-lens_specifications.html"
+      },
+      {
+        "id": 819,
+        "name": "Pentax smc DA* 60-250 mm f/4.0 ED [IF] SDM",
+        "url": "https://www.lenstip.com/819-Pentax_smc_DA*_60-250_mm_f_4.0_ED_[IF]_SDM-lens_specifications.html"
+      },
+      {
+        "id": 293,
+        "name": "Pentax smc F 17-28 mm f/3.5-4.5 Fish Eye Zoom",
+        "url": "https://www.lenstip.com/293-Pentax_smc_F_17-28_mm_f_3.5-4.5_Fish_Eye_Zoom-lens_specifications.html"
+      },
+      {
+        "id": 338,
+        "name": "Pentax smc FA 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/338-Pentax_smc_FA_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 339,
+        "name": "Pentax smc FA 100 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/339-Pentax_smc_FA_100_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 304,
+        "name": "Pentax smc FA 100-300 mm f/4.7-5.8",
+        "url": "https://www.lenstip.com/304-Pentax_smc_FA_100-300_mm_f_4.7-5.8-lens_specifications.html"
+      },
+      {
+        "id": 323,
+        "name": "Pentax smc FA 135 mm f/2.8 (IF)",
+        "url": "https://www.lenstip.com/323-Pentax_smc_FA_135_mm_f_2.8_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 279,
+        "name": "Pentax smc FA 20 mm f/2.8",
+        "url": "https://www.lenstip.com/279-Pentax_smc_FA_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 294,
+        "name": "Pentax smc FA 20-35 mm f/4",
+        "url": "https://www.lenstip.com/294-Pentax_smc_FA_20-35_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 324,
+        "name": "Pentax smc FA 200 mm f/2.8 ED (IF)",
+        "url": "https://www.lenstip.com/324-Pentax_smc_FA_200_mm_f_2.8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 342,
+        "name": "Pentax smc FA 200 mm f/4 ED",
+        "url": "https://www.lenstip.com/342-Pentax_smc_FA_200_mm_f_4_ED-lens_specifications.html"
+      },
+      {
+        "id": 280,
+        "name": "Pentax smc FA 24 mm f/2",
+        "url": "https://www.lenstip.com/280-Pentax_smc_FA_24_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 295,
+        "name": "Pentax smc FA 24-90 mm f/3.5-4.5 AL (IF)",
+        "url": "https://www.lenstip.com/295-Pentax_smc_FA_24-90_mm_f_3.5-4.5_AL_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 307,
+        "name": "Pentax smc FA 250-600 mm f/5.6 DE (IF)",
+        "url": "https://www.lenstip.com/307-Pentax_smc_FA_250-600_mm_f_5.6_DE_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 281,
+        "name": "Pentax smc FA 28 mm f/2.8 AL",
+        "url": "https://www.lenstip.com/281-Pentax_smc_FA_28_mm_f_2.8_AL-lens_specifications.html"
+      },
+      {
+        "id": 343,
+        "name": "Pentax smc FA 28 mm f/2.8 Soft",
+        "url": "https://www.lenstip.com/343-Pentax_smc_FA_28_mm_f_2.8_Soft-lens_specifications.html"
+      },
+      {
+        "id": 300,
+        "name": "Pentax smc FA 28-105 mm f/3.2-4.5 AL (IF)",
+        "url": "https://www.lenstip.com/300-Pentax_smc_FA_28-105_mm_f_3.2-4.5_AL_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 308,
+        "name": "Pentax smc FA 28-105 mm f/4.0-5.6 IF",
+        "url": "https://www.lenstip.com/308-Pentax_smc_FA_28-105_mm_f_4.0-5.6_IF-lens_specifications.html"
+      },
+      {
+        "id": 309,
+        "name": "Pentax smc FA 28-200 mm f/3.8-5.6 AL (IF)",
+        "url": "https://www.lenstip.com/309-Pentax_smc_FA_28-200_mm_f_3.8-5.6_AL_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 296,
+        "name": "Pentax smc FA 28-70 mm f/2.8 AL",
+        "url": "https://www.lenstip.com/296-Pentax_smc_FA_28-70_mm_f_2.8_AL-lens_specifications.html"
+      },
+      {
+        "id": 297,
+        "name": "Pentax smc FA 28-70 mm f/4 AL",
+        "url": "https://www.lenstip.com/297-Pentax_smc_FA_28-70_mm_f_4_AL-lens_specifications.html"
+      },
+      {
+        "id": 298,
+        "name": "Pentax smc FA 28-80 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/298-Pentax_smc_FA_28-80_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 299,
+        "name": "Pentax smc FA 28-90 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/299-Pentax_smc_FA_28-90_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 326,
+        "name": "Pentax smc FA 300 mm f/2.8 ED (IF)",
+        "url": "https://www.lenstip.com/326-Pentax_smc_FA_300_mm_f_2.8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 325,
+        "name": "Pentax smc FA 300 mm f/4.5 ED (IF)",
+        "url": "https://www.lenstip.com/325-Pentax_smc_FA_300_mm_f_4.5_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 282,
+        "name": "Pentax smc FA 31 mm f/1.8 AL",
+        "url": "https://www.lenstip.com/282-Pentax_smc_FA_31_mm_f_1.8_AL-lens_specifications.html"
+      },
+      {
+        "id": 283,
+        "name": "Pentax smc FA 35 mm f/2 AL",
+        "url": "https://www.lenstip.com/283-Pentax_smc_FA_35_mm_f_2_AL-lens_specifications.html"
+      },
+      {
+        "id": 301,
+        "name": "Pentax smc FA 35-80 mm f/4-5.6",
+        "url": "https://www.lenstip.com/301-Pentax_smc_FA_35-80_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 327,
+        "name": "Pentax smc FA 400 mm f/5.6 ED (IF)",
+        "url": "https://www.lenstip.com/327-Pentax_smc_FA_400_mm_f_5.6_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 288,
+        "name": "Pentax smc FA 43 mm f/1.9 Limited",
+        "url": "https://www.lenstip.com/288-Pentax_smc_FA_43_mm_f_1.9_Limited-lens_specifications.html"
+      },
+      {
+        "id": 289,
+        "name": "Pentax smc FA 50 mm f/1.4",
+        "url": "https://www.lenstip.com/289-Pentax_smc_FA_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2051,
+        "name": "Pentax smc FA 50 mm f/1.4 Classic",
+        "url": "https://www.lenstip.com/2051-Pentax_smc_FA_50_mm_f_1.4_Classic-lens_specifications.html"
+      },
+      {
+        "id": 337,
+        "name": "Pentax smc FA 50 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/337-Pentax_smc_FA_50_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 328,
+        "name": "Pentax smc FA 600 mm f/4 ED (IF)",
+        "url": "https://www.lenstip.com/328-Pentax_smc_FA_600_mm_f_4_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 310,
+        "name": "Pentax smc FA 70-200 mm f/4-5.6",
+        "url": "https://www.lenstip.com/310-Pentax_smc_FA_70-200_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 321,
+        "name": "Pentax smc FA 77 mm f/1.8 Limited",
+        "url": "https://www.lenstip.com/321-Pentax_smc_FA_77_mm_f_1.8_Limited-lens_specifications.html"
+      },
+      {
+        "id": 302,
+        "name": "Pentax smc FA 80-200 mm f/2.8 ED (IF)",
+        "url": "https://www.lenstip.com/302-Pentax_smc_FA_80-200_mm_f_2.8_ED_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 305,
+        "name": "Pentax smc FA 80-200 mm f/4.7-5.6",
+        "url": "https://www.lenstip.com/305-Pentax_smc_FA_80-200_mm_f_4.7-5.6-lens_specifications.html"
+      },
+      {
+        "id": 303,
+        "name": "Pentax smc FA 80-320 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/303-Pentax_smc_FA_80-320_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 322,
+        "name": "Pentax smc FA 85 mm f/1.4 (IF)",
+        "url": "https://www.lenstip.com/322-Pentax_smc_FA_85_mm_f_1.4_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 344,
+        "name": "Pentax smc FA 85 mm f/2.8 Soft",
+        "url": "https://www.lenstip.com/344-Pentax_smc_FA_85_mm_f_2.8_Soft-lens_specifications.html"
+      },
+      {
+        "id": 311,
+        "name": "Pentax smc FA J 18-35 mm f/4-5.6 AL",
+        "url": "https://www.lenstip.com/311-Pentax_smc_FA_J_18-35_mm_f_4-5.6_AL-lens_specifications.html"
+      },
+      {
+        "id": 312,
+        "name": "Pentax smc FA J 28-80 mm f/4.5-5.6 AL",
+        "url": "https://www.lenstip.com/312-Pentax_smc_FA_J_28-80_mm_f_4.5-5.6_AL-lens_specifications.html"
+      },
+      {
+        "id": 313,
+        "name": "Pentax smc FA J 75-300 mm f/4.5-5.8 AL",
+        "url": "https://www.lenstip.com/313-Pentax_smc_FA_J_75-300_mm_f_4.5-5.8_AL-lens_specifications.html"
+      },
+      {
+        "id": 329,
+        "name": "Pentax smc Reflex 1000 mm f/11",
+        "url": "https://www.lenstip.com/329-Pentax_smc_Reflex_1000_mm_f_11-lens_specifications.html"
+      },
+      {
+        "id": 306,
+        "name": "Pentax smc Reflex 400-600 mm f/8-12",
+        "url": "https://www.lenstip.com/306-Pentax_smc_Reflex_400-600_mm_f_8-12-lens_specifications.html"
+      }
+    ],
+    "Rollei": [
+      {
+        "id": 2234,
+        "name": "Rollei VAF 85 mm f/1.8 STM",
+        "url": "https://www.lenstip.com/2234-Rollei_VAF_85_mm_f_1.8_STM-lens_specifications.html"
+      }
+    ],
+    "SainSonic": [
+      {
+        "id": 1544,
+        "name": "SainSonic DZ Optics 35 mm f/1.2",
+        "url": "https://www.lenstip.com/1544-SainSonic_DZ_Optics_35_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1807,
+        "name": "SainSonic KamLan 32 mm f/1.1",
+        "url": "https://www.lenstip.com/1807-SainSonic_KamLan_32_mm_f_1.1-lens_specifications.html"
+      },
+      {
+        "id": 1548,
+        "name": "SainSonic Kamlan 50 mm f/1.1",
+        "url": "https://www.lenstip.com/1548-SainSonic_Kamlan_50_mm_f_1.1-lens_specifications.html"
+      },
+      {
+        "id": 1546,
+        "name": "SainSonic Kamlan 55 mm f/1.2",
+        "url": "https://www.lenstip.com/1546-SainSonic_Kamlan_55_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1547,
+        "name": "SainSonic Kamlan 8 mm f/3.0 Fisheye",
+        "url": "https://www.lenstip.com/1547-SainSonic_Kamlan_8_mm_f_3.0_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1545,
+        "name": "SainSonic Zonlai 22 mm f/1.8",
+        "url": "https://www.lenstip.com/1545-SainSonic_Zonlai_22_mm_f_1.8-lens_specifications.html"
+      }
+    ],
+    "Samsung": [
+      {
+        "id": 1124,
+        "name": "Samsung NX 10 mm f/3.5 Fisheye",
+        "url": "https://www.lenstip.com/1124-Samsung_NX_10_mm_f_3.5_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1086,
+        "name": "Samsung NX 12-24 mm f/4.0-5.6 ED",
+        "url": "https://www.lenstip.com/1086-Samsung_NX_12-24_mm_f_4.0-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 977,
+        "name": "Samsung NX 16 mm f/2.4",
+        "url": "https://www.lenstip.com/977-Samsung_NX_16_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 1169,
+        "name": "Samsung NX 16-50 mm f/2-2.8 S ED OIS",
+        "url": "https://www.lenstip.com/1169-Samsung_NX_16-50_mm_f_2-2.8_S_ED_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1170,
+        "name": "Samsung NX 16-50 mm f/3.5-5.6 PZ ED OIS",
+        "url": "https://www.lenstip.com/1170-Samsung_NX_16-50_mm_f_3.5-5.6_PZ_ED_OIS-lens_specifications.html"
+      },
+      {
+        "id": 981,
+        "name": "Samsung NX 16-80 mm f/3.5-4.5 OIS",
+        "url": "https://www.lenstip.com/981-Samsung_NX_16-80_mm_f_3.5-4.5_OIS-lens_specifications.html"
+      },
+      {
+        "id": 978,
+        "name": "Samsung NX 18-200 mm f/3.5-6.3 ED OIS",
+        "url": "https://www.lenstip.com/978-Samsung_NX_18-200_mm_f_3.5-6.3_ED_OIS_-lens_specifications.html"
+      },
+      {
+        "id": 898,
+        "name": "Samsung NX 18-55 mm f/3.5-5.6 OIS",
+        "url": "https://www.lenstip.com/898-Samsung_NX_18-55_mm_f_3.5-5.6_OIS-lens_specifications.html"
+      },
+      {
+        "id": 968,
+        "name": "Samsung NX 18-55 mm f/3.5-5.6 OIS II",
+        "url": "https://www.lenstip.com/968-Samsung_NX_18-55_mm_f_3.5-5.6_OIS_II-lens_specifications.html"
+      },
+      {
+        "id": 953,
+        "name": "Samsung NX 20 mm f/2.8",
+        "url": "https://www.lenstip.com/953-Samsung_NX_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 952,
+        "name": "Samsung NX 20-50 mm f/3.5-5.6 ED",
+        "url": "https://www.lenstip.com/952-Samsung_NX_20-50_mm_f_3.5-5.6_ED-lens_specifications.html"
+      },
+      {
+        "id": 1046,
+        "name": "Samsung NX 20-50 mm f/3.5-5.6 ED OIS II",
+        "url": "https://www.lenstip.com/1046-Samsung_NX_20-50_mm_f_3.5-5.6_ED_OIS_II-lens_specifications.html"
+      },
+      {
+        "id": 897,
+        "name": "Samsung NX 30 mm f/2.0",
+        "url": "https://www.lenstip.com/897-Samsung_NX_30_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 1085,
+        "name": "Samsung NX 45 mm f/1.8",
+        "url": "https://www.lenstip.com/1085-Samsung_NX_45_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1093,
+        "name": "Samsung NX 45 mm f/1.8 2D/3D",
+        "url": "https://www.lenstip.com/1093-Samsung_NX_45_mm_f_1.8_2D_3D-lens_specifications.html"
+      },
+      {
+        "id": 1234,
+        "name": "Samsung NX 50-150 mm f/2.8 S ED OIS",
+        "url": "https://www.lenstip.com/1234-Samsung_NX_50-150_mm_f_2.8_S_ED_OIS-lens_specifications.html"
+      },
+      {
+        "id": 899,
+        "name": "Samsung NX 50-200 mm f/4-5.6 ED OIS",
+        "url": "https://www.lenstip.com/899-Samsung_NX_50-200_mm_f_4-5.6_ED_OIS-lens_specifications.html"
+      },
+      {
+        "id": 1038,
+        "name": "Samsung NX 50-200 mm f/4-5.6 ED OIS II",
+        "url": "https://www.lenstip.com/1038-Samsung_NX_50-200_mm_f_4-5.6_ED_OIS_II-lens_specifications.html"
+      },
+      {
+        "id": 979,
+        "name": "Samsung NX 60 mm f/2.8 Macro ED OIS SSA",
+        "url": "https://www.lenstip.com/979-Samsung_NX_60_mm_f_2.8_Macro_ED_OIS_SSA-lens_specifications.html"
+      },
+      {
+        "id": 980,
+        "name": "Samsung NX 85 mm f/1.4 ED SSA",
+        "url": "https://www.lenstip.com/980-Samsung_NX_85_mm_f_1.4_ED_SSA-lens_specifications.html"
+      },
+      {
+        "id": 1190,
+        "name": "Samsung NX-M 17 mm f/1.8 OIS",
+        "url": "https://www.lenstip.com/1190-Samsung_NX-M_17_mm_f_1.8_OIS_-lens_specifications.html"
+      },
+      {
+        "id": 1188,
+        "name": "Samsung NX-M 9 mm f/3.5 ED",
+        "url": "https://www.lenstip.com/1188-Samsung_NX-M_9_mm_f_3.5_ED-lens_specifications.html"
+      },
+      {
+        "id": 1189,
+        "name": "Samsung NX-M 9-27 mm f/3.5-5.6 ED OIS",
+        "url": "https://www.lenstip.com/1189-Samsung_NX-M_9-27_mm_f_3.5-5.6_ED_OIS-lens_specifications.html"
+      }
+    ],
+    "Samyang": [
+      {
+        "id": 1197,
+        "name": "Samyang 10 mm T3.1 ED AS NCS CS",
+        "url": "https://www.lenstip.com/1197-Samyang_10_mm_T3.1_ED_AS_NCS_CS-lens_specifications.html"
+      },
+      {
+        "id": 1080,
+        "name": "Samyang 10 mm f/2.8 ED AS NCS CS",
+        "url": "https://www.lenstip.com/1080-Samyang_10_mm_f_2.8_ED_AS_NCS_CS-lens_specifications.html"
+      },
+      {
+        "id": 1283,
+        "name": "Samyang 100 mm T3.1 VDSLR ED UMC MACRO",
+        "url": "https://www.lenstip.com/1283-Samyang_100_mm_T3.1_VDSLR_ED_UMC_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 1282,
+        "name": "Samyang 100 mm f/2.8 ED UMC MACRO",
+        "url": "https://www.lenstip.com/1282-Samyang_100_mm_f_2.8_ED_UMC_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 1198,
+        "name": "Samyang 12 mm T2.2 NCS CS",
+        "url": "https://www.lenstip.com/1198-Samyang_12_mm_T2.2_NCS_CS-lens_specifications.html"
+      },
+      {
+        "id": 1194,
+        "name": "Samyang 12 mm f/2.0 NCS CS",
+        "url": "https://www.lenstip.com/1194-Samyang_12_mm_f_2.0_NCS_CS-lens_specifications.html"
+      },
+      {
+        "id": 1225,
+        "name": "Samyang 12 mm f/2.8 ED AS NCS Fish-eye",
+        "url": "https://www.lenstip.com/1225-Samyang_12_mm_f_2.8_ED_AS_NCS_Fish-eye-lens_specifications.html"
+      },
+      {
+        "id": 1264,
+        "name": "Samyang 135 mm T2.2 ED UMC VDSLR",
+        "url": "https://www.lenstip.com/1264-Samyang_135_mm_T2.2_ED_UMC_VDSLR-lens_specifications.html"
+      },
+      {
+        "id": 1895,
+        "name": "Samyang 135 mm T2.2 VDSLR MK2",
+        "url": "https://www.lenstip.com/1895-Samyang_135_mm_T2.2_VDSLR_MK2-lens_specifications.html"
+      },
+      {
+        "id": 1263,
+        "name": "Samyang 135 mm f/2.0 ED UMC",
+        "url": "https://www.lenstip.com/1263-Samyang_135_mm_f_2.0_ED_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1794,
+        "name": "Samyang 14 mm T3.1 VDSLR MK2",
+        "url": "https://www.lenstip.com/1794-Samyang_14_mm_T3.1_VDSLR_MK2-lens_specifications.html"
+      },
+      {
+        "id": 920,
+        "name": "Samyang 14 mm f/2.8 ED AS IF UMC",
+        "url": "https://www.lenstip.com/920-Samyang_14_mm_f_2.8_ED_AS_IF_UMC-lens_specifications.html"
+      },
+      {
+        "id": 885,
+        "name": "Samyang 14 mm f/2.8 IF ED MC Aspherical",
+        "url": "https://www.lenstip.com/885-Samyang_14_mm_f_2.8_IF_ED_MC_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1463,
+        "name": "Samyang 16 mm T2.6 ED AS UMC VDSLR",
+        "url": "https://www.lenstip.com/1463-Samyang_16_mm_T2.6_ED_AS_UMC_VDSLR_-lens_specifications.html"
+      },
+      {
+        "id": 1126,
+        "name": "Samyang 16 mm f/2.0 ED AS UMC CS",
+        "url": "https://www.lenstip.com/1126-Samyang_16_mm_f_2.0_ED_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1375,
+        "name": "Samyang 20 mm T1.9 ED AS UMC",
+        "url": "https://www.lenstip.com/1375-Samyang_20_mm_T1.9_ED_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1374,
+        "name": "Samyang 20 mm f/1.8 ED AS UMC",
+        "url": "https://www.lenstip.com/1374-Samyang_20_mm_f_1.8_ED_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1319,
+        "name": "Samyang 21 mm T1.5 ED AS UMC CS",
+        "url": "https://www.lenstip.com/1319-Samyang_21_mm_T1.5_ED_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1318,
+        "name": "Samyang 21 mm f/1.4 ED AS UMC CS",
+        "url": "https://www.lenstip.com/1318-Samyang_21_mm_f_1.4_ED_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 996,
+        "name": "Samyang 24 mm f/1.4 ED AS UMC",
+        "url": "https://www.lenstip.com/996-Samyang_24_mm_f_1.4_ED_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1127,
+        "name": "Samyang 300 mm f/6.3 Reflex ED UMC CS",
+        "url": "https://www.lenstip.com/1127-Samyang_300_mm_f_6.3_Reflex_ED_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1196,
+        "name": "Samyang 300 mm f/6.3 UMC CS",
+        "url": "https://www.lenstip.com/1196-Samyang_300_mm_f_6.3_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1373,
+        "name": "Samyang 35 mm T/1.3 ED AS UMC CS",
+        "url": "https://www.lenstip.com/1373-Samyang_35_mm_T_1.3_ED_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1372,
+        "name": "Samyang 35 mm f/1.2 ED AS UMC CS",
+        "url": "https://www.lenstip.com/1372-Samyang_35_mm_f_1.2_ED_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1195,
+        "name": "Samyang 35 mm f/1.4 AS UMC",
+        "url": "https://www.lenstip.com/1195-Samyang_35_mm_f_1.4_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 957,
+        "name": "Samyang 35 mm f/1.4 AS UMC",
+        "url": "https://www.lenstip.com/957-Samyang_35_mm_f_1.4_AS_UMC_-lens_specifications.html"
+      },
+      {
+        "id": 1320,
+        "name": "Samyang 50 mm T1.3 AS UMC CS",
+        "url": "https://www.lenstip.com/1320-Samyang_50_mm_T1.3_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1215,
+        "name": "Samyang 50 mm T1.5 AS UMC V-DSLR",
+        "url": "https://www.lenstip.com/1215-Samyang_50_mm_T1.5_AS_UMC_V-DSLR-lens_specifications.html"
+      },
+      {
+        "id": 1317,
+        "name": "Samyang 50 mm f/1.2 AS UMC CS",
+        "url": "https://www.lenstip.com/1317-Samyang_50_mm_f_1.2_AS_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 1216,
+        "name": "Samyang 50 mm f/1.4 AS UMC",
+        "url": "https://www.lenstip.com/1216-Samyang_50_mm_f_1.4_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 844,
+        "name": "Samyang 500 mm ED MC f/8.0",
+        "url": "https://www.lenstip.com/844-Samyang_500_mm_ED_MC_f_8.0-lens_specifications.html"
+      },
+      {
+        "id": 846,
+        "name": "Samyang 500 mm MC f/5.6",
+        "url": "https://www.lenstip.com/846-Samyang_500_mm_MC_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 841,
+        "name": "Samyang 500 mm Mirror MC f/6.3",
+        "url": "https://www.lenstip.com/841-Samyang_500_mm_Mirror_MC_f_6.3-lens_specifications.html"
+      },
+      {
+        "id": 842,
+        "name": "Samyang 500 mm Mirror MC f/8.0",
+        "url": "https://www.lenstip.com/842-Samyang_500_mm_Mirror_MC_f_8.0-lens_specifications.html"
+      },
+      {
+        "id": 839,
+        "name": "Samyang 650-1300 mm IF MC f/8.0-16.0",
+        "url": "https://www.lenstip.com/839-Samyang_650-1300_mm_IF_MC_f_8.0-16.0-lens_specifications.html"
+      },
+      {
+        "id": 1199,
+        "name": "Samyang 7.5 mm T3.8 CINE UMC Fish-eye",
+        "url": "https://www.lenstip.com/1199-Samyang_7.5_mm_T3.8_CINE_UMC_Fish-eye-lens_specifications.html"
+      },
+      {
+        "id": 1003,
+        "name": "Samyang 7.5 mm f/3.5 UMC Fish-eye MFT",
+        "url": "https://www.lenstip.com/1003-Samyang_7.5_mm_f_3.5_UMC_Fish-eye_MFT-lens_specifications.html"
+      },
+      {
+        "id": 1051,
+        "name": "Samyang 8 mm f/2.8 UMC Fisheye",
+        "url": "https://www.lenstip.com/1051-Samyang_8_mm_f_2.8_UMC_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2296,
+        "name": "Samyang 8 mm f/2.8 UMC Fisheye II",
+        "url": "https://www.lenstip.com/2296-Samyang_8_mm_f_2.8_UMC_Fisheye_II-lens_specifications.html"
+      },
+      {
+        "id": 855,
+        "name": "Samyang 8 mm f/3.5 Aspherical IF MC Fish-eye",
+        "url": "https://www.lenstip.com/855-Samyang_8_mm_f_3.5_Aspherical_IF_MC_Fish-eye-lens_specifications.html"
+      },
+      {
+        "id": 843,
+        "name": "Samyang 800 mm Mirror MC f/8.0",
+        "url": "https://www.lenstip.com/843-Samyang_800_mm_Mirror_MC_f_8.0-lens_specifications.html"
+      },
+      {
+        "id": 834,
+        "name": "Samyang 85 mm f/1.4 Aspherical IF",
+        "url": "https://www.lenstip.com/834-Samyang_85_mm_f_1.4_Aspherical_IF_-lens_specifications.html"
+      },
+      {
+        "id": 1557,
+        "name": "Samyang 85 mm f/1.8 ED UMC CS",
+        "url": "https://www.lenstip.com/1557-Samyang_85_mm_f_1.8_ED_UMC_CS-lens_specifications.html"
+      },
+      {
+        "id": 960,
+        "name": "Samyang AE 14 mm f/2.8 ED AS IF UMC",
+        "url": "https://www.lenstip.com/960-Samyang_AE_14_mm_f_2.8_ED_AS_IF_UMC-lens_specifications.html"
+      },
+      {
+        "id": 919,
+        "name": "Samyang AE 85 mm f/1.4 AS IF UMC",
+        "url": "https://www.lenstip.com/919-Samyang_AE_85_mm_f_1.4_AS_IF_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1837,
+        "name": "Samyang AF 12 mm f/2.0 E / X / RF-S",
+        "url": "https://www.lenstip.com/1837-Samyang_AF_12_mm_f_2.0_E___X___RF-S-lens_specifications.html"
+      },
+      {
+        "id": 1915,
+        "name": "Samyang AF 135 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1915-Samyang_AF_135_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1500,
+        "name": "Samyang AF 14 mm f/2.8 EF",
+        "url": "https://www.lenstip.com/1500-Samyang_AF_14_mm_f_2.8_EF-lens_specifications.html"
+      },
+      {
+        "id": 1551,
+        "name": "Samyang AF 14 mm f/2.8 F",
+        "url": "https://www.lenstip.com/1551-Samyang_AF_14_mm_f_2.8_F-lens_specifications.html"
+      },
+      {
+        "id": 1368,
+        "name": "Samyang AF 14 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/1368-Samyang_AF_14_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1660,
+        "name": "Samyang AF 14 mm f/2.8 RF",
+        "url": "https://www.lenstip.com/1660-Samyang_AF_14_mm_f_2.8_RF-lens_specifications.html"
+      },
+      {
+        "id": 2226,
+        "name": "Samyang AF 14-24 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/2226-Samyang_AF_14-24_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 2245,
+        "name": "Samyang AF 16 mm f/2.8 P FE",
+        "url": "https://www.lenstip.com/2245-Samyang_AF_16_mm_f_2.8_P_FE-lens_specifications.html"
+      },
+      {
+        "id": 1645,
+        "name": "Samyang AF 18 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/1645-Samyang_AF_18_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1823,
+        "name": "Samyang AF 24 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1823-Samyang_AF_24_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1539,
+        "name": "Samyang AF 24 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/1539-Samyang_AF_24_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 2267,
+        "name": "Samyang AF 24-60 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/2267-Samyang_AF_24-60_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1893,
+        "name": "Samyang AF 24-70 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/1893-Samyang_AF_24-70_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1487,
+        "name": "Samyang AF 35 mm f/1.4 FE",
+        "url": "https://www.lenstip.com/1487-Samyang_AF_35_mm_f_1.4_FE-lens_specifications.html"
+      },
+      {
+        "id": 1933,
+        "name": "Samyang AF 35 mm f/1.4 FE II",
+        "url": "https://www.lenstip.com/1933-Samyang_AF_35_mm_f_1.4_FE_II-lens_specifications.html"
+      },
+      {
+        "id": 2190,
+        "name": "Samyang AF 35 mm f/1.4 P FE",
+        "url": "https://www.lenstip.com/2190-Samyang_AF_35_mm_f_1.4_P_FE-lens_specifications.html"
+      },
+      {
+        "id": 1744,
+        "name": "Samyang AF 35 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1744-Samyang_AF_35_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 2323,
+        "name": "Samyang AF 35 mm f/1.8 P FE",
+        "url": "https://www.lenstip.com/2323-Samyang_AF_35_mm_f_1.8_P_FE-lens_specifications.html"
+      },
+      {
+        "id": 1469,
+        "name": "Samyang AF 35 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/1469-Samyang_AF_35_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 2043,
+        "name": "Samyang AF 35-150 mm f/2-2.8 FE",
+        "url": "https://www.lenstip.com/2043-Samyang_AF_35-150_mm_f_2-2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1622,
+        "name": "Samyang AF 45 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1622-Samyang_AF_45_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1367,
+        "name": "Samyang AF 50 mm f/1.4 FE",
+        "url": "https://www.lenstip.com/1367-Samyang_AF_50_mm_f_1.4_FE-lens_specifications.html"
+      },
+      {
+        "id": 1900,
+        "name": "Samyang AF 50 mm f/1.4 FE II",
+        "url": "https://www.lenstip.com/1900-Samyang_AF_50_mm_f_1.4_FE_II-lens_specifications.html"
+      },
+      {
+        "id": 1692,
+        "name": "Samyang AF 75 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1692-Samyang_AF_75_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 2035,
+        "name": "Samyang AF 75 mm f/1.8 X",
+        "url": "https://www.lenstip.com/2035-Samyang_AF_75_mm_f_1.8_X-lens_specifications.html"
+      },
+      {
+        "id": 1540,
+        "name": "Samyang AF 85 mm f/1.4 EF",
+        "url": "https://www.lenstip.com/1540-Samyang_AF_85_mm_f_1.4_EF-lens_specifications.html"
+      },
+      {
+        "id": 1965,
+        "name": "Samyang AF 85 mm f/1.4 FE II",
+        "url": "https://www.lenstip.com/1965-Samyang_AF_85_mm_f_1.4_FE_II-lens_specifications.html"
+      },
+      {
+        "id": 1609,
+        "name": "Samyang AF 85 mm f/1.4 FE/RF",
+        "url": "https://www.lenstip.com/1609-Samyang_AF_85_mm_f_1.4_FE_RF-lens_specifications.html"
+      },
+      {
+        "id": 2244,
+        "name": "Samyang AF 85 mm f/1.8 P FE",
+        "url": "https://www.lenstip.com/2244-Samyang_AF_85_mm_f_1.8_P_FE-lens_specifications.html"
+      },
+      {
+        "id": 1697,
+        "name": "Samyang MF 14 mm f/2.8 MK2",
+        "url": "https://www.lenstip.com/1697-Samyang_MF_14_mm_f_2.8_MK2-lens_specifications.html"
+      },
+      {
+        "id": 1603,
+        "name": "Samyang MF 14 mm f/2.8 RF",
+        "url": "https://www.lenstip.com/1603-Samyang_MF_14_mm_f_2.8_RF-lens_specifications.html"
+      },
+      {
+        "id": 1604,
+        "name": "Samyang MF 85 mm 1.4 RF",
+        "url": "https://www.lenstip.com/1604-Samyang_MF_85_mm_1.4_RF-lens_specifications.html"
+      },
+      {
+        "id": 1696,
+        "name": "Samyang MF 85 mm f/1.4 MK2",
+        "url": "https://www.lenstip.com/1696-Samyang_MF_85_mm_f_1.4_MK2-lens_specifications.html"
+      },
+      {
+        "id": 845,
+        "name": "Samyang Preset 500 mm ED MC f/8.0",
+        "url": "https://www.lenstip.com/845-Samyang_Preset_500_mm_ED_MC_f_8.0-lens_specifications.html"
+      },
+      {
+        "id": 840,
+        "name": "Samyang Preset 500 mm MC f/8.0",
+        "url": "https://www.lenstip.com/840-Samyang_Preset_500_mm_MC_f_8.0-lens_specifications.html"
+      },
+      {
+        "id": 2156,
+        "name": "Samyang RS 21 mm f/3.5 FE",
+        "url": "https://www.lenstip.com/2156-Samyang_RS_21_mm_f_3.5_FE-lens_specifications.html"
+      },
+      {
+        "id": 2157,
+        "name": "Samyang RS 28 mm f/3.5 FE",
+        "url": "https://www.lenstip.com/2157-Samyang_RS_28_mm_f_3.5_FE-lens_specifications.html"
+      },
+      {
+        "id": 2158,
+        "name": "Samyang RS 32 mm f/2.8 FE",
+        "url": "https://www.lenstip.com/2158-Samyang_RS_32_mm_f_2.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1066,
+        "name": "Samyang T-S 24 mm f/3.5 ED AS UMC",
+        "url": "https://www.lenstip.com/1066-Samyang_T-S_24_mm_f_3.5_ED_AS_UMC-lens_specifications.html"
+      },
+      {
+        "id": 1063,
+        "name": "Samyang V-DSLR 14 mm T3.1 ED AS IF UMC",
+        "url": "https://www.lenstip.com/1063-Samyang_V-DSLR_14_mm_T3.1_ED_AS_IF_UMC_-lens_specifications.html"
+      },
+      {
+        "id": 1061,
+        "name": "Samyang V-DSLR 24 mm T1.5 ED AS IF UMC",
+        "url": "https://www.lenstip.com/1061-Samyang_V-DSLR_24_mm_T1.5_ED_AS_IF_UMC_-lens_specifications.html"
+      },
+      {
+        "id": 1062,
+        "name": "Samyang V-DSLR 35 mm T1.5 AS UMC",
+        "url": "https://www.lenstip.com/1062-Samyang_V-DSLR_35_mm_T1.5_AS_UMC_-lens_specifications.html"
+      },
+      {
+        "id": 963,
+        "name": "Samyang V-DSLR 8 mm T3.5 Asph. IF MC Fish-eye CS",
+        "url": "https://www.lenstip.com/963-Samyang_V-DSLR_8_mm_T3.5_Asph._IF_MC_Fish-eye_CS_-lens_specifications.html"
+      },
+      {
+        "id": 1600,
+        "name": "Samyang XP 10 mm f/3.5",
+        "url": "https://www.lenstip.com/1600-Samyang_XP_10_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 1389,
+        "name": "Samyang XP 14 mm f/2.4",
+        "url": "https://www.lenstip.com/1389-Samyang_XP_14_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 1586,
+        "name": "Samyang XP 35 mm f/1.2",
+        "url": "https://www.lenstip.com/1586-Samyang_XP_35_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1511,
+        "name": "Samyang XP 50 mm f/1.2",
+        "url": "https://www.lenstip.com/1511-Samyang_XP_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1390,
+        "name": "Samyang XP 85 mm f/1.2",
+        "url": "https://www.lenstip.com/1390-Samyang_XP_85_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1370,
+        "name": "Samyang Xeen 135 mm T2.2",
+        "url": "https://www.lenstip.com/1370-Samyang_Xeen_135_mm_T2.2-lens_specifications.html"
+      },
+      {
+        "id": 1345,
+        "name": "Samyang Xeen 14 mm T3.1",
+        "url": "https://www.lenstip.com/1345-Samyang_Xeen_14_mm_T3.1-lens_specifications.html"
+      },
+      {
+        "id": 1400,
+        "name": "Samyang Xeen 16 mm T2.6",
+        "url": "https://www.lenstip.com/1400-Samyang_Xeen_16_mm_T2.6-lens_specifications.html"
+      },
+      {
+        "id": 1440,
+        "name": "Samyang Xeen 20 mm T1.9",
+        "url": "https://www.lenstip.com/1440-Samyang_Xeen_20_mm_T1.9-lens_specifications.html"
+      },
+      {
+        "id": 1304,
+        "name": "Samyang Xeen 24 mm T1.5",
+        "url": "https://www.lenstip.com/1304-Samyang_Xeen_24_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1344,
+        "name": "Samyang Xeen 35 mm T1.5",
+        "url": "https://www.lenstip.com/1344-Samyang_Xeen_35_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1305,
+        "name": "Samyang Xeen 50 mm T1.5",
+        "url": "https://www.lenstip.com/1305-Samyang_Xeen_50_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1306,
+        "name": "Samyang Xeen 85 mm T1.5",
+        "url": "https://www.lenstip.com/1306-Samyang_Xeen_85_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1647,
+        "name": "Samyang Xeen CF 24 mm T1.5",
+        "url": "https://www.lenstip.com/1647-Samyang_Xeen_CF_24_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1648,
+        "name": "Samyang Xeen CF 50 mm T1.5",
+        "url": "https://www.lenstip.com/1648-Samyang_Xeen_CF_50_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1649,
+        "name": "Samyang Xeen CF 85 mm T1.5",
+        "url": "https://www.lenstip.com/1649-Samyang_Xeen_CF_85_mm_T1.5-lens_specifications.html"
+      }
+    ],
+    "Schneider-Kreuznach": [
+      {
+        "id": 1207,
+        "name": "Schneider-Kreuznach 40-80 mm LS f/4.0-5.6",
+        "url": "https://www.lenstip.com/1207-Schneider-Kreuznach_40-80_mm_LS_f_4.0-5.6-lens_specifications.html"
+      },
+      {
+        "id": 196,
+        "name": "Schneider-Kreuznach D-XENOGON 35 mm f/2",
+        "url": "https://www.lenstip.com/196-Schneider-Kreuznach_D-XENOGON_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 198,
+        "name": "Schneider-Kreuznach D-XENON 10-17 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/198-Schneider-Kreuznach_D-XENON_10-17_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 197,
+        "name": "Schneider-Kreuznach D-XENON 100 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/197-Schneider-Kreuznach_D-XENON_100_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 195,
+        "name": "Schneider-Kreuznach D-XENON 12-24 mm f/4",
+        "url": "https://www.lenstip.com/195-Schneider-Kreuznach_D-XENON_12-24_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 199,
+        "name": "Schneider-Kreuznach D-XENON 16-45 mm f/4",
+        "url": "https://www.lenstip.com/199-Schneider-Kreuznach_D-XENON_16-45_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 193,
+        "name": "Schneider-Kreuznach D-XENON 18-55 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/193-Schneider-Kreuznach_D-XENON_18-55_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 194,
+        "name": "Schneider-Kreuznach D-XENON 50-200 mm f/4-5.6",
+        "url": "https://www.lenstip.com/194-Schneider-Kreuznach_D-XENON_50-200_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1251,
+        "name": "Schneider-Kreuznach Makro-Symmar 85 mm f/2.4",
+        "url": "https://www.lenstip.com/1251-Schneider-Kreuznach_Makro-Symmar_85_mm_f_2.4-lens_specifications.html"
+      },
+      {
+        "id": 938,
+        "name": "Schneider-Kreuznach PC-TS Apo-Digitar 5.6/120 HM Aspheric",
+        "url": "https://www.lenstip.com/938-Schneider-Kreuznach_PC-TS_Apo-Digitar_5.6_120_HM_Aspheric-lens_specifications.html"
+      },
+      {
+        "id": 937,
+        "name": "Schneider-Kreuznach PC-TS Makro-Symmar 4/90 HM",
+        "url": "https://www.lenstip.com/937-Schneider-Kreuznach_PC-TS_Makro-Symmar_4_90_HM-lens_specifications.html"
+      },
+      {
+        "id": 939,
+        "name": "Schneider-Kreuznach PC-TS Super-Angulon 2.8/50 HM",
+        "url": "https://www.lenstip.com/939-Schneider-Kreuznach_PC-TS_Super-Angulon_2.8_50_HM-lens_specifications.html"
+      },
+      {
+        "id": 1054,
+        "name": "Schneider-Kreuznach Super-Angulon 14 mm f/2.0",
+        "url": "https://www.lenstip.com/1054-Schneider-Kreuznach_Super-Angulon_14_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 1417,
+        "name": "Schneider-Kreuznach Xenon 18 mm T2.4",
+        "url": "https://www.lenstip.com/1417-Schneider-Kreuznach_Xenon_18_mm_T2.4-lens_specifications.html"
+      },
+      {
+        "id": 1249,
+        "name": "Schneider-Kreuznach Xenon 35 mm f/1.6",
+        "url": "https://www.lenstip.com/1249-Schneider-Kreuznach_Xenon_35_mm_f_1.6-lens_specifications.html"
+      },
+      {
+        "id": 1250,
+        "name": "Schneider-Kreuznach Xenon 50 mm f/1.4",
+        "url": "https://www.lenstip.com/1250-Schneider-Kreuznach_Xenon_50_mm_f_1.4-lens_specifications.html"
+      }
+    ],
+    "Sigma": [
+      {
+        "id": 663,
+        "name": "Sigma  10 mm f/2.8 EX DC FISHEYE HSM",
+        "url": "https://www.lenstip.com/663-Sigma__10_mm_f_2.8_EX_DC_FISHEYE_HSM-lens_specifications.html"
+      },
+      {
+        "id": 847,
+        "name": "Sigma 10-20 mm f/3.5 EX DC HSM",
+        "url": "https://www.lenstip.com/847-Sigma_10-20_mm_f_3.5_EX_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 29,
+        "name": "Sigma 10-20 mm f/4-5.6 EX DC HSM",
+        "url": "https://www.lenstip.com/29-Sigma_10-20_mm_f_4-5.6_EX_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 420,
+        "name": "Sigma 100-300 mm f/4 DG EX APO IF HSM",
+        "url": "https://www.lenstip.com/420-Sigma_100-300_mm_f_4_DG_EX_APO_IF_HSM-lens_specifications.html"
+      },
+      {
+        "id": 24,
+        "name": "Sigma 105 mm f/2.8 EX DG Macro",
+        "url": "https://www.lenstip.com/24-Sigma_105_mm_f_2.8_EX_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 970,
+        "name": "Sigma 105 mm f/2.8 EX DG OS HSM Macro",
+        "url": "https://www.lenstip.com/970-Sigma_105_mm_f_2.8_EX_DG_OS_HSM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 407,
+        "name": "Sigma 12-24 mm f/4.5-5.6 EX DG Aspherical HSM",
+        "url": "https://www.lenstip.com/407-Sigma_12-24_mm_f_4.5-5.6_EX_DG_Aspherical_HSM-lens_specifications.html"
+      },
+      {
+        "id": 969,
+        "name": "Sigma 12-24 mm f/4.5-5.6 II DG HSM",
+        "url": "https://www.lenstip.com/969-Sigma_12-24_mm_f_4.5-5.6_II_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 961,
+        "name": "Sigma 120-300 mm f/2.8 APO EX DG OS HSM",
+        "url": "https://www.lenstip.com/961-Sigma_120-300_mm_f_2.8_APO_EX_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 421,
+        "name": "Sigma 120-300 mm f/2.8 DG EX APO IF HSM",
+        "url": "https://www.lenstip.com/421-Sigma_120-300_mm_f_2.8_DG_EX_APO_IF_HSM-lens_specifications.html"
+      },
+      {
+        "id": 681,
+        "name": "Sigma 120-400 mm f/4.5-5.6 APO DG OS HSM",
+        "url": "https://www.lenstip.com/681-Sigma_120-400_mm_f_4.5-5.6_APO_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 422,
+        "name": "Sigma 135-400 mm f/4.5-5.6 APO",
+        "url": "https://www.lenstip.com/422-Sigma_135-400_mm_f_4.5-5.6_APO-lens_specifications.html"
+      },
+      {
+        "id": 425,
+        "name": "Sigma 135-400 mm f/4.5-5.6 DG APO",
+        "url": "https://www.lenstip.com/425-Sigma_135-400_mm_f_4.5-5.6_DG_APO-lens_specifications.html"
+      },
+      {
+        "id": 396,
+        "name": "Sigma 14 mm f/2.8 EX Aspherical HSM",
+        "url": "https://www.lenstip.com/396-Sigma_14_mm_f_2.8_EX_Aspherical_HSM-lens_specifications.html"
+      },
+      {
+        "id": 397,
+        "name": "Sigma 15 mm f/2.8 EX DG Fisheye",
+        "url": "https://www.lenstip.com/397-Sigma_15_mm_f_2.8_EX_DG_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 408,
+        "name": "Sigma 15-30 mm f/3.5-4.5 EX DG Aspherical",
+        "url": "https://www.lenstip.com/408-Sigma_15-30_mm_f_3.5-4.5_EX_DG_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 962,
+        "name": "Sigma 150 mm f/2.8 APO EX DG OS HSM Macro",
+        "url": "https://www.lenstip.com/962-Sigma_150_mm_f_2.8_APO_EX_DG_OS_HSM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 402,
+        "name": "Sigma 150 mm f/2.8 EX DG HSM APO Macro",
+        "url": "https://www.lenstip.com/402-Sigma_150_mm_f_2.8_EX_DG_HSM_APO_Macro-lens_specifications.html"
+      },
+      {
+        "id": 682,
+        "name": "Sigma 150-500 mm f/5.0-6.3 APO DG OS HSM",
+        "url": "https://www.lenstip.com/682-Sigma_150-500_mm_f_5.0-6.3_APO_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 37,
+        "name": "Sigma 17-35 mm f/2.8-4 EX DG HSM Aspherical",
+        "url": "https://www.lenstip.com/37-Sigma_17-35_mm_f_2.8-4_EX_DG_HSM_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 908,
+        "name": "Sigma 17-50 mm f/2.8 EX DC OS HSM",
+        "url": "https://www.lenstip.com/908-Sigma_17-50_mm_f_2.8_EX_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 892,
+        "name": "Sigma 17-70 mm f/2.8-4.0 DC Macro OS HSM",
+        "url": "https://www.lenstip.com/892-Sigma_17-70_mm_f_2.8-4.0_DC_Macro_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 10,
+        "name": "Sigma 17-70 mm f/2.8-4.5 DC Macro",
+        "url": "https://www.lenstip.com/10-Sigma_17-70_mm_f_2.8-4.5_DC_Macro-lens_specifications.html"
+      },
+      {
+        "id": 423,
+        "name": "Sigma 170-500 mm f/5-6.3 APO DG Aspherical",
+        "url": "https://www.lenstip.com/423-Sigma_170-500_mm_f_5-6.3_APO_DG_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 7,
+        "name": "Sigma 18-125 mm f/3.5-5.6 DC ASP IF",
+        "url": "https://www.lenstip.com/7-Sigma_18-125_mm_f_3.5-5.6_DC_ASP_IF-lens_specifications.html"
+      },
+      {
+        "id": 680,
+        "name": "Sigma 18-125 mm f/3.8-5.6 DC OS HSM",
+        "url": "https://www.lenstip.com/680-Sigma_18-125_mm_f_3.8-5.6_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 391,
+        "name": "Sigma 18-200 mm f/3.5-6.3 DC",
+        "url": "https://www.lenstip.com/391-Sigma_18-200_mm_f_3.5-6.3_DC-lens_specifications.html"
+      },
+      {
+        "id": 394,
+        "name": "Sigma 18-200 mm f/3.5-6.3 DC OS",
+        "url": "https://www.lenstip.com/394-Sigma_18-200_mm_f_3.5-6.3_DC_OS-lens_specifications.html"
+      },
+      {
+        "id": 1008,
+        "name": "Sigma 18-200 mm f/3.5-6.3 II DC OS HSM",
+        "url": "https://www.lenstip.com/1008-Sigma_18-200_mm_f_3.5-6.3_II_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1053,
+        "name": "Sigma 18-250 mm f/3.5-6.3 DC MACRO OS HSM",
+        "url": "https://www.lenstip.com/1053-Sigma_18-250_mm_f_3.5-6.3_DC_MACRO_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 832,
+        "name": "Sigma 18-250 mm f/3.5-6.3 DC OS HSM",
+        "url": "https://www.lenstip.com/832-Sigma_18-250_mm_f_3.5-6.3_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 11,
+        "name": "Sigma 18-50 mm f/2.8 EX DC",
+        "url": "https://www.lenstip.com/11-Sigma_18-50_mm_f_2.8_EX_DC-lens_specifications.html"
+      },
+      {
+        "id": 618,
+        "name": "Sigma 18-50 mm f/2.8 EX DC Macro",
+        "url": "https://www.lenstip.com/618-Sigma_18-50_mm_f_2.8_EX_DC_Macro-lens_specifications.html"
+      },
+      {
+        "id": 848,
+        "name": "Sigma 18-50 mm f/2.8-4.5 DC OS HSM",
+        "url": "https://www.lenstip.com/848-Sigma_18-50_mm_f_2.8-4.5_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 390,
+        "name": "Sigma 18-50 mm f/3.5-5.6 DC",
+        "url": "https://www.lenstip.com/390-Sigma_18-50_mm_f_3.5-5.6_DC-lens_specifications.html"
+      },
+      {
+        "id": 800,
+        "name": "Sigma 18-50 mm f/3.5-5.6 DC HSM",
+        "url": "https://www.lenstip.com/800-Sigma_18-50_mm_f_3.5-5.6_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1023,
+        "name": "Sigma 180 mm f/2.8 APO Macro EX DG OS HSM",
+        "url": "https://www.lenstip.com/1023-Sigma_180_mm_f_2.8_APO_Macro_EX_DG_OS_HSM_-lens_specifications.html"
+      },
+      {
+        "id": 403,
+        "name": "Sigma 180 mm f/3.5 EX DG HSM Macro APO",
+        "url": "https://www.lenstip.com/403-Sigma_180_mm_f_3.5_EX_DG_HSM_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 1021,
+        "name": "Sigma 19 mm f/2.8 EX DN",
+        "url": "https://www.lenstip.com/1021-Sigma_19_mm_f_2.8_EX_DN_-lens_specifications.html"
+      },
+      {
+        "id": 398,
+        "name": "Sigma 20 mm f/1.8 EX DG Aspherical RF",
+        "url": "https://www.lenstip.com/398-Sigma_20_mm_f_1.8_EX_DG_Aspherical_RF-lens_specifications.html"
+      },
+      {
+        "id": 409,
+        "name": "Sigma 20-40 mm f/2.8 EX DG Aspherical",
+        "url": "https://www.lenstip.com/409-Sigma_20-40_mm_f_2.8_EX_DG_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 683,
+        "name": "Sigma 200-500 mm f/2.8 EX DG",
+        "url": "https://www.lenstip.com/683-Sigma_200-500_mm_f_2.8_EX_DG-lens_specifications.html"
+      },
+      {
+        "id": 23,
+        "name": "Sigma 24 mm f/1.8 EX DG Aspherical Macro",
+        "url": "https://www.lenstip.com/23-Sigma_24_mm_f_1.8_EX_DG_Aspherical_Macro-lens_specifications.html"
+      },
+      {
+        "id": 414,
+        "name": "Sigma 24-135 mm f/2.8-4.5 Aspherical IF",
+        "url": "https://www.lenstip.com/414-Sigma_24-135_mm_f_2.8-4.5_Aspherical_IF-lens_specifications.html"
+      },
+      {
+        "id": 27,
+        "name": "Sigma 24-60 mm f/2.8 EX DG",
+        "url": "https://www.lenstip.com/27-Sigma_24-60_mm_f_2.8_EX_DG-lens_specifications.html"
+      },
+      {
+        "id": 826,
+        "name": "Sigma 24-70 mm f/2.8 EX DG HSM",
+        "url": "https://www.lenstip.com/826-Sigma_24-70_mm_f_2.8_EX_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 410,
+        "name": "Sigma 24-70 mm f/2.8 EX DG Macro",
+        "url": "https://www.lenstip.com/410-Sigma_24-70_mm_f_2.8_EX_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 411,
+        "name": "Sigma 24-70 mm f/3.5-5.6 Aspherical HF",
+        "url": "https://www.lenstip.com/411-Sigma_24-70_mm_f_3.5-5.6_Aspherical_HF-lens_specifications.html"
+      },
+      {
+        "id": 2,
+        "name": "Sigma 28 mm f/1.8 EX DG Aspherical Macro",
+        "url": "https://www.lenstip.com/2-Sigma_28_mm_f_1.8_EX_DG_Aspherical_Macro-lens_specifications.html"
+      },
+      {
+        "id": 509,
+        "name": "Sigma 28-105 mm f/2.8-4 DG",
+        "url": "https://www.lenstip.com/509-Sigma_28-105_mm_f_2.8-4_DG-lens_specifications.html"
+      },
+      {
+        "id": 510,
+        "name": "Sigma 28-105 mm f/3.8-5.6 UC-III Aspherical IF",
+        "url": "https://www.lenstip.com/510-Sigma_28-105_mm_f_3.8-5.6_UC-III_Aspherical_IF-lens_specifications.html"
+      },
+      {
+        "id": 415,
+        "name": "Sigma 28-135 mm f/3.8-5.6 Aspherical IF Macro",
+        "url": "https://www.lenstip.com/415-Sigma_28-135_mm_f_3.8-5.6_Aspherical_IF_Macro-lens_specifications.html"
+      },
+      {
+        "id": 416,
+        "name": "Sigma 28-200 mm f/3.5-5.6 DG Macro",
+        "url": "https://www.lenstip.com/416-Sigma_28-200_mm_f_3.5-5.6_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 417,
+        "name": "Sigma 28-300 mm f/3.5-6.3 DG Macro",
+        "url": "https://www.lenstip.com/417-Sigma_28-300_mm_f_3.5-6.3_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 412,
+        "name": "Sigma 28-70 mm f/2.8 EX DG",
+        "url": "https://www.lenstip.com/412-Sigma_28-70_mm_f_2.8_EX_DG-lens_specifications.html"
+      },
+      {
+        "id": 413,
+        "name": "Sigma 28-70 mm f/2.8-4 DG",
+        "url": "https://www.lenstip.com/413-Sigma_28-70_mm_f_2.8-4_DG-lens_specifications.html"
+      },
+      {
+        "id": 6,
+        "name": "Sigma 30 mm f/1.4 EX DC HSM",
+        "url": "https://www.lenstip.com/6-Sigma_30_mm_f_1.4_EX_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1022,
+        "name": "Sigma 30 mm f/2.8 EX DN",
+        "url": "https://www.lenstip.com/1022-Sigma_30_mm_f_2.8_EX_DN_-lens_specifications.html"
+      },
+      {
+        "id": 404,
+        "name": "Sigma 300 mm f/2.8 EX DG HSM APO",
+        "url": "https://www.lenstip.com/404-Sigma_300_mm_f_2.8_EX_DG_HSM_APO-lens_specifications.html"
+      },
+      {
+        "id": 424,
+        "name": "Sigma 300-800 mm f/5.6 EX DG IF HSM APO",
+        "url": "https://www.lenstip.com/424-Sigma_300-800_mm_f_5.6_EX_DG_IF_HSM_APO_-lens_specifications.html"
+      },
+      {
+        "id": 662,
+        "name": "Sigma 4.5 mm f/2.8 EX DC CIRCULAR FISHEYE HSM",
+        "url": "https://www.lenstip.com/662-Sigma_4.5_mm_f_2.8_EX_DC_CIRCULAR_FISHEYE_HSM-lens_specifications.html"
+      },
+      {
+        "id": 786,
+        "name": "Sigma 50 mm f/1.4 EX DG HSM",
+        "url": "https://www.lenstip.com/786-Sigma_50_mm_f_1.4_EX_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 401,
+        "name": "Sigma 50 mm f/2.8 EX DG Macro",
+        "url": "https://www.lenstip.com/401-Sigma_50_mm_f_2.8_EX_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 142,
+        "name": "Sigma 50-150 mm f/2.8 APO EX DC HSM",
+        "url": "https://www.lenstip.com/142-Sigma_50-150_mm_f_2.8_APO_EX_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 971,
+        "name": "Sigma 50-150 mm f/2.8 APO EX DC OS HSM",
+        "url": "https://www.lenstip.com/971-Sigma_50-150_mm_f_2.8_APO_EX_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 685,
+        "name": "Sigma 50-150 mm f/2.8 II APO EX DC HSM",
+        "url": "https://www.lenstip.com/685-Sigma_50-150_mm_f_2.8_II_APO_EX_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 849,
+        "name": "Sigma 50-200 mm f/4-5.6 DC OS HSM",
+        "url": "https://www.lenstip.com/849-Sigma_50-200_mm_f_4-5.6_DC_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 418,
+        "name": "Sigma 50-500 mm f/4-6.3 DG EX APO RF HSM",
+        "url": "https://www.lenstip.com/418-Sigma_50-500_mm_f_4-6.3_DG_EX_APO_RF_HSM-lens_specifications.html"
+      },
+      {
+        "id": 909,
+        "name": "Sigma 50-500 mm f/4.5-6.3 APO DG OS HSM",
+        "url": "https://www.lenstip.com/909-Sigma_50-500_mm_f_4.5-6.3_APO_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 405,
+        "name": "Sigma 500 mm F4.5 EX DG HSM APO",
+        "url": "https://www.lenstip.com/405-Sigma_500_mm_F4.5_EX_DG_HSM_APO-lens_specifications.html"
+      },
+      {
+        "id": 18,
+        "name": "Sigma 55-200 mm f/4-5.6 DC",
+        "url": "https://www.lenstip.com/18-Sigma_55-200_mm_f_4-5.6_DC-lens_specifications.html"
+      },
+      {
+        "id": 801,
+        "name": "Sigma 55-200 mm f/4-5.6 DC HSM",
+        "url": "https://www.lenstip.com/801-Sigma_55-200_mm_f_4-5.6_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 144,
+        "name": "Sigma 70 mm f/2.8 EX DG Macro",
+        "url": "https://www.lenstip.com/144-Sigma_70_mm_f_2.8_EX_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 42,
+        "name": "Sigma 70-200 mm f/2.8 EX APO DG HSM Macro",
+        "url": "https://www.lenstip.com/42-Sigma_70-200_mm_f_2.8_EX_APO_DG_HSM_Macro-lens_specifications.html"
+      },
+      {
+        "id": 911,
+        "name": "Sigma 70-200 mm f/2.8 EX DG APO OS HSM",
+        "url": "https://www.lenstip.com/911-Sigma_70-200_mm_f_2.8_EX_DG_APO_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 511,
+        "name": "Sigma 70-200 mm f/2.8 EX DG HSM APO",
+        "url": "https://www.lenstip.com/511-Sigma_70-200_mm_f_2.8_EX_DG_HSM_APO-lens_specifications.html"
+      },
+      {
+        "id": 684,
+        "name": "Sigma 70-200 mm f/2.8 II EX APO DG Macro HSM",
+        "url": "https://www.lenstip.com/684-Sigma_70-200_mm_f_2.8_II_EX_APO_DG_Macro_HSM-lens_specifications.html"
+      },
+      {
+        "id": 8,
+        "name": "Sigma 70-300 mm f/4-5.6 APO DG Macro",
+        "url": "https://www.lenstip.com/8-Sigma_70-300_mm_f_4-5.6_APO_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 512,
+        "name": "Sigma 70-300 mm f/4-5.6 DG Macro",
+        "url": "https://www.lenstip.com/512-Sigma_70-300_mm_f_4-5.6_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 883,
+        "name": "Sigma 70-300 mm f/4-5.6 DG OS",
+        "url": "https://www.lenstip.com/883-Sigma_70-300_mm_f_4-5.6_DG_OS-lens_specifications.html"
+      },
+      {
+        "id": 399,
+        "name": "Sigma 8 mm f/3.5 EX DG Fisheye",
+        "url": "https://www.lenstip.com/399-Sigma_8_mm_f_3.5_EX_DG_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 395,
+        "name": "Sigma 8 mm f/4 EX DG Fisheye",
+        "url": "https://www.lenstip.com/395-Sigma_8_mm_f_4_EX_DG_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 912,
+        "name": "Sigma 8-16 mm f/4.5-5.6 DC HSM",
+        "url": "https://www.lenstip.com/912-Sigma_8-16_mm_f_4.5-5.6_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 419,
+        "name": "Sigma 80-400 mm f/4-5.6 OS EX DG APO",
+        "url": "https://www.lenstip.com/419-Sigma_80-400_mm_f_4-5.6_OS_EX_DG_APO-lens_specifications.html"
+      },
+      {
+        "id": 406,
+        "name": "Sigma 800 mm f/5.6 EX DG HSM APO",
+        "url": "https://www.lenstip.com/406-Sigma_800_mm_f_5.6_EX_DG_HSM_APO-lens_specifications.html"
+      },
+      {
+        "id": 910,
+        "name": "Sigma 85 mm f/1.4 EX DG HSM",
+        "url": "https://www.lenstip.com/910-Sigma_85_mm_f_1.4_EX_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1517,
+        "name": "Sigma A 105 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1517-Sigma_A_105_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1750,
+        "name": "Sigma A 105 mm f/2.8 DG DN Macro",
+        "url": "https://www.lenstip.com/1750-Sigma_A_105_mm_f_2.8_DG_DN_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1403,
+        "name": "Sigma A 12-24 mm f/4 DG HSM",
+        "url": "https://www.lenstip.com/1403-Sigma_A_12-24_mm_f_4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2262,
+        "name": "Sigma A 135 mm f/1.4 DG",
+        "url": "https://www.lenstip.com/2262-Sigma_A_135_mm_f_1.4_DG-lens_specifications.html"
+      },
+      {
+        "id": 1449,
+        "name": "Sigma A 135 mm f/1.8 DG HSM",
+        "url": "https://www.lenstip.com/1449-Sigma_A_135_mm_f_1.8_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2058,
+        "name": "Sigma A 14 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/2058-Sigma_A_14_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1448,
+        "name": "Sigma A 14 mm f/1.8 DG HSM",
+        "url": "https://www.lenstip.com/1448-Sigma_A_14_mm_f_1.8_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1631,
+        "name": "Sigma A 14-24 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1631-Sigma_A_14-24_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1507,
+        "name": "Sigma A 14-24 mm f/2.8 DG HSM",
+        "url": "https://www.lenstip.com/1507-Sigma_A_14-24_mm_f_2.8_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2113,
+        "name": "Sigma A 15 mm f/1.4 DG DN Diagonal fisheye",
+        "url": "https://www.lenstip.com/2113-Sigma_A_15_mm_f_1.4_DG_DN_Diagonal_fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2238,
+        "name": "Sigma A 17-40 mm f/1.8 DC",
+        "url": "https://www.lenstip.com/2238-Sigma_A_17-40_mm_f_1.8_DC-lens_specifications.html"
+      },
+      {
+        "id": 1118,
+        "name": "Sigma A 18-35 mm f/1.8 DC HSM",
+        "url": "https://www.lenstip.com/1118-Sigma_A_18-35_mm_f_1.8_DC_HSM_-lens_specifications.html"
+      },
+      {
+        "id": 1107,
+        "name": "Sigma A 19 mm f/2.8 DN",
+        "url": "https://www.lenstip.com/1107-Sigma_A_19_mm_f_2.8_DN-lens_specifications.html"
+      },
+      {
+        "id": 1967,
+        "name": "Sigma A 20 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/1967-Sigma_A_20_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1326,
+        "name": "Sigma A 20 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1326-Sigma_A_20_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1968,
+        "name": "Sigma A 24 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/1968-Sigma_A_24_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1274,
+        "name": "Sigma A 24 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1274-Sigma_A_24_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1154,
+        "name": "Sigma A 24-105 mm f/4 DG OS HSM",
+        "url": "https://www.lenstip.com/1154-Sigma_A_24-105_mm_f_4_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1295,
+        "name": "Sigma A 24-35 mm f/2.0 DG HSM",
+        "url": "https://www.lenstip.com/1295-Sigma_A_24-35_mm_f_2.0_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1661,
+        "name": "Sigma A 24-70 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1661-Sigma_A_24-70_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2131,
+        "name": "Sigma A 24-70 mm f/2.8 DG DN II",
+        "url": "https://www.lenstip.com/2131-Sigma_A_24-70_mm_f_2.8_DG_DN_II-lens_specifications.html"
+      },
+      {
+        "id": 1447,
+        "name": "Sigma A 24-70 mm f/2.8 DG OS HSM",
+        "url": "https://www.lenstip.com/1447-Sigma_A_24-70_mm_f_2.8_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1569,
+        "name": "Sigma A 28 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1569-Sigma_A_28_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2162,
+        "name": "Sigma A 28-105 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/2162-Sigma_A_28-105_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2135,
+        "name": "Sigma A 28-45 mm f/1.8 DG DN",
+        "url": "https://www.lenstip.com/2135-Sigma_A_28-45_mm_f_1.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1105,
+        "name": "Sigma A 30 mm f/1.4 DC HSM",
+        "url": "https://www.lenstip.com/1105-Sigma_A_30_mm_f_1.4_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1106,
+        "name": "Sigma A 30 mm f/2.8 DN",
+        "url": "https://www.lenstip.com/1106-Sigma_A_30_mm_f_2.8_DN-lens_specifications.html"
+      },
+      {
+        "id": 1632,
+        "name": "Sigma A 35 mm f/1.2 DG DN",
+        "url": "https://www.lenstip.com/1632-Sigma_A_35_mm_f_1.2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2261,
+        "name": "Sigma A 35 mm f/1.2 DG II",
+        "url": "https://www.lenstip.com/2261-Sigma_A_35_mm_f_1.2_DG_II-lens_specifications.html"
+      },
+      {
+        "id": 1838,
+        "name": "Sigma A 35 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/1838-Sigma_A_35_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1082,
+        "name": "Sigma A 35 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1082-Sigma_A_35_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2315,
+        "name": "Sigma A 35 mm f/1.4 DG II",
+        "url": "https://www.lenstip.com/2315-Sigma_A_35_mm_f_1.4_DG_II-lens_specifications.html"
+      },
+      {
+        "id": 1570,
+        "name": "Sigma A 40 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1570-Sigma_A_40_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2120,
+        "name": "Sigma A 50 mm f/1.2 DG DN",
+        "url": "https://www.lenstip.com/2120-Sigma_A_50_mm_f_1.2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2020,
+        "name": "Sigma A 50 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/2020-Sigma_A_50_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1172,
+        "name": "Sigma A 50 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1172-Sigma_A_50_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1352,
+        "name": "Sigma A 50-100 mm f/1.8 DC HSM",
+        "url": "https://www.lenstip.com/1352-Sigma_A_50-100_mm_f_1.8_DC_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1104,
+        "name": "Sigma A 60 mm f/2.8 DN",
+        "url": "https://www.lenstip.com/1104-Sigma_A_60_mm_f_2.8_DN-lens_specifications.html"
+      },
+      {
+        "id": 1518,
+        "name": "Sigma A 70 mm f/2.8 DG Macro",
+        "url": "https://www.lenstip.com/1518-Sigma_A_70_mm_f_2.8_DG_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1722,
+        "name": "Sigma A 85 mm f/1.4 DG DN",
+        "url": "https://www.lenstip.com/1722-Sigma_A_85_mm_f_1.4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1401,
+        "name": "Sigma A 85 mm f/1.4 DG HSM",
+        "url": "https://www.lenstip.com/1401-Sigma_A_85_mm_f_1.4_DG_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2082,
+        "name": "Sigma C 10-18 mm f/2.8 DC DN",
+        "url": "https://www.lenstip.com/2082-Sigma_C_10-18_mm_f_2.8_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1703,
+        "name": "Sigma C 100-400 mm f/5-6.3 DG DN OS",
+        "url": "https://www.lenstip.com/1703-Sigma_C_100-400_mm_f_5-6.3_DG_DN_OS-lens_specifications.html"
+      },
+      {
+        "id": 1446,
+        "name": "Sigma C 100-400 mm f/5-6.3 DG OS HSM",
+        "url": "https://www.lenstip.com/1446-Sigma_C_100-400_mm_f_5-6.3_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2254,
+        "name": "Sigma C 12 mm f/1.4 DC",
+        "url": "https://www.lenstip.com/2254-Sigma_C_12_mm_f_1.4_DC-lens_specifications.html"
+      },
+      {
+        "id": 2314,
+        "name": "Sigma C 15 mm f/1.4 DC",
+        "url": "https://www.lenstip.com/2314-Sigma_C_15_mm_f_1.4_DC-lens_specifications.html"
+      },
+      {
+        "id": 1227,
+        "name": "Sigma C 150-600 mm f/5-6.3 DG OS HSM",
+        "url": "https://www.lenstip.com/1227-Sigma_C_150-600_mm_f_5-6.3_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1490,
+        "name": "Sigma C 16 mm f/1.4 DC DN",
+        "url": "https://www.lenstip.com/1490-Sigma_C_16_mm_f_1.4_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1943,
+        "name": "Sigma C 16-28 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1943-Sigma_C_16-28_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2208,
+        "name": "Sigma C 16-300 mm f/3.5-6.7 DC OS",
+        "url": "https://www.lenstip.com/2208-Sigma_C_16-300_mm_f_3.5-6.7_DC_OS-lens_specifications.html"
+      },
+      {
+        "id": 2041,
+        "name": "Sigma C 17 mm f/4 DG DN",
+        "url": "https://www.lenstip.com/2041-Sigma_C_17_mm_f_4_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1083,
+        "name": "Sigma C 17-70 mm f/2.8-4.0 DC Macro OS HSM",
+        "url": "https://www.lenstip.com/1083-Sigma_C_17-70_mm_f_2.8-4.0_DC_Macro_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1171,
+        "name": "Sigma C 18-200 mm f/3.5-6.3 DC Macro OS HSM",
+        "url": "https://www.lenstip.com/1171-Sigma_C_18-200_mm_f_3.5-6.3_DC_Macro_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1220,
+        "name": "Sigma C 18-300 mm f/3.5-6.3 DC MACRO OS HSM",
+        "url": "https://www.lenstip.com/1220-Sigma_C_18-300_mm_f_3.5-6.3_DC_MACRO_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1890,
+        "name": "Sigma C 18-50 mm f/2.8 DC DN",
+        "url": "https://www.lenstip.com/1890-Sigma_C_18-50_mm_f_2.8_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1916,
+        "name": "Sigma C 20 mm f/2 DG DN",
+        "url": "https://www.lenstip.com/1916-Sigma_C_20_mm_f_2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2260,
+        "name": "Sigma C 20-200 mm f/3.5-6.3 DG",
+        "url": "https://www.lenstip.com/2260-Sigma_C_20-200_mm_f_3.5-6.3_DG-lens_specifications.html"
+      },
+      {
+        "id": 2040,
+        "name": "Sigma C 23 mm f/1.4 DC DN",
+        "url": "https://www.lenstip.com/2040-Sigma_C_23_mm_f_1.4_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1868,
+        "name": "Sigma C 24 mm f/2 DG DN",
+        "url": "https://www.lenstip.com/1868-Sigma_C_24_mm_f_2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1779,
+        "name": "Sigma C 24 mm f/3.5 DG DN",
+        "url": "https://www.lenstip.com/1779-Sigma_C_24_mm_f_3.5_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1812,
+        "name": "Sigma C 28-70 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1812-Sigma_C_28-70_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1353,
+        "name": "Sigma C 30 mm f/1.4 DC DN",
+        "url": "https://www.lenstip.com/1353-Sigma_C_30_mm_f_1.4_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1774,
+        "name": "Sigma C 35 mm f/2 DG DN",
+        "url": "https://www.lenstip.com/1774-Sigma_C_35_mm_f_2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1633,
+        "name": "Sigma C 45 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1633-Sigma_C_45_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2042,
+        "name": "Sigma C 50 mm f/2 DG DN",
+        "url": "https://www.lenstip.com/2042-Sigma_C_50_mm_f_2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1571,
+        "name": "Sigma C 56 mm f/1.4 DC DN",
+        "url": "https://www.lenstip.com/1571-Sigma_C_56_mm_f_1.4_DC_DN-lens_specifications.html"
+      },
+      {
+        "id": 1776,
+        "name": "Sigma C 65 mm f/2 DG DN",
+        "url": "https://www.lenstip.com/1776-Sigma_C_65_mm_f_2_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 1869,
+        "name": "Sigma C 90 mm f/2.8 DG DN",
+        "url": "https://www.lenstip.com/1869-Sigma_C_90_mm_f_2.8_DG_DN-lens_specifications.html"
+      },
+      {
+        "id": 2209,
+        "name": "Sigma S  300-600mm f/4 DG OS",
+        "url": "https://www.lenstip.com/2209-Sigma_S__300-600mm_f_4_DG_OS-lens_specifications.html"
+      },
+      {
+        "id": 1084,
+        "name": "Sigma S 120-300 mm f/2.8 APO EX DG OS HSM",
+        "url": "https://www.lenstip.com/1084-Sigma_S_120-300_mm_f_2.8_APO_EX_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 1861,
+        "name": "Sigma S 150-600 mm f/5-6.3 DG DN OS",
+        "url": "https://www.lenstip.com/1861-Sigma_S_150-600_mm_f_5-6.3_DG_DN_OS-lens_specifications.html"
+      },
+      {
+        "id": 1221,
+        "name": "Sigma S 150-600 mm f/5-6.3 DG OS HSM",
+        "url": "https://www.lenstip.com/1221-Sigma_S_150-600_mm_f_5-6.3_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2253,
+        "name": "Sigma S 200 mm f/2 DG OS",
+        "url": "https://www.lenstip.com/2253-Sigma_S_200_mm_f_2_DG_OS-lens_specifications.html"
+      },
+      {
+        "id": 1402,
+        "name": "Sigma S 500 mm f/4 DG OS HSM",
+        "url": "https://www.lenstip.com/1402-Sigma_S_500_mm_f_4_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2114,
+        "name": "Sigma S 500 mm f/5.6 DG DN OS",
+        "url": "https://www.lenstip.com/2114-Sigma_S_500_mm_f_5.6_DG_DN_OS-lens_specifications.html"
+      },
+      {
+        "id": 2015,
+        "name": "Sigma S 60-600 mm f/4.5-6.3 DG DN OS",
+        "url": "https://www.lenstip.com/2015-Sigma_S_60-600_mm_f_4.5-6.3_DG_DN_OS-lens_specifications.html"
+      },
+      {
+        "id": 1573,
+        "name": "Sigma S 60-600 mm f/4.5-6.3 DG OS HSM",
+        "url": "https://www.lenstip.com/1573-Sigma_S_60-600_mm_f_4.5-6.3_DG_OS_HSM-lens_specifications.html"
+      },
+      {
+        "id": 2096,
+        "name": "Sigma S 70-200 mm f/2.8 DG DN OS",
+        "url": "https://www.lenstip.com/2096-Sigma_S_70-200_mm_f_2.8_DG_DN_OS-lens_specifications.html"
+      },
+      {
+        "id": 1572,
+        "name": "Sigma S 70-200 mm f/2.8 DG OS HSM",
+        "url": "https://www.lenstip.com/1572-Sigma_S_70-200_mm_f_2.8_DG_OS_HSM-lens_specifications.html"
+      }
+    ],
+    "Sirui": [
+      {
+        "id": 1781,
+        "name": "Sirui 24 mm f/2.8 Anamorphic 1.33x",
+        "url": "https://www.lenstip.com/1781-Sirui_24_mm_f_2.8_Anamorphic_1.33x-lens_specifications.html"
+      },
+      {
+        "id": 1717,
+        "name": "Sirui 35 mm f/1.8 Anamorphic 1.33x",
+        "url": "https://www.lenstip.com/1717-Sirui_35_mm_f_1.8_Anamorphic_1.33x-lens_specifications.html"
+      },
+      {
+        "id": 1881,
+        "name": "Sirui 50 mm T2.9 Anamorphic 1.6x",
+        "url": "https://www.lenstip.com/1881-Sirui_50_mm_T2.9_Anamorphic_1.6x-lens_specifications.html"
+      },
+      {
+        "id": 1716,
+        "name": "Sirui 50 mm f/1.8 Anamorphic 1.33x",
+        "url": "https://www.lenstip.com/1716-Sirui_50_mm_f_1.8_Anamorphic_1.33x-lens_specifications.html"
+      },
+      {
+        "id": 1929,
+        "name": "Sirui 75 mm T2.9 Anamorphic 1.6x",
+        "url": "https://www.lenstip.com/1929-Sirui_75_mm_T2.9_Anamorphic_1.6x-lens_specifications.html"
+      },
+      {
+        "id": 1845,
+        "name": "Sirui 75 mm f/1.8 Anamorphic 1.33x",
+        "url": "https://www.lenstip.com/1845-Sirui_75_mm_f_1.8_Anamorphic_1.33x-lens_specifications.html"
+      },
+      {
+        "id": 2272,
+        "name": "Sirui Aurora 35 mm f/1.4",
+        "url": "https://www.lenstip.com/2272-Sirui_Aurora_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2178,
+        "name": "Sirui Aurora 85 mm f/1.4",
+        "url": "https://www.lenstip.com/2178-Sirui_Aurora_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2142,
+        "name": "Sirui Sniper 16 mm f/1.2",
+        "url": "https://www.lenstip.com/2142-Sirui_Sniper_16_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2102,
+        "name": "Sirui Sniper 23 mm f/1.2",
+        "url": "https://www.lenstip.com/2102-Sirui_Sniper_23_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2103,
+        "name": "Sirui Sniper 33 mm f/1.2",
+        "url": "https://www.lenstip.com/2103-Sirui_Sniper_33_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2104,
+        "name": "Sirui Sniper 56 mm f/1.2",
+        "url": "https://www.lenstip.com/2104-Sirui_Sniper_56_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2143,
+        "name": "Sirui Sniper 75 mm f/1.2",
+        "url": "https://www.lenstip.com/2143-Sirui_Sniper_75_mm_f_1.2-lens_specifications.html"
+      }
+    ],
+    "SLR Magic": [
+      {
+        "id": 1219,
+        "name": "SLR Magic 10 mm T2.1 HyperPrime Cine",
+        "url": "https://www.lenstip.com/1219-SLR_Magic_10_mm_T2.1_HyperPrime_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1167,
+        "name": "SLR Magic 17 mm T1.6",
+        "url": "https://www.lenstip.com/1167-SLR_Magic_17_mm_T1.6-lens_specifications.html"
+      },
+      {
+        "id": 1233,
+        "name": "SLR Magic 50 mm T2.1 APO HyperPrime Cine",
+        "url": "https://www.lenstip.com/1233-SLR_Magic_50_mm_T2.1_APO_HyperPrime_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1452,
+        "name": "SLR Magic 8 mm f/4",
+        "url": "https://www.lenstip.com/1452-SLR_Magic_8_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1013,
+        "name": "SLR Magic HyperPrime 12 mm f/1.6",
+        "url": "https://www.lenstip.com/1013-SLR_Magic_HyperPrime_12_mm_f_1.6-lens_specifications.html"
+      },
+      {
+        "id": 1016,
+        "name": "SLR Magic HyperPrime 23 mm f/1.7",
+        "url": "https://www.lenstip.com/1016-SLR_Magic_HyperPrime_23_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 1753,
+        "name": "SLR Magic MicroPrime CINE 17 mm T1.5",
+        "url": "https://www.lenstip.com/1753-SLR_Magic_MicroPrime_CINE_17_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 1754,
+        "name": "SLR Magic MicroPrime CINE 35 mm T1.5",
+        "url": "https://www.lenstip.com/1754-SLR_Magic_MicroPrime_CINE_35_mm_T1.5-lens_specifications.html"
+      },
+      {
+        "id": 906,
+        "name": "SLR Magic Noktor HyperPrime 50 mm f/0.95",
+        "url": "https://www.lenstip.com/906-SLR_Magic_Noktor_HyperPrime_50_mm_f_0.95-lens_specifications.html"
+      }
+    ],
+    "Sony": [
+      {
+        "id": 499,
+        "name": "Sony 100 mm f.2.8 Macro",
+        "url": "https://www.lenstip.com/499-Sony_100_mm_f.2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 500,
+        "name": "Sony 135 mm f/2.8",
+        "url": "https://www.lenstip.com/500-Sony_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 493,
+        "name": "Sony 16 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/493-Sony_16_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1643,
+        "name": "Sony 16-55 mm f/2.8 G",
+        "url": "https://www.lenstip.com/1643-Sony_16-55_mm_f_2.8_G-lens_specifications.html"
+      },
+      {
+        "id": 494,
+        "name": "Sony 20 mm f/2.8",
+        "url": "https://www.lenstip.com/494-Sony_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 505,
+        "name": "Sony 24-105 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/505-Sony_24-105_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 495,
+        "name": "Sony 28 mm f/2.8",
+        "url": "https://www.lenstip.com/495-Sony_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 876,
+        "name": "Sony 28-75 mm f/2.8 SAM",
+        "url": "https://www.lenstip.com/876-Sony_28-75_mm_f_2.8_SAM-lens_specifications.html"
+      },
+      {
+        "id": 501,
+        "name": "Sony 300 mm f/2.8G",
+        "url": "https://www.lenstip.com/501-Sony_300_mm_f_2.8G-lens_specifications.html"
+      },
+      {
+        "id": 1072,
+        "name": "Sony 300 mm f/2.8G SSM II",
+        "url": "https://www.lenstip.com/1072-Sony_300_mm_f_2.8G_SSM_II-lens_specifications.html"
+      },
+      {
+        "id": 496,
+        "name": "Sony 35 mm f/1.4G",
+        "url": "https://www.lenstip.com/496-Sony_35_mm_f_1.4G-lens_specifications.html"
+      },
+      {
+        "id": 497,
+        "name": "Sony 50 mm f/1.4",
+        "url": "https://www.lenstip.com/497-Sony_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 498,
+        "name": "Sony 50 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/498-Sony_50_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1036,
+        "name": "Sony 500 mm f/4 G SSM",
+        "url": "https://www.lenstip.com/1036-Sony_500_mm_f_4_G_SSM_-lens_specifications.html"
+      },
+      {
+        "id": 506,
+        "name": "Sony 70-200 mm f/2.8G",
+        "url": "https://www.lenstip.com/506-Sony_70-200_mm_f_2.8G-lens_specifications.html"
+      },
+      {
+        "id": 1144,
+        "name": "Sony 70-200 mm f/2.8G SSM II",
+        "url": "https://www.lenstip.com/1144-Sony_70-200_mm_f_2.8G_SSM_II-lens_specifications.html"
+      },
+      {
+        "id": 667,
+        "name": "Sony 70-300 mm f/4.5-5.6 G SSM",
+        "url": "https://www.lenstip.com/667-Sony_70-300_mm_f_4.5-5.6_G_SSM-lens_specifications.html"
+      },
+      {
+        "id": 1644,
+        "name": "Sony 70-350 mm f/4.5-6.3 G OSS",
+        "url": "https://www.lenstip.com/1644-Sony_70-350_mm_f_4.5-6.3_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 805,
+        "name": "Sony 70-400 mm f/4-5.6 G SSM",
+        "url": "https://www.lenstip.com/805-Sony_70-400_mm_f_4-5.6_G_SSM-lens_specifications.html"
+      },
+      {
+        "id": 1111,
+        "name": "Sony 70-400 mm f/4-5.6 G SSM II",
+        "url": "https://www.lenstip.com/1111-Sony_70-400_mm_f_4-5.6_G_SSM_II-lens_specifications.html"
+      },
+      {
+        "id": 507,
+        "name": "Sony 75-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/507-Sony_75-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 930,
+        "name": "Sony 85 mm f/2.8 SAM",
+        "url": "https://www.lenstip.com/930-Sony_85_mm_f_2.8_SAM-lens_specifications.html"
+      },
+      {
+        "id": 1278,
+        "name": "Sony Carl Zeiss Distagon T FE 35 mm f/1.4 ZA",
+        "url": "https://www.lenstip.com/1278-Sony_Carl_Zeiss_Distagon_T_FE_35_mm_f_1.4_ZA-lens_specifications.html"
+      },
+      {
+        "id": 928,
+        "name": "Sony Carl Zeiss Distagon T* 24 mm f/2 ZA SSM",
+        "url": "https://www.lenstip.com/928-Sony_Carl_Zeiss_Distagon_T*_24_mm_f_2_ZA_SSM-lens_specifications.html"
+      },
+      {
+        "id": 1112,
+        "name": "Sony Carl Zeiss Planar T* 50 mm f/1.4 ZA SSM",
+        "url": "https://www.lenstip.com/1112-Sony_Carl_Zeiss_Planar_T*_50_mm_f_1.4_ZA_SSM-lens_specifications.html"
+      },
+      {
+        "id": 490,
+        "name": "Sony Carl Zeiss Planar T* 85 mm f/1.4",
+        "url": "https://www.lenstip.com/490-Sony_Carl_Zeiss_Planar_T*_85_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1369,
+        "name": "Sony Carl Zeiss Planar T* FE 50 mm f/1.4 ZA",
+        "url": "https://www.lenstip.com/1369-Sony_Carl_Zeiss_Planar_T*_FE_50_mm_f_1.4_ZA-lens_specifications.html"
+      },
+      {
+        "id": 491,
+        "name": "Sony Carl Zeiss Sonnar T* 135 mm f/1.8",
+        "url": "https://www.lenstip.com/491-Sony_Carl_Zeiss_Sonnar_T*_135_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 998,
+        "name": "Sony Carl Zeiss Sonnar T* E 24 mm f/1.8 ZA",
+        "url": "https://www.lenstip.com/998-Sony_Carl_Zeiss_Sonnar_T*_E_24_mm_f_1.8_ZA-lens_specifications.html"
+      },
+      {
+        "id": 1145,
+        "name": "Sony Carl Zeiss Sonnar T* E 35 mm f/1.8 ZA",
+        "url": "https://www.lenstip.com/1145-Sony_Carl_Zeiss_Sonnar_T*_E_35_mm_f_1.8_ZA-lens_specifications.html"
+      },
+      {
+        "id": 1155,
+        "name": "Sony Carl Zeiss Sonnar T* FE 35 mm f/2.8 ZA",
+        "url": "https://www.lenstip.com/1155-Sony_Carl_Zeiss_Sonnar_T*_FE_35_mm_f_2.8_ZA-lens_specifications.html"
+      },
+      {
+        "id": 1156,
+        "name": "Sony Carl Zeiss Sonnar T* FE 55 mm f/1.8 ZA",
+        "url": "https://www.lenstip.com/1156-Sony_Carl_Zeiss_Sonnar_T*_FE_55_mm_f_1.8_ZA-lens_specifications.html"
+      },
+      {
+        "id": 806,
+        "name": "Sony Carl Zeiss Vario Sonnar 16-35 mm f/2.8 T* SSM",
+        "url": "https://www.lenstip.com/806-Sony_Carl_Zeiss_Vario_Sonnar_16-35_mm_f_2.8_T*_SSM-lens_specifications.html"
+      },
+      {
+        "id": 668,
+        "name": "Sony Carl Zeiss Vario Sonnar 24-70 mm f/2.8 T* SSM",
+        "url": "https://www.lenstip.com/668-Sony_Carl_Zeiss_Vario_Sonnar_24-70_mm_f_2.8_T*_SSM-lens_specifications.html"
+      },
+      {
+        "id": 1289,
+        "name": "Sony Carl Zeiss Vario-Sonnar 16-35 mm f/2.8 T* ZA SSM II",
+        "url": "https://www.lenstip.com/1289-Sony_Carl_Zeiss_Vario-Sonnar_16-35_mm_f_2.8_T*_ZA_SSM_II-lens_specifications.html"
+      },
+      {
+        "id": 1288,
+        "name": "Sony Carl Zeiss Vario-Sonnar 24-70 mm f/2.8 T* ZA SSM II",
+        "url": "https://www.lenstip.com/1288-Sony_Carl_Zeiss_Vario-Sonnar_24-70_mm_f_2.8_T*_ZA_SSM_II-lens_specifications.html"
+      },
+      {
+        "id": 492,
+        "name": "Sony Carl Zeiss Vario-Sonnar T* DT 16-80 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/492-Sony_Carl_Zeiss_Vario-Sonnar_T*_DT_16-80_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 1235,
+        "name": "Sony Carl Zeiss Vario-Tessar T FE 16-35 mm f/4 ZA OSS",
+        "url": "https://www.lenstip.com/1235-Sony_Carl_Zeiss_Vario-Tessar_T_FE_16-35_mm_f_4_ZA_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1136,
+        "name": "Sony Carl Zeiss Vario-Tessar T* E 16-70 mm f/4 ZA OSS",
+        "url": "https://www.lenstip.com/1136-Sony_Carl_Zeiss_Vario-Tessar_T*_E_16-70_mm_f_4_ZA_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1157,
+        "name": "Sony Carl Zeiss Vario-Tessar T* FE 24-70 mm f/4 ZA OSS",
+        "url": "https://www.lenstip.com/1157-Sony_Carl_Zeiss_Vario-Tessar_T*_FE_24-70_mm_f_4_ZA_OSS-lens_specifications.html"
+      },
+      {
+        "id": 503,
+        "name": "Sony DT 11-18 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/503-Sony_DT_11-18_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 650,
+        "name": "Sony DT 16-105 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/650-Sony_DT_16-105_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 997,
+        "name": "Sony DT 16-50 mm f/2.8 SSM",
+        "url": "https://www.lenstip.com/997-Sony_DT_16-50_mm_f_2.8_SSM-lens_specifications.html"
+      },
+      {
+        "id": 1045,
+        "name": "Sony DT 18-135 mm f/3.5-5.6 SAM",
+        "url": "https://www.lenstip.com/1045-Sony_DT_18-135_mm_f_3.5-5.6_SAM-lens_specifications.html"
+      },
+      {
+        "id": 504,
+        "name": "Sony DT 18-200 mm f/3.5-6.3",
+        "url": "https://www.lenstip.com/504-Sony_DT_18-200_mm_f_3.5-6.3-lens_specifications.html"
+      },
+      {
+        "id": 651,
+        "name": "Sony DT 18-250 mm f/3.5-6.3",
+        "url": "https://www.lenstip.com/651-Sony_DT_18-250_mm_f_3.5-6.3-lens_specifications.html"
+      },
+      {
+        "id": 861,
+        "name": "Sony DT 18-55 mm f/3.5-5.6 SAM",
+        "url": "https://www.lenstip.com/861-Sony_DT_18-55_mm_f_3.5-5.6_SAM-lens_specifications.html"
+      },
+      {
+        "id": 1113,
+        "name": "Sony DT 18-55 mm f/3.5-5.6 SAM II",
+        "url": "https://www.lenstip.com/1113-Sony_DT_18-55_mm_f_3.5-5.6_SAM_II-lens_specifications.html"
+      },
+      {
+        "id": 34,
+        "name": "Sony DT 18-70 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/34-Sony_DT_18-70_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 862,
+        "name": "Sony DT 30 mm f/2.8 Macro SAM",
+        "url": "https://www.lenstip.com/862-Sony_DT_30_mm_f_2.8_Macro_SAM-lens_specifications.html"
+      },
+      {
+        "id": 929,
+        "name": "Sony DT 35 mm f/1.8 SAM",
+        "url": "https://www.lenstip.com/929-Sony_DT_35_mm_f_1.8_SAM-lens_specifications.html"
+      },
+      {
+        "id": 863,
+        "name": "Sony DT 50 mm f/1.8 SAM",
+        "url": "https://www.lenstip.com/863-Sony_DT_50_mm_f_1.8_SAM-lens_specifications.html"
+      },
+      {
+        "id": 652,
+        "name": "Sony DT 55-200 mm f/4-5.6",
+        "url": "https://www.lenstip.com/652-Sony_DT_55-200_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 860,
+        "name": "Sony DT 55-200 mm f/4-5.6 SAM",
+        "url": "https://www.lenstip.com/860-Sony_DT_55-200_mm_f_4-5.6_SAM-lens_specifications.html"
+      },
+      {
+        "id": 1060,
+        "name": "Sony DT 55-300 mm f/4.5-5.6 SAM",
+        "url": "https://www.lenstip.com/1060-Sony_DT_55-300_mm_f_4.5-5.6_SAM-lens_specifications.html"
+      },
+      {
+        "id": 1074,
+        "name": "Sony E 10-18 mm f/4 OSS",
+        "url": "https://www.lenstip.com/1074-Sony_E_10-18_mm_f_4_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1940,
+        "name": "Sony E 11 mm f/1.8",
+        "url": "https://www.lenstip.com/1940-Sony_E_11_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1941,
+        "name": "Sony E 15 mm f/1.4 G",
+        "url": "https://www.lenstip.com/1941-Sony_E_15_mm_f_1.4_G-lens_specifications.html"
+      },
+      {
+        "id": 923,
+        "name": "Sony E 16 mm f/2.8",
+        "url": "https://www.lenstip.com/923-Sony_E_16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1075,
+        "name": "Sony E 16-50 mm f/3.5-5.6 PZ OSS",
+        "url": "https://www.lenstip.com/1075-Sony_E_16-50_mm_f_3.5-5.6_PZ_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2159,
+        "name": "Sony E 16-50 mm f/3.5-5.6 PZ OSS II",
+        "url": "https://www.lenstip.com/2159-Sony_E_16-50_mm_f_3.5-5.6_PZ_OSS_II-lens_specifications.html"
+      },
+      {
+        "id": 1137,
+        "name": "Sony E 18-105 mm f/4 PZ G OSS",
+        "url": "https://www.lenstip.com/1137-Sony_E_18-105_mm_f_4_PZ_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1413,
+        "name": "Sony E 18-110 mm f/4 G PZ OSS",
+        "url": "https://www.lenstip.com/1413-Sony_E_18-110_mm_f_4_G_PZ_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1499,
+        "name": "Sony E 18-135 mm f/3.5-5.6 OSS",
+        "url": "https://www.lenstip.com/1499-Sony_E_18-135_mm_f_3.5-5.6_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1044,
+        "name": "Sony E 18-200 mm f/3.5-6.3 LE OSS",
+        "url": "https://www.lenstip.com/1044-Sony_E_18-200_mm_f_3.5-6.3_LE_OSS-lens_specifications.html"
+      },
+      {
+        "id": 925,
+        "name": "Sony E 18-200 mm f/3.5-6.3 OSS",
+        "url": "https://www.lenstip.com/925-Sony_E_18-200_mm_f_3.5-6.3_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1098,
+        "name": "Sony E 18-200 mm f/3.5-6.3 PZ OSS",
+        "url": "https://www.lenstip.com/1098-Sony_E_18-200_mm_f_3.5-6.3_PZ_OSS-lens_specifications.html"
+      },
+      {
+        "id": 924,
+        "name": "Sony E 18-55 mm f/3.5-5.6 OSS",
+        "url": "https://www.lenstip.com/924-Sony_E_18-55_mm_f_3.5-5.6_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1097,
+        "name": "Sony E 20 mm f/2.8",
+        "url": "https://www.lenstip.com/1097-Sony_E_20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 983,
+        "name": "Sony E 30 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/983-Sony_E_30_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1073,
+        "name": "Sony E 35 mm f/1.8 OSS",
+        "url": "https://www.lenstip.com/1073-Sony_E_35_mm_f_1.8_OSS-lens_specifications.html"
+      },
+      {
+        "id": 999,
+        "name": "Sony E 50 mm f/1.8 OSS",
+        "url": "https://www.lenstip.com/999-Sony_E_50_mm_f_1.8_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1000,
+        "name": "Sony E 55-210 mm f/4.5-6.3 OSS",
+        "url": "https://www.lenstip.com/1000-Sony_E_55-210_mm_f_4.5-6.3_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1942,
+        "name": "Sony E PZ 10-20 mm f/4 G",
+        "url": "https://www.lenstip.com/1942-Sony_E_PZ_10-20_mm_f_4_G-lens_specifications.html"
+      },
+      {
+        "id": 2274,
+        "name": "Sony FE 100 mm f/2.8 Macro GM OSS",
+        "url": "https://www.lenstip.com/2274-Sony_FE_100_mm_f_2.8_Macro_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1443,
+        "name": "Sony FE 100 mm f/2.8 STF GM OSS",
+        "url": "https://www.lenstip.com/1443-Sony_FE_100_mm_f_2.8_STF_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2332,
+        "name": "Sony FE 100-400 mm f/4.5 GM OSS",
+        "url": "https://www.lenstip.com/2332-Sony_FE_100-400_mm_f_4.5_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1462,
+        "name": "Sony FE 100-400 mm f/4.5-5.6 GM OSS",
+        "url": "https://www.lenstip.com/1462-Sony_FE_100-400_mm_f_4.5-5.6_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1711,
+        "name": "Sony FE 12-24 mm f/2.8 GM",
+        "url": "https://www.lenstip.com/1711-Sony_FE_12-24_mm_f_2.8_GM-lens_specifications.html"
+      },
+      {
+        "id": 1464,
+        "name": "Sony FE 12-24 mm f/4 G",
+        "url": "https://www.lenstip.com/1464-Sony_FE_12-24_mm_f_4_G-lens_specifications.html"
+      },
+      {
+        "id": 1602,
+        "name": "Sony FE 135 mm f/1.8 GM",
+        "url": "https://www.lenstip.com/1602-Sony_FE_135_mm_f_1.8_GM-lens_specifications.html"
+      },
+      {
+        "id": 1822,
+        "name": "Sony FE 14 mm f/1.8 GM",
+        "url": "https://www.lenstip.com/1822-Sony_FE_14_mm_f_1.8_GM-lens_specifications.html"
+      },
+      {
+        "id": 2205,
+        "name": "Sony FE 16 mm f/1.8 G",
+        "url": "https://www.lenstip.com/2205-Sony_FE_16_mm_f_1.8_G-lens_specifications.html"
+      },
+      {
+        "id": 2123,
+        "name": "Sony FE 16-25 mm f/2.8 G",
+        "url": "https://www.lenstip.com/2123-Sony_FE_16-25_mm_f_2.8_G-lens_specifications.html"
+      },
+      {
+        "id": 1465,
+        "name": "Sony FE 16-35 mm f/2.8 GM",
+        "url": "https://www.lenstip.com/1465-Sony_FE_16-35_mm_f_2.8_GM-lens_specifications.html"
+      },
+      {
+        "id": 2064,
+        "name": "Sony FE 16-35 mm f/2.8 GM II",
+        "url": "https://www.lenstip.com/2064-Sony_FE_16-35_mm_f_2.8_GM_II-lens_specifications.html"
+      },
+      {
+        "id": 1683,
+        "name": "Sony FE 20 mm f/1.8 G",
+        "url": "https://www.lenstip.com/1683-Sony_FE_20_mm_f_1.8_G-lens_specifications.html"
+      },
+      {
+        "id": 2008,
+        "name": "Sony FE 20-70 mm f/4 G",
+        "url": "https://www.lenstip.com/2008-Sony_FE_20-70_mm_f_4_G-lens_specifications.html"
+      },
+      {
+        "id": 1625,
+        "name": "Sony FE 200-600 mm f/5.6-6.3 G OSS",
+        "url": "https://www.lenstip.com/1625-Sony_FE_200-600_mm_f_5.6-6.3_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1566,
+        "name": "Sony FE 24 mm f/1.4 GM",
+        "url": "https://www.lenstip.com/1566-Sony_FE_24_mm_f_1.4_GM-lens_specifications.html"
+      },
+      {
+        "id": 1819,
+        "name": "Sony FE 24 mm f/2.8 G",
+        "url": "https://www.lenstip.com/1819-Sony_FE_24_mm_f_2.8_G-lens_specifications.html"
+      },
+      {
+        "id": 1491,
+        "name": "Sony FE 24-105 mm f/4 G OSS",
+        "url": "https://www.lenstip.com/1491-Sony_FE_24-105_mm_f_4_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1280,
+        "name": "Sony FE 24-240 mm f/3.5-6.3 OSS",
+        "url": "https://www.lenstip.com/1280-Sony_FE_24-240_mm_f_3.5-6.3_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2115,
+        "name": "Sony FE 24-50 mm f/2.8 G",
+        "url": "https://www.lenstip.com/2115-Sony_FE_24-50_mm_f_2.8_G-lens_specifications.html"
+      },
+      {
+        "id": 1341,
+        "name": "Sony FE 24-70 mm f/2.8 GM",
+        "url": "https://www.lenstip.com/1341-Sony_FE_24-70_mm_f_2.8_GM-lens_specifications.html"
+      },
+      {
+        "id": 1936,
+        "name": "Sony FE 24-70 mm f/2.8 GM II",
+        "url": "https://www.lenstip.com/1936-Sony_FE_24-70_mm_f_2.8_GM_II-lens_specifications.html"
+      },
+      {
+        "id": 1281,
+        "name": "Sony FE 28 mm f/2",
+        "url": "https://www.lenstip.com/1281-Sony_FE_28_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1894,
+        "name": "Sony FE 28-60 mm f/4-5.6",
+        "url": "https://www.lenstip.com/1894-Sony_FE_28-60_mm_f_4-5.6_-lens_specifications.html"
+      },
+      {
+        "id": 2189,
+        "name": "Sony FE 28-70 mm f/2 GM",
+        "url": "https://www.lenstip.com/2189-Sony_FE_28-70_mm_f_2_GM-lens_specifications.html"
+      },
+      {
+        "id": 1158,
+        "name": "Sony FE 28-70 mm f/3.5-5.6 OSS",
+        "url": "https://www.lenstip.com/1158-Sony_FE_28-70_mm_f_3.5-5.6_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2290,
+        "name": "Sony FE 28-70 mm f/3.5-5.6 OSS II",
+        "url": "https://www.lenstip.com/2290-Sony_FE_28-70_mm_f_3.5-5.6_OSS_II-lens_specifications.html"
+      },
+      {
+        "id": 2095,
+        "name": "Sony FE 300 mm f/2.8 GM OSS",
+        "url": "https://www.lenstip.com/2095-Sony_FE_300_mm_f_2.8_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1757,
+        "name": "Sony FE 35 mm f/1.4 GM",
+        "url": "https://www.lenstip.com/1757-Sony_FE_35_mm_f_1.4_GM-lens_specifications.html"
+      },
+      {
+        "id": 1630,
+        "name": "Sony FE 35 mm f/1.8",
+        "url": "https://www.lenstip.com/1630-Sony_FE_35_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1820,
+        "name": "Sony FE 40 mm f/2.5 G",
+        "url": "https://www.lenstip.com/1820-Sony_FE_40_mm_f_2.5_G-lens_specifications.html"
+      },
+      {
+        "id": 1541,
+        "name": "Sony FE 400 mm f/2.8 GM OSS",
+        "url": "https://www.lenstip.com/1541-Sony_FE_400_mm_f_2.8_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2206,
+        "name": "Sony FE 400-800 mm f/6.3-8 G OSS",
+        "url": "https://www.lenstip.com/2206-Sony_FE_400-800_mm_f_6.3-8_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1817,
+        "name": "Sony FE 50 mm f/1.2 GM",
+        "url": "https://www.lenstip.com/1817-Sony_FE_50_mm_f_1.2_GM-lens_specifications.html"
+      },
+      {
+        "id": 2022,
+        "name": "Sony FE 50 mm f/1.4 GM",
+        "url": "https://www.lenstip.com/2022-Sony_FE_50_mm_f_1.4_GM-lens_specifications.html"
+      },
+      {
+        "id": 1361,
+        "name": "Sony FE 50 mm f/1.8",
+        "url": "https://www.lenstip.com/1361-Sony_FE_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1821,
+        "name": "Sony FE 50 mm f/2.5 G",
+        "url": "https://www.lenstip.com/1821-Sony_FE_50_mm_f_2.5_G-lens_specifications.html"
+      },
+      {
+        "id": 1381,
+        "name": "Sony FE 50 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/1381-Sony_FE_50_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2225,
+        "name": "Sony FE 50-150 mm f/2 GM",
+        "url": "https://www.lenstip.com/2225-Sony_FE_50-150_mm_f_2_GM-lens_specifications.html"
+      },
+      {
+        "id": 1626,
+        "name": "Sony FE 600 mm f/4 GM OSS",
+        "url": "https://www.lenstip.com/1626-Sony_FE_600_mm_f_4_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1343,
+        "name": "Sony FE 70-200 mm f/2.8 GM OSS",
+        "url": "https://www.lenstip.com/1343-Sony_FE_70-200_mm_f_2.8_GM_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1886,
+        "name": "Sony FE 70-200 mm f/2.8 GM OSS II",
+        "url": "https://www.lenstip.com/1886-Sony_FE_70-200_mm_f_2.8_GM_OSS_II-lens_specifications.html"
+      },
+      {
+        "id": 1159,
+        "name": "Sony FE 70-200 mm f/4 G OSS",
+        "url": "https://www.lenstip.com/1159-Sony_FE_70-200_mm_f_4_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 2061,
+        "name": "Sony FE 70-200 mm f/4 Macro G OSS II",
+        "url": "https://www.lenstip.com/2061-Sony_FE_70-200_mm_f_4_Macro_G_OSS_II-lens_specifications.html"
+      },
+      {
+        "id": 1360,
+        "name": "Sony FE 70-300 mm f/4.5-5.6 G OSS",
+        "url": "https://www.lenstip.com/1360-Sony_FE_70-300_mm_f_4.5-5.6_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1342,
+        "name": "Sony FE 85 mm f/1.4 GM",
+        "url": "https://www.lenstip.com/1342-Sony_FE_85_mm_f_1.4_GM-lens_specifications.html"
+      },
+      {
+        "id": 2160,
+        "name": "Sony FE 85 mm f/1.4 GM II",
+        "url": "https://www.lenstip.com/2160-Sony_FE_85_mm_f_1.4_GM_II-lens_specifications.html"
+      },
+      {
+        "id": 1444,
+        "name": "Sony FE 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1444-Sony_FE_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1279,
+        "name": "Sony FE 90 mm f/2.8 Macro G OSS",
+        "url": "https://www.lenstip.com/1279-Sony_FE_90_mm_f_2.8_Macro_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 1772,
+        "name": "Sony FE C 16-35 mm T3.1 G",
+        "url": "https://www.lenstip.com/1772-Sony_FE_C_16-35_mm_T3.1_G-lens_specifications.html"
+      },
+      {
+        "id": 1932,
+        "name": "Sony FE PZ 16-35 mm f/4 G",
+        "url": "https://www.lenstip.com/1932-Sony_FE_PZ_16-35_mm_f_4_G-lens_specifications.html"
+      },
+      {
+        "id": 1232,
+        "name": "Sony FE PZ 28-135 mm f/4 G OSS",
+        "url": "https://www.lenstip.com/1232-Sony_FE_PZ_28-135_mm_f_4_G_OSS-lens_specifications.html"
+      },
+      {
+        "id": 502,
+        "name": "Sony Reflex 500 mm f/8",
+        "url": "https://www.lenstip.com/502-Sony_Reflex_500_mm_f_8-lens_specifications.html"
+      }
+    ],
+    "Tamron": [
+      {
+        "id": 1442,
+        "name": "Tamron 10-24 mm f/3.5-4.5 Di II VC HLD",
+        "url": "https://www.lenstip.com/1442-Tamron_10-24_mm_f_3.5-4.5_Di_II_VC_HLD-lens_specifications.html"
+      },
+      {
+        "id": 1486,
+        "name": "Tamron 100-400 mm f/4.5-6.3 Di VC USD",
+        "url": "https://www.lenstip.com/1486-Tamron_100-400_mm_f_4.5-6.3_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1835,
+        "name": "Tamron 11-20 mm f/2.8 Di III-A RXD",
+        "url": "https://www.lenstip.com/1835-Tamron_11-20_mm_f_2.8_Di_III-A_RXD-lens_specifications.html"
+      },
+      {
+        "id": 1212,
+        "name": "Tamron 14-150 mm f/3.5-5.8 Di III",
+        "url": "https://www.lenstip.com/1212-Tamron_14-150_mm_f_3.5-5.8_Di_III-lens_specifications.html"
+      },
+      {
+        "id": 1108,
+        "name": "Tamron 14-150 mm f/3.5-5.8 Di III VC",
+        "url": "https://www.lenstip.com/1108-Tamron_14-150_mm_f_3.5-5.8_Di_III_VC-lens_specifications.html"
+      },
+      {
+        "id": 1836,
+        "name": "Tamron 150-500 mm f/5-6.7 Di III VC VXD",
+        "url": "https://www.lenstip.com/1836-Tamron_150-500_mm_f_5-6.7_Di_III_VC_VXD-lens_specifications.html"
+      },
+      {
+        "id": 2241,
+        "name": "Tamron 16-30 mm f/2.8 Di III VXD G2",
+        "url": "https://www.lenstip.com/2241-Tamron_16-30_mm_f_2.8_Di_III_VXD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1179,
+        "name": "Tamron 16-300 mm f/3.5-6.3 Di II VC PZD MACRO",
+        "url": "https://www.lenstip.com/1179-Tamron_16-300_mm_f_3.5-6.3_Di_II_VC_PZD_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 1627,
+        "name": "Tamron 17-28 mm f/2.8 Di III RXD",
+        "url": "https://www.lenstip.com/1627-Tamron_17-28_mm_f_2.8_Di_III_RXD-lens_specifications.html"
+      },
+      {
+        "id": 1550,
+        "name": "Tamron 17-35 mm f/2.8-4 Di OSD",
+        "url": "https://www.lenstip.com/1550-Tamron_17-35_mm_f_2.8-4_Di_OSD-lens_specifications.html"
+      },
+      {
+        "id": 2100,
+        "name": "Tamron 17-50 mm f/4 Di III VXD",
+        "url": "https://www.lenstip.com/2100-Tamron_17-50_mm_f_4_Di_III_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1778,
+        "name": "Tamron 17-70 mm f/2.8 Di III-A VC RXD",
+        "url": "https://www.lenstip.com/1778-Tamron_17-70_mm_f_2.8_Di_III-A_VC_RXD-lens_specifications.html"
+      },
+      {
+        "id": 1302,
+        "name": "Tamron 18-200 mm f/3.5-6.3 Di II VC",
+        "url": "https://www.lenstip.com/1302-Tamron_18-200_mm_f_3.5-6.3_Di_II_VC-lens_specifications.html"
+      },
+      {
+        "id": 1211,
+        "name": "Tamron 18-200 mm f/3.5-6.3 Di III VC",
+        "url": "https://www.lenstip.com/1211-Tamron_18-200_mm_f_3.5-6.3_Di_III_VC-lens_specifications.html"
+      },
+      {
+        "id": 1014,
+        "name": "Tamron 18-200 mm f/3.5-6.3 Di III VC",
+        "url": "https://www.lenstip.com/1014-Tamron_18-200_mm_f_3.5-6.3_Di_III_VC-lens_specifications.html"
+      },
+      {
+        "id": 1865,
+        "name": "Tamron 18-300 mm f/3.5-6.3 Di III-A VC VXD",
+        "url": "https://www.lenstip.com/1865-Tamron_18-300_mm_f_3.5-6.3_Di_III-A_VC_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1471,
+        "name": "Tamron 18-400 mm f/3.5-6.3 Di II VC HLD",
+        "url": "https://www.lenstip.com/1471-Tamron_18-400_mm_f_3.5-6.3_Di_II_VC_HLD-lens_specifications.html"
+      },
+      {
+        "id": 1654,
+        "name": "Tamron 20 mm f/2.8 Di III OSD M 1:2",
+        "url": "https://www.lenstip.com/1654-Tamron_20_mm_f_2.8_Di_III_OSD_M_1:2-lens_specifications.html"
+      },
+      {
+        "id": 1983,
+        "name": "Tamron 20-40 mm f/2.8 Di III VXD",
+        "url": "https://www.lenstip.com/1983-Tamron_20-40_mm_f_2.8_Di_III_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1655,
+        "name": "Tamron 24 mm f/2.8 Di III OSD M 1:2",
+        "url": "https://www.lenstip.com/1655-Tamron_24_mm_f_2.8_Di_III_OSD_M_1:2-lens_specifications.html"
+      },
+      {
+        "id": 2283,
+        "name": "Tamron 25-200 mm f/2.8-5.6 Di III VXD G2",
+        "url": "https://www.lenstip.com/2283-Tamron_25-200_mm_f_2.8-5.6_Di_III_VXD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1701,
+        "name": "Tamron 28-200 mm f/2.8-5.6 Di III RXD",
+        "url": "https://www.lenstip.com/1701-Tamron_28-200_mm_f_2.8-5.6_Di_III_RXD-lens_specifications.html"
+      },
+      {
+        "id": 1180,
+        "name": "Tamron 28-300 mm F/3.5-6.3 Di VC PZD (Model A010)",
+        "url": "https://www.lenstip.com/1180-Tamron_28-300_mm_F_3.5-6.3_Di_VC_PZD_(Model_A010)_-lens_specifications.html"
+      },
+      {
+        "id": 2150,
+        "name": "Tamron 28-300 mm f/4-7.1 Di III VC VXD",
+        "url": "https://www.lenstip.com/2150-Tamron_28-300_mm_f_4-7.1_Di_III_VC_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1513,
+        "name": "Tamron 28-75 mm f/2.8 Di III RXD",
+        "url": "https://www.lenstip.com/1513-Tamron_28-75_mm_f_2.8_Di_III_RXD-lens_specifications.html"
+      },
+      {
+        "id": 1885,
+        "name": "Tamron 28-75 mm f/2.8 Di III VXD G2",
+        "url": "https://www.lenstip.com/1885-Tamron_28-75_mm_f_2.8_Di_III_VXD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1656,
+        "name": "Tamron 35 mm f/2.8 Di III OSD M 1:2",
+        "url": "https://www.lenstip.com/1656-Tamron_35_mm_f_2.8_Di_III_OSD_M_1:2-lens_specifications.html"
+      },
+      {
+        "id": 2313,
+        "name": "Tamron 35-100 mm f/2.8 Di III VXD",
+        "url": "https://www.lenstip.com/2313-Tamron_35-100_mm_f_2.8_Di_III_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1884,
+        "name": "Tamron 35-150 mm f/2-2.8 Di III VXD",
+        "url": "https://www.lenstip.com/1884-Tamron_35-150_mm_f_2-2.8_Di_III_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1616,
+        "name": "Tamron 35-150 mm f/2.8-4 Di VC OSD",
+        "url": "https://www.lenstip.com/1616-Tamron_35-150_mm_f_2.8-4_Di_VC_OSD-lens_specifications.html"
+      },
+      {
+        "id": 2137,
+        "name": "Tamron 50-300 mm f/4.5-6.3 Di III VC VXD",
+        "url": "https://www.lenstip.com/2137-Tamron_50-300_mm_f_4.5-6.3_Di_III_VC_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1966,
+        "name": "Tamron 50-400 mm f/4.5-6.3 Di III VC VXD",
+        "url": "https://www.lenstip.com/1966-Tamron_50-400_mm_f_4.5-6.3_Di_III_VC_VXD-lens_specifications.html"
+      },
+      {
+        "id": 2077,
+        "name": "Tamron 70-180 mm f/2.8 Di III VC VXD G2",
+        "url": "https://www.lenstip.com/2077-Tamron_70-180_mm_f_2.8_Di_III_VC_VXD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1657,
+        "name": "Tamron 70-180 mm f/2.8 Di III VXD",
+        "url": "https://www.lenstip.com/1657-Tamron_70-180_mm_f_2.8_Di_III_VXD-lens_specifications.html"
+      },
+      {
+        "id": 1512,
+        "name": "Tamron 70-210 mm f/4 Di VC USD",
+        "url": "https://www.lenstip.com/1512-Tamron_70-210_mm_f_4_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1752,
+        "name": "Tamron 70-300 mm f/4.5-6.3 Di III RXD",
+        "url": "https://www.lenstip.com/1752-Tamron_70-300_mm_f_4.5-6.3_Di_III_RXD-lens_specifications.html"
+      },
+      {
+        "id": 2171,
+        "name": "Tamron 90 mm f/2.8 Di III Macro VXD",
+        "url": "https://www.lenstip.com/2171-Tamron_90_mm_f_2.8_Di_III_Macro_VXD-lens_specifications.html"
+      },
+      {
+        "id": 109,
+        "name": "Tamron AF 18-200 mm f/3.5-6.3 XR Di II LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/109-Tamron_AF_18-200_mm_f_3.5-6.3_XR_Di_II_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 653,
+        "name": "Tamron AF 18-250 mm f/3.5-6.3 Di II LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/653-Tamron_AF_18-250_mm_f_3.5-6.3_Di_II_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 799,
+        "name": "Tamron AF 18-270 mm f/3.5-6.3 Di II VC LD Asph. (IF) MACRO",
+        "url": "https://www.lenstip.com/799-Tamron_AF_18-270_mm_f_3.5-6.3_Di_II_VC_LD_Asph._(IF)_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 967,
+        "name": "Tamron AF 18-270 mm f/3.5-6.3 Di II VC PZD",
+        "url": "https://www.lenstip.com/967-Tamron_AF_18-270_mm_f_3.5-6.3_Di_II_VC_PZD_-lens_specifications.html"
+      },
+      {
+        "id": 128,
+        "name": "Tamron AF 200-500 mm f/5-6.3 Di LD (IF)",
+        "url": "https://www.lenstip.com/128-Tamron_AF_200-500_mm_f_5-6.3_Di_LD_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 114,
+        "name": "Tamron AF 28-200 mm f/3.8-5.6 XR Di Aspherical (IF) Macro",
+        "url": "https://www.lenstip.com/114-Tamron_AF_28-200_mm_f_3.8-5.6_XR_Di_Aspherical_(IF)_Macro-lens_specifications.html"
+      },
+      {
+        "id": 115,
+        "name": "Tamron AF 28-300 mm f/3.5-6.3 XR Di LD Aspherical (IF) Macro",
+        "url": "https://www.lenstip.com/115-Tamron_AF_28-300_mm_f_3.5-6.3_XR_Di_LD_Aspherical_(IF)_Macro-lens_specifications.html"
+      },
+      {
+        "id": 625,
+        "name": "Tamron AF 28-300mm F/3.5-6.3 XR Di VC LD Asph. (IF) MACRO",
+        "url": "https://www.lenstip.com/625-Tamron_AF_28-300mm_F_3.5-6.3_XR_Di_VC_LD_Asph._(IF)_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 113,
+        "name": "Tamron AF 28-80 mm f/3.5-5.6 Aspherical",
+        "url": "https://www.lenstip.com/113-Tamron_AF_28-80_mm_f_3.5-5.6_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 16,
+        "name": "Tamron AF 55-200 mm f/4-5.6 Di II LD Macro",
+        "url": "https://www.lenstip.com/16-Tamron_AF_55-200_mm_f_4-5.6_Di_II_LD_Macro-lens_specifications.html"
+      },
+      {
+        "id": 40,
+        "name": "Tamron AF 70-300 mm f/4-5.6 Di LD Macro",
+        "url": "https://www.lenstip.com/40-Tamron_AF_70-300_mm_f_4-5.6_Di_LD_Macro-lens_specifications.html"
+      },
+      {
+        "id": 117,
+        "name": "Tamron AF 70-300 mm f/4-5.6 Macro",
+        "url": "https://www.lenstip.com/117-Tamron_AF_70-300_mm_f_4-5.6_Macro-lens_specifications.html"
+      },
+      {
+        "id": 124,
+        "name": "Tamron MF 28-200 mm f/3.8-5.6 LD Aspherical (IF) Super",
+        "url": "https://www.lenstip.com/124-Tamron_MF_28-200_mm_f_3.8-5.6_LD_Aspherical_(IF)_Super-lens_specifications.html"
+      },
+      {
+        "id": 123,
+        "name": "Tamron MF 28-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/123-Tamron_MF_28-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 127,
+        "name": "Tamron MF 500 mm f/8",
+        "url": "https://www.lenstip.com/127-Tamron_MF_500_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 126,
+        "name": "Tamron MF SP 300 mm f/2.8 LD (IF)",
+        "url": "https://www.lenstip.com/126-Tamron_MF_SP_300_mm_f_2.8_LD_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 125,
+        "name": "Tamron MF SP 90 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/125-Tamron_MF_SP_90_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1231,
+        "name": "Tamron SP 15-30 mm f/2.8 Di VC USD",
+        "url": "https://www.lenstip.com/1231-Tamron_SP_15-30_mm_f_2.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1558,
+        "name": "Tamron SP 15-30 mm f/2.8 Di VC USD G2",
+        "url": "https://www.lenstip.com/1558-Tamron_SP_15-30_mm_f_2.8_Di_VC_USD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1165,
+        "name": "Tamron SP 150-600 mm f/5-6.3 Di VC USD",
+        "url": "https://www.lenstip.com/1165-Tamron_SP_150-600_mm_f_5-6.3_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1382,
+        "name": "Tamron SP 150-600 mm f/5-6.3 Di VC USD G2",
+        "url": "https://www.lenstip.com/1382-Tamron_SP_150-600_mm_f_5-6.3_Di_VC_USD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1031,
+        "name": "Tamron SP 24-70 mm f/2.8 Di VC USD",
+        "url": "https://www.lenstip.com/1031-Tamron_SP_24-70_mm_f_2.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1472,
+        "name": "Tamron SP 24-70 mm f/2.8 VC USD G2",
+        "url": "https://www.lenstip.com/1472-Tamron_SP_24-70_mm_f_2.8_VC_USD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1624,
+        "name": "Tamron SP 35 mm f/1.4 Di USD",
+        "url": "https://www.lenstip.com/1624-Tamron_SP_35_mm_f_1.4_Di_USD-lens_specifications.html"
+      },
+      {
+        "id": 1308,
+        "name": "Tamron SP 35 mm f/1.8 Di VC USD",
+        "url": "https://www.lenstip.com/1308-Tamron_SP_35_mm_f_1.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1309,
+        "name": "Tamron SP 45 mm f/1.8 Di VC USD",
+        "url": "https://www.lenstip.com/1309-Tamron_SP_45_mm_f_1.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1077,
+        "name": "Tamron SP 70-200 mm f/2.8 Di VC USD",
+        "url": "https://www.lenstip.com/1077-Tamron_SP_70-200_mm_f_2.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1441,
+        "name": "Tamron SP 70-200 mm f/2.8 Di VC USD G2",
+        "url": "https://www.lenstip.com/1441-Tamron_SP_70-200_mm_f_2.8_Di_VC_USD_G2-lens_specifications.html"
+      },
+      {
+        "id": 1439,
+        "name": "Tamron SP 70-300 mm f/4-5.6 Di VC USD",
+        "url": "https://www.lenstip.com/1439-Tamron_SP_70-300_mm_f_4-5.6_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 916,
+        "name": "Tamron SP 70-300 mm f/4-5.6 Di VC USD",
+        "url": "https://www.lenstip.com/916-Tamron_SP_70-300_mm_f_4-5.6_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1355,
+        "name": "Tamron SP 85 mm f/1.8 Di VC USD",
+        "url": "https://www.lenstip.com/1355-Tamron_SP_85_mm_f_1.8_Di_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1078,
+        "name": "Tamron SP 90 mm f/2.8 Di MACRO 1:1 VC USD",
+        "url": "https://www.lenstip.com/1078-Tamron_SP_90_mm_f_2.8_Di_MACRO_1:1_VC_USD-lens_specifications.html"
+      },
+      {
+        "id": 1354,
+        "name": "Tamron SP 90 mm f/2.8 Di MACRO 1:1 VC USD (Model: F017)",
+        "url": "https://www.lenstip.com/1354-Tamron_SP_90_mm_f_2.8_Di_MACRO_1:1_VC_USD_(Model:_F017)-lens_specifications.html"
+      },
+      {
+        "id": 686,
+        "name": "Tamron SP AF 10-24 mm f/3.5-4.5 Di II LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/686-Tamron_SP_AF_10-24_mm_f_3.5-4.5_Di_II_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 38,
+        "name": "Tamron SP AF 11-18 mm f/4.5-5.6 Di II LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/38-Tamron_SP_AF_11-18_mm_f_4.5-5.6_Di_II_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 118,
+        "name": "Tamron SP AF 14 mm f/2.8 Aspherical (IF)",
+        "url": "https://www.lenstip.com/118-Tamron_SP_AF_14_mm_f_2.8_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 59,
+        "name": "Tamron SP AF 17-35 mm f/2.8-4 Di LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/59-Tamron_SP_AF_17-35_mm_f_2.8-4_Di_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 26,
+        "name": "Tamron SP AF 17-50 mm f/2.8 XR Di II LD Aspherical (IF)",
+        "url": "https://www.lenstip.com/26-Tamron_SP_AF_17-50_mm_f_2.8_XR_Di_II_LD_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 880,
+        "name": "Tamron SP AF 17-50 mm f/2.8 XR Di II VC",
+        "url": "https://www.lenstip.com/880-Tamron_SP_AF_17-50_mm_f_2.8_XR_Di_II_VC-lens_specifications.html"
+      },
+      {
+        "id": 120,
+        "name": "Tamron SP AF 180 mm f/3.5 Di LD (IF) Macro",
+        "url": "https://www.lenstip.com/120-Tamron_SP_AF_180_mm_f_3.5_Di_LD_(IF)_Macro-lens_specifications.html"
+      },
+      {
+        "id": 629,
+        "name": "Tamron SP AF 20-40 mm f/2.7-3.5 Aspherical (IF)",
+        "url": "https://www.lenstip.com/629-Tamron_SP_AF_20-40_mm_f_2.7-3.5_Aspherical_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 111,
+        "name": "Tamron SP AF 24-135 mm f/3.5-5.6 AD Aspherical (IF) Macro",
+        "url": "https://www.lenstip.com/111-Tamron_SP_AF_24-135_mm_f_3.5-5.6_AD_Aspherical_(IF)_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2184,
+        "name": "Tamron SP AF 28-105 mm f/2.8 LD Aspherical IF",
+        "url": "https://www.lenstip.com/2184-Tamron_SP_AF_28-105_mm_f_2.8_LD_Aspherical_IF-lens_specifications.html"
+      },
+      {
+        "id": 22,
+        "name": "Tamron SP AF 28-75 mm f/2.8 XR Di LD Aspherical (IF) MACRO",
+        "url": "https://www.lenstip.com/22-Tamron_SP_AF_28-75_mm_f_2.8_XR_Di_LD_Aspherical_(IF)_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 121,
+        "name": "Tamron SP AF 300 mm f/2.8 LD (IF)",
+        "url": "https://www.lenstip.com/121-Tamron_SP_AF_300_mm_f_2.8_LD_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 122,
+        "name": "Tamron SP AF 300 mm f/2.8 LD IF",
+        "url": "https://www.lenstip.com/122-Tamron_SP_AF_300_mm_f_2.8_LD_IF-lens_specifications.html"
+      },
+      {
+        "id": 853,
+        "name": "Tamron SP AF 60 mm f/2.0 Di II LD (IF) Macro 1:1",
+        "url": "https://www.lenstip.com/853-Tamron_SP_AF_60_mm_f_2.0_Di_II_LD_(IF)_Macro_1:1-lens_specifications.html"
+      },
+      {
+        "id": 626,
+        "name": "Tamron SP AF 70-200 mm f/2.8 Di LD (IF) MACRO",
+        "url": "https://www.lenstip.com/626-Tamron_SP_AF_70-200_mm_f_2.8_Di_LD_(IF)_MACRO-lens_specifications.html"
+      },
+      {
+        "id": 35,
+        "name": "Tamron SP AF 90 mm f/2.8 Di Macro",
+        "url": "https://www.lenstip.com/35-Tamron_SP_AF_90_mm_f_2.8_Di_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2194,
+        "name": "Tamron SP AF 90 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/2194-Tamron_SP_AF_90_mm_f_2.8_Macro-lens_specifications.html"
+      }
+    ],
+    "Thypoch": [
+      {
+        "id": 2301,
+        "name": "Thypoch Eureka 28 mm f/2.8",
+        "url": "https://www.lenstip.com/2301-Thypoch_Eureka_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2302,
+        "name": "Thypoch Eureka 50 mm f/2",
+        "url": "https://www.lenstip.com/2302-Thypoch_Eureka_50_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 2303,
+        "name": "Thypoch Ksana 21 mm f/3.5 ASPH",
+        "url": "https://www.lenstip.com/2303-Thypoch_Ksana_21_mm_f_3.5_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2335,
+        "name": "Thypoch Ksana 35 mm f/2 ASPH",
+        "url": "https://www.lenstip.com/2335-Thypoch_Ksana_35_mm_f_2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2304,
+        "name": "Thypoch Simera 21 mm f/1.4",
+        "url": "https://www.lenstip.com/2304-Thypoch_Simera_21_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2305,
+        "name": "Thypoch Simera 28 mm f/1.4",
+        "url": "https://www.lenstip.com/2305-Thypoch_Simera_28_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2306,
+        "name": "Thypoch Simera 35 mm f/1.4",
+        "url": "https://www.lenstip.com/2306-Thypoch_Simera_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2307,
+        "name": "Thypoch Simera 50 mm f/1.4",
+        "url": "https://www.lenstip.com/2307-Thypoch_Simera_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2308,
+        "name": "Thypoch Simera 75 mm f/1.4",
+        "url": "https://www.lenstip.com/2308-Thypoch_Simera_75_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2330,
+        "name": "Thypoch Voyager AF 24-50 mm f/2.8",
+        "url": "https://www.lenstip.com/2330-Thypoch_Voyager_AF_24-50_mm_f_2.8-lens_specifications.html"
+      }
+    ],
+    "Tokina": [
+      {
+        "id": 1184,
+        "name": "Tokina 11-16 mm T3.0 CINEMA",
+        "url": "https://www.lenstip.com/1184-Tokina_11-16_mm_T3.0_CINEMA-lens_specifications.html"
+      },
+      {
+        "id": 1185,
+        "name": "Tokina 16-28 mm T3.0 CINEMA",
+        "url": "https://www.lenstip.com/1185-Tokina_16-28_mm_T3.0_CINEMA_-lens_specifications.html"
+      },
+      {
+        "id": 1695,
+        "name": "Tokina 25-75 mm T2.9 CINEMA",
+        "url": "https://www.lenstip.com/1695-Tokina_25-75_mm_T2.9_CINEMA_-lens_specifications.html"
+      },
+      {
+        "id": 90,
+        "name": "Tokina AF 193 19-35 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/90-Tokina_AF_193_19-35_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 514,
+        "name": "Tokina AF 20-35 mm f/3.5-4.5 II",
+        "url": "https://www.lenstip.com/514-Tokina_AF_20-35_mm_f_3.5-4.5_II-lens_specifications.html"
+      },
+      {
+        "id": 1333,
+        "name": "Tokina AT-X 100 mm T/2.9 Macro Cinema",
+        "url": "https://www.lenstip.com/1333-Tokina_AT-X_100_mm_T_2.9_Macro_Cinema-lens_specifications.html"
+      },
+      {
+        "id": 87,
+        "name": "Tokina AT-X 107 DX AF Fish-Eye 10-17 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/87-Tokina_AT-X_107_DX_AF_Fish-Eye_10-17_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 664,
+        "name": "Tokina AT-X 116 PRO DX AF 11-16 mm f/2.8",
+        "url": "https://www.lenstip.com/664-Tokina_AT-X_116_PRO_DX_AF_11-16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1024,
+        "name": "Tokina AT-X 116 PRO DX II AF 11-16 mm f/2.8",
+        "url": "https://www.lenstip.com/1024-Tokina_AT-X_116_PRO_DX_II_AF_11-16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1272,
+        "name": "Tokina AT-X 116 PRO DX V 11-16 mm f/2.8",
+        "url": "https://www.lenstip.com/1272-Tokina_AT-X_116_PRO_DX_V_11-16_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 43,
+        "name": "Tokina AT-X 124 PRO DX AF 12-24 mm f/4",
+        "url": "https://www.lenstip.com/43-Tokina_AT-X_124_PRO_DX_AF_12-24_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 818,
+        "name": "Tokina AT-X 124 PRO DX II AF 12-24 mm f/4",
+        "url": "https://www.lenstip.com/818-Tokina_AT-X_124_PRO_DX_II_AF_12-24_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 630,
+        "name": "Tokina AT-X 165 PRO DX AF 16-50 mm f/2.8",
+        "url": "https://www.lenstip.com/630-Tokina_AT-X_165_PRO_DX_AF_16-50_mm_f_2.8_-lens_specifications.html"
+      },
+      {
+        "id": 97,
+        "name": "Tokina AT-X 17 PRO AF 17 mm f/3.5",
+        "url": "https://www.lenstip.com/97-Tokina_AT-X_17_PRO_AF_17_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 98,
+        "name": "Tokina AT-X 235 PRO AF 20-35 mm f/2.8",
+        "url": "https://www.lenstip.com/98-Tokina_AT-X_235_PRO_AF_20-35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 89,
+        "name": "Tokina AT-X 242 AF 24-200 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/89-Tokina_AT-X_242_AF_24-200_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 100,
+        "name": "Tokina AT-X 280 PRO AF 28-80 mm f/2.8",
+        "url": "https://www.lenstip.com/100-Tokina_AT-X_280_PRO_AF_28-80_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 99,
+        "name": "Tokina AT-X 287 PROSV AF 28-70 mm f/2.8",
+        "url": "https://www.lenstip.com/99-Tokina_AT-X_287_PROSV_AF_28-70_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 102,
+        "name": "Tokina AT-X 300 PRO AF 300 mm f/2.8",
+        "url": "https://www.lenstip.com/102-Tokina_AT-X_300_PRO_AF_300_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 105,
+        "name": "Tokina AT-X 340 AF-II 100-300 mm f/4",
+        "url": "https://www.lenstip.com/105-Tokina_AT-X_340_AF-II_100-300_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1275,
+        "name": "Tokina AT-X 50-135 mm T3.0 Cinema",
+        "url": "https://www.lenstip.com/1275-Tokina_AT-X_50-135_mm_T3.0_Cinema_-lens_specifications.html"
+      },
+      {
+        "id": 85,
+        "name": "Tokina AT-X 535 PRO DX AF 50-135 mm f/2.8",
+        "url": "https://www.lenstip.com/85-Tokina_AT-X_535_PRO_DX_AF_50-135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 101,
+        "name": "Tokina AT-X 828 PRO AF 80-200 mm f/2.8",
+        "url": "https://www.lenstip.com/101-Tokina_AT-X_828_PRO_AF_80-200_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 104,
+        "name": "Tokina AT-X 840 AF 80-400 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/104-Tokina_AT-X_840_AF_80-400_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 88,
+        "name": "Tokina AT-X 840 AF D 80-400 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/88-Tokina_AT-X_840_AF_D_80-400_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 103,
+        "name": "Tokina AT-X 840 AF-II 80-400 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/103-Tokina_AT-X_840_AF-II_80-400_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 852,
+        "name": "Tokina AT-X DX AF 16.5-135 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/852-Tokina_AT-X_DX_AF_16.5-135_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 86,
+        "name": "Tokina AT-X M100 PRO AF D 100 mm f/2.8",
+        "url": "https://www.lenstip.com/86-Tokina_AT-X_M100_PRO_AF_D_100_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 665,
+        "name": "Tokina AT-X M35 PRO DX 35 mm f/2.8",
+        "url": "https://www.lenstip.com/665-Tokina_AT-X_M35_PRO_DX_35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 513,
+        "name": "Tokina AT-X PRO AF-II 28-70 mm f/2.6-2.8",
+        "url": "https://www.lenstip.com/513-Tokina_AT-X_PRO_AF-II_28-70_mm_f_2.6-2.8_-lens_specifications.html"
+      },
+      {
+        "id": 1256,
+        "name": "Tokina AT-X PRO DX 11-20 mm f/2.8",
+        "url": "https://www.lenstip.com/1256-Tokina_AT-X_PRO_DX_11-20_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1103,
+        "name": "Tokina AT-X PRO DX 12-28 mm f/4",
+        "url": "https://www.lenstip.com/1103-Tokina_AT-X_PRO_DX_12-28_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 927,
+        "name": "Tokina AT-X PRO FX SD 16-28 mm f/2.8 (IF)",
+        "url": "https://www.lenstip.com/927-Tokina_AT-X_PRO_FX_SD_16-28_mm_f_2.8_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 992,
+        "name": "Tokina AT-X PRO FX SD 17-35 mm f/4 (IF)",
+        "url": "https://www.lenstip.com/992-Tokina_AT-X_PRO_FX_SD_17-35_mm_f_4_(IF)_-lens_specifications.html"
+      },
+      {
+        "id": 1290,
+        "name": "Tokina AT-X PRO FX SD 24-70 mm f/2.8 (IF)",
+        "url": "https://www.lenstip.com/1290-Tokina_AT-X_PRO_FX_SD_24-70_mm_f_2.8_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 1102,
+        "name": "Tokina AT-X PRO FX SD 70-200 f/4 VCM-S",
+        "url": "https://www.lenstip.com/1102-Tokina_AT-X_PRO_FX_SD_70-200_f_4_VCM-S-lens_specifications.html"
+      },
+      {
+        "id": 1029,
+        "name": "Tokina AT-X PRO FX SD 70-200 mm f/4 (IF)",
+        "url": "https://www.lenstip.com/1029-Tokina_AT-X_PRO_FX_SD_70-200_mm_f_4_(IF)-lens_specifications.html"
+      },
+      {
+        "id": 1334,
+        "name": "Tokina AT-X PRO SD 14-20 mm f/2 (IF) DX",
+        "url": "https://www.lenstip.com/1334-Tokina_AT-X_PRO_SD_14-20_mm_f_2_(IF)_DX-lens_specifications.html"
+      },
+      {
+        "id": 1978,
+        "name": "Tokina ATX-M 11-18 mm f/2.8",
+        "url": "https://www.lenstip.com/1978-Tokina_ATX-M_11-18_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1773,
+        "name": "Tokina ATX-M 23 mm f/1.4 X",
+        "url": "https://www.lenstip.com/1773-Tokina_ATX-M_23_mm_f_1.4_X-lens_specifications.html"
+      },
+      {
+        "id": 1775,
+        "name": "Tokina ATX-M 33 mm f/1.4 X",
+        "url": "https://www.lenstip.com/1775-Tokina_ATX-M_33_mm_f_1.4_X-lens_specifications.html"
+      },
+      {
+        "id": 1858,
+        "name": "Tokina ATX-M 56 mm f/1.4 X",
+        "url": "https://www.lenstip.com/1858-Tokina_ATX-M_56_mm_f_1.4_X-lens_specifications.html"
+      },
+      {
+        "id": 1671,
+        "name": "Tokina ATX-M 85 mm f/1.8 FE",
+        "url": "https://www.lenstip.com/1671-Tokina_ATX-M_85_mm_f_1.8_FE-lens_specifications.html"
+      },
+      {
+        "id": 1664,
+        "name": "Tokina ATX-i 100 mm f/2.8 1:1 Macro",
+        "url": "https://www.lenstip.com/1664-Tokina_ATX-i_100_mm_f_2.8_1:1_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1652,
+        "name": "Tokina ATX-i 11-16 mm f/2.8 CF APS-C DSLR",
+        "url": "https://www.lenstip.com/1652-Tokina_ATX-i_11-16_mm_f_2.8_CF_APS-C_DSLR-lens_specifications.html"
+      },
+      {
+        "id": 1702,
+        "name": "Tokina ATX-i 11-20 mm f/2.8 CF",
+        "url": "https://www.lenstip.com/1702-Tokina_ATX-i_11-20_mm_f_2.8_CF-lens_specifications.html"
+      },
+      {
+        "id": 1777,
+        "name": "Tokina ATX-i 17-35 mm f/4",
+        "url": "https://www.lenstip.com/1777-Tokina_ATX-i_17-35_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 1613,
+        "name": "Tokina Firin 100 mm f/2.8 FE AF Macro",
+        "url": "https://www.lenstip.com/1613-Tokina_Firin_100_mm_f_2.8_FE_AF_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1514,
+        "name": "Tokina FпїЅrin 20 mm f/2 FE AF",
+        "url": "https://www.lenstip.com/1514-Tokina_FпїЅrin_20_mm_f_2_FE_AF-lens_specifications.html"
+      },
+      {
+        "id": 1391,
+        "name": "Tokina FпїЅrin 20 mm f/2 FE MF",
+        "url": "https://www.lenstip.com/1391-Tokina_FпїЅrin_20_mm_f_2_FE_MF-lens_specifications.html"
+      },
+      {
+        "id": 1599,
+        "name": "Tokina Opera 16-28 mm f/2.8 FF",
+        "url": "https://www.lenstip.com/1599-Tokina_Opera_16-28_mm_f_2.8_FF-lens_specifications.html"
+      },
+      {
+        "id": 1567,
+        "name": "Tokina Opera 50 mm f/1.4 FF",
+        "url": "https://www.lenstip.com/1567-Tokina_Opera_50_mm_f_1.4_FF-lens_specifications.html"
+      },
+      {
+        "id": 1030,
+        "name": "Tokina Reflex 300 mm f/6.3",
+        "url": "https://www.lenstip.com/1030-Tokina_Reflex_300_mm_f_6.3_-lens_specifications.html"
+      },
+      {
+        "id": 108,
+        "name": "Tokina SL-17 MF 17 mm f/3.5",
+        "url": "https://www.lenstip.com/108-Tokina_SL-17_MF_17_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 96,
+        "name": "Tokina SL-28 MF 28 mm f/2.8",
+        "url": "https://www.lenstip.com/96-Tokina_SL-28_MF_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1990,
+        "name": "Tokina SZ 300 mm f/7.1 PRO Reflex MF CF",
+        "url": "https://www.lenstip.com/1990-Tokina_SZ_300_mm_f_7.1_PRO_Reflex_MF_CF-lens_specifications.html"
+      },
+      {
+        "id": 1945,
+        "name": "Tokina SZ 33 mm f/1.2",
+        "url": "https://www.lenstip.com/1945-Tokina_SZ_33_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1991,
+        "name": "Tokina SZ 600 mm f/8 PRO Reflex MF CF",
+        "url": "https://www.lenstip.com/1991-Tokina_SZ_600_mm_f_8_PRO_Reflex_MF_CF-lens_specifications.html"
+      },
+      {
+        "id": 1920,
+        "name": "Tokina SZ 8 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1920-Tokina_SZ_8_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1992,
+        "name": "Tokina SZ 900 mm f/11 PRO Reflex MF CF",
+        "url": "https://www.lenstip.com/1992-Tokina_SZ_900_mm_f_11_PRO_Reflex_MF_CF-lens_specifications.html"
+      },
+      {
+        "id": 1914,
+        "name": "Tokina SZ Super Tele 500 mm f/8 Reflex MF",
+        "url": "https://www.lenstip.com/1914-Tokina_SZ_Super_Tele_500_mm_f_8_Reflex_MF-lens_specifications.html"
+      },
+      {
+        "id": 91,
+        "name": "Tokina SZ-X 205 MF 28-105 mm f/3.5-4.8",
+        "url": "https://www.lenstip.com/91-Tokina_SZ-X_205_MF_28-105_mm_f_3.5-4.8-lens_specifications.html"
+      },
+      {
+        "id": 93,
+        "name": "Tokina SZ-X 270 - II MF 28-70 mm f/3.9-4.8",
+        "url": "https://www.lenstip.com/93-Tokina_SZ-X_270_-_II_MF_28-70_mm_f_3.9-4.8-lens_specifications.html"
+      },
+      {
+        "id": 106,
+        "name": "Tokina SZ-X 270 SD MF 28-70 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/106-Tokina_SZ-X_270_SD_MF_28-70_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 94,
+        "name": "Tokina SZ-X 282 MF 28-200 mm f/3.5-5.3",
+        "url": "https://www.lenstip.com/94-Tokina_SZ-X_282_MF_28-200_mm_f_3.5-5.3-lens_specifications.html"
+      },
+      {
+        "id": 95,
+        "name": "Tokina SZ-X 630 MF 60-300 mm f/4-5.6",
+        "url": "https://www.lenstip.com/95-Tokina_SZ-X_630_MF_60-300_mm_f_4-5.6-lens_specifications.html"
+      },
+      {
+        "id": 92,
+        "name": "Tokina SZ-X 721 MF 70-210 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/92-Tokina_SZ-X_721_MF_70-210_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 107,
+        "name": "Tokina SZ-X 730 MF 75-300 mm /4.5-5.6",
+        "url": "https://www.lenstip.com/107-Tokina_SZ-X_730_MF_75-300_mm__4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1718,
+        "name": "Tokina SZX Super Tele 400 mm f/8 Reflex MF",
+        "url": "https://www.lenstip.com/1718-Tokina_SZX_Super_Tele_400_mm_f_8_Reflex_MF-lens_specifications.html"
+      }
+    ],
+    "TTartisan": [
+      {
+        "id": 2099,
+        "name": "TTartisan 10 mm f/2",
+        "url": "https://www.lenstip.com/2099-TTartisan_10_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 2065,
+        "name": "TTartisan 100 mm f/2.8 Soap Bubble Bokeh",
+        "url": "https://www.lenstip.com/2065-TTartisan_100_mm_f_2.8_Soap_Bubble_Bokeh-lens_specifications.html"
+      },
+      {
+        "id": 2087,
+        "name": "TTartisan 11 mm f/2.8 Fisheye (DSLR)",
+        "url": "https://www.lenstip.com/2087-TTartisan_11_mm_f_2.8_Fisheye_(DSLR)-lens_specifications.html"
+      },
+      {
+        "id": 1787,
+        "name": "TTartisan 11 mm f/2.8 Fisheye (Mirrorless)",
+        "url": "https://www.lenstip.com/1787-TTartisan_11_mm_f_2.8_Fisheye_(Mirrorless)-lens_specifications.html"
+      },
+      {
+        "id": 2255,
+        "name": "TTartisan 14 mm f/2.8 ASPH",
+        "url": "https://www.lenstip.com/2255-TTartisan_14_mm_f_2.8_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1846,
+        "name": "TTartisan 17 mm f/1.4",
+        "url": "https://www.lenstip.com/1846-TTartisan_17_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2275,
+        "name": "TTartisan 17 mm f/4 Tilt-Shift ASPH",
+        "url": "https://www.lenstip.com/2275-TTartisan_17_mm_f_4_Tilt-Shift_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1788,
+        "name": "TTartisan 21 mm f/1.5 Leica M",
+        "url": "https://www.lenstip.com/1788-TTartisan_21_mm_f_1.5_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 1906,
+        "name": "TTartisan 23 mm f/1.4",
+        "url": "https://www.lenstip.com/1906-TTartisan_23_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1971,
+        "name": "TTartisan 25 mm f/2.0",
+        "url": "https://www.lenstip.com/1971-TTartisan_25_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 2136,
+        "name": "TTartisan 250 mm f/5.6 Reflex",
+        "url": "https://www.lenstip.com/2136-TTartisan_250_mm_f_5.6_Reflex-lens_specifications.html"
+      },
+      {
+        "id": 1905,
+        "name": "TTartisan 28 mm f/5.6 Leica M",
+        "url": "https://www.lenstip.com/1905-TTartisan_28_mm_f_5.6_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 2000,
+        "name": "TTartisan 35 mm f/0.95",
+        "url": "https://www.lenstip.com/2000-TTartisan_35_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1789,
+        "name": "TTartisan 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1789-TTartisan_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1790,
+        "name": "TTartisan 35 mm f/1.4 Leica M",
+        "url": "https://www.lenstip.com/1790-TTartisan_35_mm_f_1.4_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 1963,
+        "name": "TTartisan 35 mm f/2.0 APO Leica M",
+        "url": "https://www.lenstip.com/1963-TTartisan_35_mm_f_2.0_APO_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 1879,
+        "name": "TTartisan 40 mm f/2.8 Macro",
+        "url": "https://www.lenstip.com/1879-TTartisan_40_mm_f_2.8_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1939,
+        "name": "TTartisan 50 mm f/0.95",
+        "url": "https://www.lenstip.com/1939-TTartisan_50_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1791,
+        "name": "TTartisan 50 mm f/0.95 Leica M",
+        "url": "https://www.lenstip.com/1791-TTartisan_50_mm_f_0.95_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 1793,
+        "name": "TTartisan 50 mm f/1.2",
+        "url": "https://www.lenstip.com/1793-TTartisan_50_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1863,
+        "name": "TTartisan 50 mm f/1.4 ASPH",
+        "url": "https://www.lenstip.com/1863-TTartisan_50_mm_f_1.4_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1792,
+        "name": "TTartisan 50 mm f/1.4 Leica M",
+        "url": "https://www.lenstip.com/1792-TTartisan_50_mm_f_1.4_Leica_M-lens_specifications.html"
+      },
+      {
+        "id": 1962,
+        "name": "TTartisan 50 mm f/2",
+        "url": "https://www.lenstip.com/1962-TTartisan_50_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 2078,
+        "name": "TTartisan 500 mm f/6.3",
+        "url": "https://www.lenstip.com/2078-TTartisan_500_mm_f_6.3-lens_specifications.html"
+      },
+      {
+        "id": 1860,
+        "name": "TTartisan 7.5 mm f/2 Fisheye",
+        "url": "https://www.lenstip.com/1860-TTartisan_7.5_mm_f_2_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2170,
+        "name": "TTartisan 75 mm f/1.5 Swirly Bokeh",
+        "url": "https://www.lenstip.com/2170-TTartisan_75_mm_f_1.5_Swirly_Bokeh-lens_specifications.html"
+      },
+      {
+        "id": 1840,
+        "name": "TTartisan 90 mm f/1.25",
+        "url": "https://www.lenstip.com/1840-TTartisan_90_mm_f_1.25-lens_specifications.html"
+      },
+      {
+        "id": 2215,
+        "name": "TTartisan AF 14 mm f/3.5",
+        "url": "https://www.lenstip.com/2215-TTartisan_AF_14_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 2324,
+        "name": "TTartisan AF 17 mm f/1.8 Air",
+        "url": "https://www.lenstip.com/2324-TTartisan_AF_17_mm_f_1.8_Air-lens_specifications.html"
+      },
+      {
+        "id": 2196,
+        "name": "TTartisan AF 23 mm f/1.8",
+        "url": "https://www.lenstip.com/2196-TTartisan_AF_23_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1995,
+        "name": "TTartisan AF 27 mm f/2.8",
+        "url": "https://www.lenstip.com/1995-TTartisan_AF_27_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2083,
+        "name": "TTartisan AF 35 mm f/1.8",
+        "url": "https://www.lenstip.com/2083-TTartisan_AF_35_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2191,
+        "name": "TTartisan AF 35 mm f/1.8 II",
+        "url": "https://www.lenstip.com/2191-TTartisan_AF_35_mm_f_1.8_II-lens_specifications.html"
+      },
+      {
+        "id": 2250,
+        "name": "TTartisan AF 40 mm f/2 ED ASPH",
+        "url": "https://www.lenstip.com/2250-TTartisan_AF_40_mm_f_2_ED_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2097,
+        "name": "TTartisan AF 56 mm f/1.8",
+        "url": "https://www.lenstip.com/2097-TTartisan_AF_56_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2167,
+        "name": "TTartisan AF 75 mm f/2 ED",
+        "url": "https://www.lenstip.com/2167-TTartisan_AF_75_mm_f_2_ED-lens_specifications.html"
+      },
+      {
+        "id": 2228,
+        "name": "TTartisan Tilt 35 mm f/1.4 APS-C",
+        "url": "https://www.lenstip.com/2228-TTartisan_Tilt_35_mm_f_1.4_APS-C-lens_specifications.html"
+      },
+      {
+        "id": 1985,
+        "name": "TTartisan Tilt 50 mm f/1.4",
+        "url": "https://www.lenstip.com/1985-TTartisan_Tilt_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2049,
+        "name": "TTartisan Tilt-Shift 100 mm f/2.8 2x Macro",
+        "url": "https://www.lenstip.com/2049-TTartisan_Tilt-Shift_100_mm_f_2.8_2x_Macro-lens_specifications.html"
+      }
+    ],
+    "Venus Optics LAOWA": [
+      {
+        "id": 1925,
+        "name": "Venus Optics LAOWA 10 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1925-Venus_Optics_LAOWA_10_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1782,
+        "name": "Venus Optics LAOWA 10 mm f/2 Zero-D MFT",
+        "url": "https://www.lenstip.com/1782-Venus_Optics_LAOWA_10_mm_f_2_Zero-D_MFT-lens_specifications.html"
+      },
+      {
+        "id": 1964,
+        "name": "Venus Optics LAOWA 10 mm f/4 Cookie",
+        "url": "https://www.lenstip.com/1964-Venus_Optics_LAOWA_10_mm_f_4_Cookie-lens_specifications.html"
+      },
+      {
+        "id": 1524,
+        "name": "Venus Optics LAOWA 10-18 mm f/4.5-5.6 Zoom",
+        "url": "https://www.lenstip.com/1524-Venus_Optics_LAOWA_10-18_mm_f_4.5-5.6_Zoom-lens_specifications.html"
+      },
+      {
+        "id": 1525,
+        "name": "Venus Optics LAOWA 100 mm f/2.8 2X Ultra Macro APO",
+        "url": "https://www.lenstip.com/1525-Venus_Optics_LAOWA_100_mm_f_2.8_2X_Ultra_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 2128,
+        "name": "Venus Optics LAOWA 100 mm f/2.8 Tilt-Shift 1x Macro",
+        "url": "https://www.lenstip.com/2128-Venus_Optics_LAOWA_100_mm_f_2.8_Tilt-Shift_1x_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1740,
+        "name": "Venus Optics LAOWA 11 mm f/4.5 FF RL",
+        "url": "https://www.lenstip.com/1740-Venus_Optics_LAOWA_11_mm_f_4.5_FF_RL-lens_specifications.html"
+      },
+      {
+        "id": 1584,
+        "name": "Venus Optics LAOWA 12 mm T2.9 Zero-D Cine",
+        "url": "https://www.lenstip.com/1584-Venus_Optics_LAOWA_12_mm_T2.9_Zero-D_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1581,
+        "name": "Venus Optics LAOWA 12 mm f/1.8 MFT",
+        "url": "https://www.lenstip.com/1581-Venus_Optics_LAOWA_12_mm_f_1.8_MFT_-lens_specifications.html"
+      },
+      {
+        "id": 2240,
+        "name": "Venus Optics LAOWA 12 mm f/2.8 Lite Zero-D FF",
+        "url": "https://www.lenstip.com/2240-Venus_Optics_LAOWA_12_mm_f_2.8_Lite_Zero-D_FF-lens_specifications.html"
+      },
+      {
+        "id": 1408,
+        "name": "Venus Optics LAOWA 12 mm f/2.8 ZERO-D",
+        "url": "https://www.lenstip.com/1408-Venus_Optics_LAOWA_12_mm_f_2.8_ZERO-D_-lens_specifications.html"
+      },
+      {
+        "id": 1796,
+        "name": "Venus Optics LAOWA 12-24 mm f/5.6 C-Dreamer",
+        "url": "https://www.lenstip.com/1796-Venus_Optics_LAOWA_12-24_mm_f_5.6_C-Dreamer-lens_specifications.html"
+      },
+      {
+        "id": 2148,
+        "name": "Venus Optics LAOWA 12-24 mm f/5.6 CF Shift",
+        "url": "https://www.lenstip.com/2148-Venus_Optics_LAOWA_12-24_mm_f_5.6_CF_Shift-lens_specifications.html"
+      },
+      {
+        "id": 1748,
+        "name": "Venus Optics LAOWA 14 mm f/4 FF RL Zero-D",
+        "url": "https://www.lenstip.com/1748-Venus_Optics_LAOWA_14_mm_f_4_FF_RL_Zero-D-lens_specifications.html"
+      },
+      {
+        "id": 1859,
+        "name": "Venus Optics LAOWA 14 mm f/4 Zero-D DSLR",
+        "url": "https://www.lenstip.com/1859-Venus_Optics_LAOWA_14_mm_f_4_Zero-D_DSLR-lens_specifications.html"
+      },
+      {
+        "id": 1704,
+        "name": "Venus Optics LAOWA 15 mm T2.1 Zero-D Cine",
+        "url": "https://www.lenstip.com/1704-Venus_Optics_LAOWA_15_mm_T2.1_Zero-D_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1395,
+        "name": "Venus Optics LAOWA 15 mm f/2 ZERO-D",
+        "url": "https://www.lenstip.com/1395-Venus_Optics_LAOWA_15_mm_f_2_ZERO-D-lens_specifications.html"
+      },
+      {
+        "id": 1346,
+        "name": "Venus Optics LAOWA 15 mm f/4 Wide-Angle 1:1 Macro",
+        "url": "https://www.lenstip.com/1346-Venus_Optics_LAOWA_15_mm_f_4_Wide-Angle_1:1_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2230,
+        "name": "Venus Optics LAOWA 15 mm f/4.5 0.5x Macro",
+        "url": "https://www.lenstip.com/2230-Venus_Optics_LAOWA_15_mm_f_4.5_0.5x_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1763,
+        "name": "Venus Optics LAOWA 15 mm f/4.5 Zero-D Shift",
+        "url": "https://www.lenstip.com/1763-Venus_Optics_LAOWA_15_mm_f_4.5_Zero-D_Shift-lens_specifications.html"
+      },
+      {
+        "id": 1926,
+        "name": "Venus Optics LAOWA 17 mm T1.9 Cine",
+        "url": "https://www.lenstip.com/1926-Venus_Optics_LAOWA_17_mm_T1.9_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1580,
+        "name": "Venus Optics LAOWA 17 mm f/1.8 MFT",
+        "url": "https://www.lenstip.com/1580-Venus_Optics_LAOWA_17_mm_f_1.8_MFT-lens_specifications.html"
+      },
+      {
+        "id": 1653,
+        "name": "Venus Optics LAOWA 17 mm f/1.8 MFT II",
+        "url": "https://www.lenstip.com/1653-Venus_Optics_LAOWA_17_mm_f_1.8_MFT_II-lens_specifications.html"
+      },
+      {
+        "id": 1526,
+        "name": "Venus Optics LAOWA 17 mm f/4 GFX Zero-D",
+        "url": "https://www.lenstip.com/1526-Venus_Optics_LAOWA_17_mm_f_4_GFX_Zero-D-lens_specifications.html"
+      },
+      {
+        "id": 2321,
+        "name": "Venus Optics LAOWA 17 mm f/4 Zero-D Shift",
+        "url": "https://www.lenstip.com/2321-Venus_Optics_LAOWA_17_mm_f_4_Zero-D_Shift-lens_specifications.html"
+      },
+      {
+        "id": 2322,
+        "name": "Venus Optics LAOWA 17 mm f/4 Zero-D Tilt-Shift",
+        "url": "https://www.lenstip.com/2322-Venus_Optics_LAOWA_17_mm_f_4_Zero-D_Tilt-Shift-lens_specifications.html"
+      },
+      {
+        "id": 2268,
+        "name": "Venus Optics LAOWA 180 mm f/4.5 1.5x Ultra Macro APO",
+        "url": "https://www.lenstip.com/2268-Venus_Optics_LAOWA_180_mm_f_4.5_1.5x_Ultra_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 2010,
+        "name": "Venus Optics LAOWA 19 mm f/2.8 Zero-D GFX",
+        "url": "https://www.lenstip.com/2010-Venus_Optics_LAOWA_19_mm_f_2.8_Zero-D_GFX-lens_specifications.html"
+      },
+      {
+        "id": 1934,
+        "name": "Venus Optics LAOWA 20 mm f/4 Zero-D Shift",
+        "url": "https://www.lenstip.com/1934-Venus_Optics_LAOWA_20_mm_f_4_Zero-D_Shift-lens_specifications.html"
+      },
+      {
+        "id": 2276,
+        "name": "Venus Optics LAOWA 200 mm f/2 AF FF",
+        "url": "https://www.lenstip.com/2276-Venus_Optics_LAOWA_200_mm_f_2_AF_FF-lens_specifications.html"
+      },
+      {
+        "id": 2066,
+        "name": "Venus Optics LAOWA 24 mm T8 2x Macro Pro2be",
+        "url": "https://www.lenstip.com/2066-Venus_Optics_LAOWA_24_mm_T8_2x_Macro_Pro2be-lens_specifications.html"
+      },
+      {
+        "id": 1549,
+        "name": "Venus Optics LAOWA 24 mm f/14 Relay 2X",
+        "url": "https://www.lenstip.com/1549-Venus_Optics_LAOWA_24_mm_f_14_Relay_2X-lens_specifications.html"
+      },
+      {
+        "id": 1516,
+        "name": "Venus Optics LAOWA 25 mm f/2.8 2.5-5X Ultra Macro",
+        "url": "https://www.lenstip.com/1516-Venus_Optics_LAOWA_25_mm_f_2.8_2.5-5X_Ultra_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1579,
+        "name": "Venus Optics LAOWA 25-100 mm T2.9 Cine",
+        "url": "https://www.lenstip.com/1579-Venus_Optics_LAOWA_25-100_mm_T2.9_Cine-lens_specifications.html"
+      },
+      {
+        "id": 2289,
+        "name": "Venus Optics LAOWA 35 mm f/2.8 Zero-D Tilt Shift 0.5x Macro",
+        "url": "https://www.lenstip.com/2289-Venus_Optics_LAOWA_35_mm_f_2.8_Zero-D_Tilt_Shift_0.5x_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1527,
+        "name": "Venus Optics LAOWA 4 mm f/2.8 Fisheye",
+        "url": "https://www.lenstip.com/1527-Venus_Optics_LAOWA_4_mm_f_2.8_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2333,
+        "name": "Venus Optics LAOWA 4.5-10 mm f/2.8 CF Zoom Fisheye",
+        "url": "https://www.lenstip.com/2333-Venus_Optics_LAOWA_4.5-10_mm_f_2.8_CF_Zoom_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 1927,
+        "name": "Venus Optics LAOWA 50 mm T2.9 Macro APO Cine",
+        "url": "https://www.lenstip.com/1927-Venus_Optics_LAOWA_50_mm_T2.9_Macro_APO_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1739,
+        "name": "Venus Optics LAOWA 50 mm f/2.8 2X Ultra Macro APO",
+        "url": "https://www.lenstip.com/1739-Venus_Optics_LAOWA_50_mm_f_2.8_2X_Ultra_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 2129,
+        "name": "Venus Optics LAOWA 55 mm f/2.8 Tilt-Shift 1x Macro",
+        "url": "https://www.lenstip.com/2129-Venus_Optics_LAOWA_55_mm_f_2.8_Tilt-Shift_1x_Macro-lens_specifications.html"
+      },
+      {
+        "id": 1982,
+        "name": "Venus Optics LAOWA 58 mm f/2.8 2X Ultra Macro APO",
+        "url": "https://www.lenstip.com/1982-Venus_Optics_LAOWA_58_mm_f_2.8_2X_Ultra_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 1924,
+        "name": "Venus Optics LAOWA 6 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1924-Venus_Optics_LAOWA_6_mm_T2.1_Cine-lens_specifications.html"
+      },
+      {
+        "id": 2013,
+        "name": "Venus Optics LAOWA 6 mm f/2 Zero-D MFT",
+        "url": "https://www.lenstip.com/2013-Venus_Optics_LAOWA_6_mm_f_2_Zero-D_MFT-lens_specifications.html"
+      },
+      {
+        "id": 1347,
+        "name": "Venus Optics LAOWA 60 mm f/2.8 Ultra-Macro Lens",
+        "url": "https://www.lenstip.com/1347-Venus_Optics_LAOWA_60_mm_f_2.8_Ultra-Macro_Lens-lens_specifications.html"
+      },
+      {
+        "id": 1674,
+        "name": "Venus Optics LAOWA 65 mm f/2.8 2x Macro APO",
+        "url": "https://www.lenstip.com/1674-Venus_Optics_LAOWA_65_mm_f_2.8_2x_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 1582,
+        "name": "Venus Optics LAOWA 7.5 mm T2.1 Cine",
+        "url": "https://www.lenstip.com/1582-Venus_Optics_LAOWA_7.5_mm_T2.1_Cine_-lens_specifications.html"
+      },
+      {
+        "id": 1928,
+        "name": "Venus Optics LAOWA 7.5 mm T2.9 Zero-D S35 Cine",
+        "url": "https://www.lenstip.com/1928-Venus_Optics_LAOWA_7.5_mm_T2.9_Zero-D_S35_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1396,
+        "name": "Venus Optics LAOWA 7.5 mm f/2 MFT",
+        "url": "https://www.lenstip.com/1396-Venus_Optics_LAOWA_7.5_mm_f_2_MFT-lens_specifications.html"
+      },
+      {
+        "id": 2233,
+        "name": "Venus Optics LAOWA 8-15 mm f/2.8 FF Zoom Fisheye",
+        "url": "https://www.lenstip.com/2233-Venus_Optics_LAOWA_8-15_mm_f_2.8_FF_Zoom_Fisheye-lens_specifications.html"
+      },
+      {
+        "id": 2084,
+        "name": "Venus Optics LAOWA 8-16 mm f/3.5-5 Zoom CF",
+        "url": "https://www.lenstip.com/2084-Venus_Optics_LAOWA_8-16_mm_f_3.5-5_Zoom_CF-lens_specifications.html"
+      },
+      {
+        "id": 1907,
+        "name": "Venus Optics LAOWA 85 mm f/5.6 2x Ultra Macro APO",
+        "url": "https://www.lenstip.com/1907-Venus_Optics_LAOWA_85_mm_f_5.6_2x_Ultra_Macro_APO-lens_specifications.html"
+      },
+      {
+        "id": 1583,
+        "name": "Venus Optics LAOWA 9 mm T2.9 Zero-D Cine",
+        "url": "https://www.lenstip.com/1583-Venus_Optics_LAOWA_9_mm_T2.9_Zero-D_Cine-lens_specifications.html"
+      },
+      {
+        "id": 1515,
+        "name": "Venus Optics LAOWA 9 mm f/2.8 ZERO-D",
+        "url": "https://www.lenstip.com/1515-Venus_Optics_LAOWA_9_mm_f_2.8_ZERO-D-lens_specifications.html"
+      },
+      {
+        "id": 1708,
+        "name": "Venus Optics LAOWA 9 mm f/5.6 FF RL",
+        "url": "https://www.lenstip.com/1708-Venus_Optics_LAOWA_9_mm_f_5.6_FF_RL-lens_specifications.html"
+      },
+      {
+        "id": 1994,
+        "name": "Venus Optics LAOWA Argus 18 mm f/0.95 MFT APO",
+        "url": "https://www.lenstip.com/1994-Venus_Optics_LAOWA_Argus_18_mm_f_0.95_MFT_APO-lens_specifications.html"
+      },
+      {
+        "id": 1993,
+        "name": "Venus Optics LAOWA Argus 25 mm f/0.95 CF APO",
+        "url": "https://www.lenstip.com/1993-Venus_Optics_LAOWA_Argus_25_mm_f_0.95_CF_APO-lens_specifications.html"
+      },
+      {
+        "id": 1797,
+        "name": "Venus Optics LAOWA Argus 25 mm f/0.95 MFT",
+        "url": "https://www.lenstip.com/1797-Venus_Optics_LAOWA_Argus_25_mm_f_0.95_MFT-lens_specifications.html"
+      },
+      {
+        "id": 2039,
+        "name": "Venus Optics LAOWA Argus 28 mm f/1.2 FF",
+        "url": "https://www.lenstip.com/2039-Venus_Optics_LAOWA_Argus_28_mm_f_1.2_FF-lens_specifications.html"
+      },
+      {
+        "id": 1798,
+        "name": "Venus Optics LAOWA Argus 33 mm f/0.95 CF APO",
+        "url": "https://www.lenstip.com/1798-Venus_Optics_LAOWA_Argus_33_mm_f_0.95_CF_APO-lens_specifications.html"
+      },
+      {
+        "id": 1799,
+        "name": "Venus Optics LAOWA Argus 35 mm f/0.95 FF",
+        "url": "https://www.lenstip.com/1799-Venus_Optics_LAOWA_Argus_35_mm_f_0.95_FF-lens_specifications.html"
+      },
+      {
+        "id": 1800,
+        "name": "Venus Optics LAOWA Argus 45 mm f/0.95 FF",
+        "url": "https://www.lenstip.com/1800-Venus_Optics_LAOWA_Argus_45_mm_f_0.95_FF-lens_specifications.html"
+      },
+      {
+        "id": 2101,
+        "name": "Venus Optics LAOWA FFII 10 mm f/2.8 CD-Dreamer",
+        "url": "https://www.lenstip.com/2101-Venus_Optics_LAOWA_FFII_10_mm_f_2.8_CD-Dreamer-lens_specifications.html"
+      },
+      {
+        "id": 2130,
+        "name": "Venus Optics LAOWA FFII 15 mm f/5.0 Cookie",
+        "url": "https://www.lenstip.com/2130-Venus_Optics_LAOWA_FFII_15_mm_f_5.0_Cookie-lens_specifications.html"
+      },
+      {
+        "id": 1951,
+        "name": "Venus Optics LAOWA FFII 90 mm f/2.8 CA-Dreamer Macro 2X",
+        "url": "https://www.lenstip.com/1951-Venus_Optics_LAOWA_FFII_90_mm_f_2.8_CA-Dreamer_Macro_2X-lens_specifications.html"
+      },
+      {
+        "id": 1348,
+        "name": "Venus Optics LAOWA STF 105 mm f/2 (T3.2)",
+        "url": "https://www.lenstip.com/1348-Venus_Optics_LAOWA_STF_105_mm_f_2_(T3.2)-lens_specifications.html"
+      }
+    ],
+    "Viltrox": [
+      {
+        "id": 1911,
+        "name": "Viltrox AF 13 mm f/1.4 XF",
+        "url": "https://www.lenstip.com/1911-Viltrox_AF_13_mm_f_1.4_XF-lens_specifications.html"
+      },
+      {
+        "id": 2183,
+        "name": "Viltrox AF 135 mm f/1.8 LAB",
+        "url": "https://www.lenstip.com/2183-Viltrox_AF_135_mm_f_1.8_LAB-lens_specifications.html"
+      },
+      {
+        "id": 2270,
+        "name": "Viltrox AF 14 mm f/4 Air",
+        "url": "https://www.lenstip.com/2270-Viltrox_AF_14_mm_f_4_Air-lens_specifications.html"
+      },
+      {
+        "id": 2247,
+        "name": "Viltrox AF 15 mm f/1.7 Air",
+        "url": "https://www.lenstip.com/2247-Viltrox_AF_15_mm_f_1.7_Air-lens_specifications.html"
+      },
+      {
+        "id": 2052,
+        "name": "Viltrox AF 16 mm f/1.8",
+        "url": "https://www.lenstip.com/2052-Viltrox_AF_16_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2088,
+        "name": "Viltrox AF 20 mm f/2.8 Air",
+        "url": "https://www.lenstip.com/2088-Viltrox_AF_20_mm_f_2.8_Air-lens_specifications.html"
+      },
+      {
+        "id": 1693,
+        "name": "Viltrox AF 23 mm f/1.4 XF",
+        "url": "https://www.lenstip.com/1693-Viltrox_AF_23_mm_f_1.4_XF-lens_specifications.html"
+      },
+      {
+        "id": 1784,
+        "name": "Viltrox AF 24 mm f/1.8 FE / Z",
+        "url": "https://www.lenstip.com/1784-Viltrox_AF_24_mm_f_1.8_FE___Z-lens_specifications.html"
+      },
+      {
+        "id": 2212,
+        "name": "Viltrox AF 25 mm f/1.7 Air",
+        "url": "https://www.lenstip.com/2212-Viltrox_AF_25_mm_f_1.7_Air-lens_specifications.html"
+      },
+      {
+        "id": 2069,
+        "name": "Viltrox AF 27 mm f/1.2",
+        "url": "https://www.lenstip.com/2069-Viltrox_AF_27_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2048,
+        "name": "Viltrox AF 28 mm f/1.8",
+        "url": "https://www.lenstip.com/2048-Viltrox_AF_28_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2172,
+        "name": "Viltrox AF 28 mm f/4.5 FE Pancake",
+        "url": "https://www.lenstip.com/2172-Viltrox_AF_28_mm_f_4.5_FE_Pancake-lens_specifications.html"
+      },
+      {
+        "id": 1686,
+        "name": "Viltrox AF 33 mm f/1.4 STM ED IF",
+        "url": "https://www.lenstip.com/1686-Viltrox_AF_33_mm_f_1.4_STM_ED_IF-lens_specifications.html"
+      },
+      {
+        "id": 2224,
+        "name": "Viltrox AF 35 mm f/1.2 LAB",
+        "url": "https://www.lenstip.com/2224-Viltrox_AF_35_mm_f_1.2_LAB-lens_specifications.html"
+      },
+      {
+        "id": 2195,
+        "name": "Viltrox AF 35 mm f/1.7 Air",
+        "url": "https://www.lenstip.com/2195-Viltrox_AF_35_mm_f_1.7_Air-lens_specifications.html"
+      },
+      {
+        "id": 2326,
+        "name": "Viltrox AF 35 mm f/1.8 EVO",
+        "url": "https://www.lenstip.com/2326-Viltrox_AF_35_mm_f_1.8_EVO-lens_specifications.html"
+      },
+      {
+        "id": 1785,
+        "name": "Viltrox AF 35 mm f/1.8 FE / Z",
+        "url": "https://www.lenstip.com/1785-Viltrox_AF_35_mm_f_1.8_FE___Z-lens_specifications.html"
+      },
+      {
+        "id": 2126,
+        "name": "Viltrox AF 40 mm f/2.5 Air",
+        "url": "https://www.lenstip.com/2126-Viltrox_AF_40_mm_f_2.5_Air-lens_specifications.html"
+      },
+      {
+        "id": 2278,
+        "name": "Viltrox AF 50 mm f/1.4 Pro",
+        "url": "https://www.lenstip.com/2278-Viltrox_AF_50_mm_f_1.4_Pro-lens_specifications.html"
+      },
+      {
+        "id": 1786,
+        "name": "Viltrox AF 50 mm f/1.8 FE / Z",
+        "url": "https://www.lenstip.com/1786-Viltrox_AF_50_mm_f_1.8_FE___Z-lens_specifications.html"
+      },
+      {
+        "id": 2218,
+        "name": "Viltrox AF 50 mm f/2.0 Air",
+        "url": "https://www.lenstip.com/2218-Viltrox_AF_50_mm_f_2.0_Air-lens_specifications.html"
+      },
+      {
+        "id": 2327,
+        "name": "Viltrox AF 55 mm f/1.8 EVO",
+        "url": "https://www.lenstip.com/2327-Viltrox_AF_55_mm_f_1.8_EVO-lens_specifications.html"
+      },
+      {
+        "id": 2259,
+        "name": "Viltrox AF 56 mm f/1.2 Pro",
+        "url": "https://www.lenstip.com/2259-Viltrox_AF_56_mm_f_1.2_Pro-lens_specifications.html"
+      },
+      {
+        "id": 1749,
+        "name": "Viltrox AF 56 mm f/1.4 XF",
+        "url": "https://www.lenstip.com/1749-Viltrox_AF_56_mm_f_1.4_XF-lens_specifications.html"
+      },
+      {
+        "id": 2122,
+        "name": "Viltrox AF 56 mm f/1.7 Air",
+        "url": "https://www.lenstip.com/2122-Viltrox_AF_56_mm_f_1.7_Air-lens_specifications.html"
+      },
+      {
+        "id": 2014,
+        "name": "Viltrox AF 75 mm f/1.2",
+        "url": "https://www.lenstip.com/2014-Viltrox_AF_75_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 2235,
+        "name": "Viltrox AF 85 mm f/1.4 Pro",
+        "url": "https://www.lenstip.com/2235-Viltrox_AF_85_mm_f_1.4_Pro-lens_specifications.html"
+      },
+      {
+        "id": 1700,
+        "name": "Viltrox AF 85 mm f/1.8 II FE",
+        "url": "https://www.lenstip.com/1700-Viltrox_AF_85_mm_f_1.8_II_FE-lens_specifications.html"
+      },
+      {
+        "id": 1902,
+        "name": "Viltrox AF 85 mm f/1.8 RF",
+        "url": "https://www.lenstip.com/1902-Viltrox_AF_85_mm_f_1.8_RF-lens_specifications.html"
+      },
+      {
+        "id": 2282,
+        "name": "Viltrox AF 85 mm f/2 EVO",
+        "url": "https://www.lenstip.com/2282-Viltrox_AF_85_mm_f_2_EVO-lens_specifications.html"
+      },
+      {
+        "id": 2269,
+        "name": "Viltrox AF 9 mm f/2.8 Air",
+        "url": "https://www.lenstip.com/2269-Viltrox_AF_9_mm_f_2.8_Air-lens_specifications.html"
+      },
+      {
+        "id": 2246,
+        "name": "Viltrox AF 90 mm f/3.5 DL",
+        "url": "https://www.lenstip.com/2246-Viltrox_AF_90_mm_f_3.5_DL-lens_specifications.html"
+      },
+      {
+        "id": 1688,
+        "name": "Viltrox PFU RBMH 20 mm T2 ASPH",
+        "url": "https://www.lenstip.com/1688-Viltrox_PFU_RBMH_20_mm_T2_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1611,
+        "name": "Viltrox PFU RBMH 20 mm f/1.8 ASPH",
+        "url": "https://www.lenstip.com/1611-Viltrox_PFU_RBMH_20_mm_f_1.8_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 1618,
+        "name": "Viltrox PFU RBMH 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1618-Viltrox_PFU_RBMH_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1617,
+        "name": "Viltrox PFU RBMH 85 mm f/1.8 STM",
+        "url": "https://www.lenstip.com/1617-Viltrox_PFU_RBMH_85_mm_f_1.8_STM-lens_specifications.html"
+      }
+    ],
+    "Vivitar": [
+      {
+        "id": 520,
+        "name": "Vivitar AF 100 mm f/3.5 Macro",
+        "url": "https://www.lenstip.com/520-Vivitar_AF_100_mm_f_3.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 521,
+        "name": "Vivitar AF 100-300 mm f/5.6-6.7",
+        "url": "https://www.lenstip.com/521-Vivitar_AF_100-300_mm_f_5.6-6.7-lens_specifications.html"
+      },
+      {
+        "id": 516,
+        "name": "Vivitar AF S1 19-35 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/516-Vivitar_AF_S1_19-35_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 517,
+        "name": "Vivitar AF S1 28-210 mm f/4.2-6.5",
+        "url": "https://www.lenstip.com/517-Vivitar_AF_S1_28-210_mm_f_4.2-6.5-lens_specifications.html"
+      },
+      {
+        "id": 518,
+        "name": "Vivitar AF S1 28-300 mm f/4-6.3",
+        "url": "https://www.lenstip.com/518-Vivitar_AF_S1_28-300_mm_f_4-6.3-lens_specifications.html"
+      },
+      {
+        "id": 525,
+        "name": "Vivitar MF 100-300 mm f/5.6-6.7",
+        "url": "https://www.lenstip.com/525-Vivitar_MF_100-300_mm_f_5.6-6.7-lens_specifications.html"
+      },
+      {
+        "id": 523,
+        "name": "Vivitar MF 28-210 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/523-Vivitar_MF_28-210_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 522,
+        "name": "Vivitar MF 28-80 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/522-Vivitar_MF_28-80_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 527,
+        "name": "Vivitar MF 500 mm f/8 Mirror",
+        "url": "https://www.lenstip.com/527-Vivitar_MF_500_mm_f_8_Mirror-lens_specifications.html"
+      },
+      {
+        "id": 526,
+        "name": "Vivitar MF 600-1000 mm",
+        "url": "https://www.lenstip.com/526-Vivitar_MF_600-1000_mm-lens_specifications.html"
+      },
+      {
+        "id": 524,
+        "name": "Vivitar MF 70-210 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/524-Vivitar_MF_70-210_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 519,
+        "name": "Vivitar S1 AF 100-400 mm f/4.5-6.7",
+        "url": "https://www.lenstip.com/519-Vivitar_S1_AF_100-400_mm_f_4.5-6.7-lens_specifications.html"
+      }
+    ],
+    "Voigtlander": [
+      {
+        "id": 1681,
+        "name": "Voigtlander 21 mm f/1.4 Aspherical VM",
+        "url": "https://www.lenstip.com/1681-Voigtlander_21_mm_f_1.4_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 1520,
+        "name": "Voigtlander Apo Lanthar 110 mm f/2.5 Macro",
+        "url": "https://www.lenstip.com/1520-Voigtlander_Apo_Lanthar_110_mm_f_2.5_Macro-lens_specifications.html"
+      },
+      {
+        "id": 2239,
+        "name": "Voigtlander Apo Lanthar 28 mm f/2 Aspherical",
+        "url": "https://www.lenstip.com/2239-Voigtlander_Apo_Lanthar_28_mm_f_2_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1808,
+        "name": "Voigtlander Apo Lanthar 35 mm f/2 Aspherical",
+        "url": "https://www.lenstip.com/1808-Voigtlander_Apo_Lanthar_35_mm_f_2_Aspherical_-lens_specifications.html"
+      },
+      {
+        "id": 1780,
+        "name": "Voigtlander Apo Lanthar 50 mm f/2 Aspherical",
+        "url": "https://www.lenstip.com/1780-Voigtlander_Apo_Lanthar_50_mm_f_2_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1853,
+        "name": "Voigtlander Apo Lanthar 50 mm f/2 Aspherical VM",
+        "url": "https://www.lenstip.com/1853-Voigtlander_Apo_Lanthar_50_mm_f_2_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 2146,
+        "name": "Voigtlander Apo Lanthar 50 mm f/3.5 VM Type I",
+        "url": "https://www.lenstip.com/2146-Voigtlander_Apo_Lanthar_50_mm_f_3.5_VM_Type_I-lens_specifications.html"
+      },
+      {
+        "id": 2147,
+        "name": "Voigtlander Apo Lanthar 50 mm f/3.5 VM Type II",
+        "url": "https://www.lenstip.com/2147-Voigtlander_Apo_Lanthar_50_mm_f_3.5_VM_Type_II-lens_specifications.html"
+      },
+      {
+        "id": 702,
+        "name": "Voigtlander Apo Lanthar 90 mm f/3.5",
+        "url": "https://www.lenstip.com/702-Voigtlander_Apo_Lanthar_90_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 907,
+        "name": "Voigtlander Apo Lanthar 90 mm f/3.5 SL II",
+        "url": "https://www.lenstip.com/907-Voigtlander_Apo_Lanthar_90_mm_f_3.5_SL_II-lens_specifications.html"
+      },
+      {
+        "id": 2319,
+        "name": "Voigtlander Apo Lanthar 90 mm f/4 Close Focus VM",
+        "url": "https://www.lenstip.com/2319-Voigtlander_Apo_Lanthar_90_mm_f_4_Close_Focus_VM-lens_specifications.html"
+      },
+      {
+        "id": 2320,
+        "name": "Voigtlander Apo Skopar 75 mm f/2.8 VM",
+        "url": "https://www.lenstip.com/2320-Voigtlander_Apo_Skopar_75_mm_f_2.8_VM-lens_specifications.html"
+      },
+      {
+        "id": 1892,
+        "name": "Voigtlander Apo Skopar 90 mm f/2.8 SL II S",
+        "url": "https://www.lenstip.com/1892-Voigtlander_Apo_Skopar_90_mm_f_2.8_SL_II_S-lens_specifications.html"
+      },
+      {
+        "id": 1891,
+        "name": "Voigtlander Apo Skopar 90 mm f/2.8 VM",
+        "url": "https://www.lenstip.com/1891-Voigtlander_Apo_Skopar_90_mm_f_2.8_VM-lens_specifications.html"
+      },
+      {
+        "id": 2193,
+        "name": "Voigtlander Apo Ultron 90 mm f/2.0 VM",
+        "url": "https://www.lenstip.com/2193-Voigtlander_Apo_Ultron_90_mm_f_2.0_VM-lens_specifications.html"
+      },
+      {
+        "id": 706,
+        "name": "Voigtlander Apo Zoomar AF 210  28-210 mm f/4.2-6.5",
+        "url": "https://www.lenstip.com/706-Voigtlander_Apo_Zoomar_AF_210__28-210_mm_f_4.2-6.5-lens_specifications.html"
+      },
+      {
+        "id": 1414,
+        "name": "Voigtlander Apo-Lanthar 65 mm f/2 Aspherical 1:2 Macro",
+        "url": "https://www.lenstip.com/1414-Voigtlander_Apo-Lanthar_65_mm_f_2_Aspherical_1:2_Macro-lens_specifications.html"
+      },
+      {
+        "id": 696,
+        "name": "Voigtlander Color Heliar 75 mm f/2.5",
+        "url": "https://www.lenstip.com/696-Voigtlander_Color_Heliar_75_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 2107,
+        "name": "Voigtlander Color Skopar 18 mm f/2.8 Aspherical",
+        "url": "https://www.lenstip.com/2107-Voigtlander_Color_Skopar_18_mm_f_2.8_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 835,
+        "name": "Voigtlander Color Skopar 20 mm f/3.5 SL II Aspherical",
+        "url": "https://www.lenstip.com/835-Voigtlander_Color_Skopar_20_mm_f_3.5_SL_II_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1521,
+        "name": "Voigtlander Color Skopar 21 mm f/3.5 Aspherical",
+        "url": "https://www.lenstip.com/1521-Voigtlander_Color_Skopar_21_mm_f_3.5_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1587,
+        "name": "Voigtlander Color Skopar 21 mm f/3.5 Aspherical VM Vintage Line",
+        "url": "https://www.lenstip.com/1587-Voigtlander_Color_Skopar_21_mm_f_3.5_Aspherical_VM_Vintage_Line-lens_specifications.html"
+      },
+      {
+        "id": 1904,
+        "name": "Voigtlander Color Skopar 21 mm f/3.5 Aspherical VM Vintage Line II",
+        "url": "https://www.lenstip.com/1904-Voigtlander_Color_Skopar_21_mm_f_3.5_Aspherical_VM_Vintage_Line_II-lens_specifications.html"
+      },
+      {
+        "id": 692,
+        "name": "Voigtlander Color Skopar 21 mm f/4.0",
+        "url": "https://www.lenstip.com/692-Voigtlander_Color_Skopar_21_mm_f_4.0-lens_specifications.html"
+      },
+      {
+        "id": 1037,
+        "name": "Voigtlander Color Skopar 28 mm f/2.8 SL II",
+        "url": "https://www.lenstip.com/1037-Voigtlander_Color_Skopar_28_mm_f_2.8_SL_II-lens_specifications.html"
+      },
+      {
+        "id": 1878,
+        "name": "Voigtlander Color Skopar 28 mm f/2.8 SL IIs",
+        "url": "https://www.lenstip.com/1878-Voigtlander_Color_Skopar_28_mm_f_2.8_SL_IIs-lens_specifications.html"
+      },
+      {
+        "id": 693,
+        "name": "Voigtlander Color Skopar 28 mm f/3.5",
+        "url": "https://www.lenstip.com/693-Voigtlander_Color_Skopar_28_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 697,
+        "name": "Voigtlander Color Skopar 35 mm f/2.5",
+        "url": "https://www.lenstip.com/697-Voigtlander_Color_Skopar_35_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 2204,
+        "name": "Voigtlander Color Skopar 35 mm f/3.5 Aspherical VM",
+        "url": "https://www.lenstip.com/2204-Voigtlander_Color_Skopar_35_mm_f_3.5_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 2141,
+        "name": "Voigtlander Color Skopar 50 mm f/2.2 VM",
+        "url": "https://www.lenstip.com/2141-Voigtlander_Color_Skopar_50_mm_f_2.2_VM-lens_specifications.html"
+      },
+      {
+        "id": 701,
+        "name": "Voigtlander Color Skopar 50 mm f/2.5",
+        "url": "https://www.lenstip.com/701-Voigtlander_Color_Skopar_50_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 691,
+        "name": "Voigtlander Color Skopar II 21mm f/4.0",
+        "url": "https://www.lenstip.com/691-Voigtlander_Color_Skopar_II_21mm_f_4.0-lens_specifications.html"
+      },
+      {
+        "id": 1247,
+        "name": "Voigtlander Heliar 15 mm f/4.5 Aspherical VM Type III",
+        "url": "https://www.lenstip.com/1247-Voigtlander_Heliar_15_mm_f_4.5_Aspherical_VM_Type_III-lens_specifications.html"
+      },
+      {
+        "id": 1248,
+        "name": "Voigtlander Heliar 40 mm f/2.8",
+        "url": "https://www.lenstip.com/1248-Voigtlander_Heliar_40_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 1919,
+        "name": "Voigtlander Heliar 40 mm f/2.8 (Leica M / L39)",
+        "url": "https://www.lenstip.com/1919-Voigtlander_Heliar_40_mm_f_2.8_(Leica_M___L39)-lens_specifications.html"
+      },
+      {
+        "id": 889,
+        "name": "Voigtlander Heliar 50 mm f/2.0",
+        "url": "https://www.lenstip.com/889-Voigtlander_Heliar_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 890,
+        "name": "Voigtlander Heliar 50 mm f/3.5",
+        "url": "https://www.lenstip.com/890-Voigtlander_Heliar_50_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 1416,
+        "name": "Voigtlander Heliar 50 mm f/3.5 VM",
+        "url": "https://www.lenstip.com/1416-Voigtlander_Heliar_50_mm_f_3.5_VM-lens_specifications.html"
+      },
+      {
+        "id": 1864,
+        "name": "Voigtlander Heliar Classic 50 mm f/1.5 VM",
+        "url": "https://www.lenstip.com/1864-Voigtlander_Heliar_Classic_50_mm_f_1.5_VM-lens_specifications.html"
+      },
+      {
+        "id": 940,
+        "name": "Voigtlander Heliar Classic 75 mm f/1.8",
+        "url": "https://www.lenstip.com/940-Voigtlander_Heliar_Classic_75_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 975,
+        "name": "Voigtlander Heliar Classic 75 mm f/1.8 SL II",
+        "url": "https://www.lenstip.com/975-Voigtlander_Heliar_Classic_75_mm_f_1.8_SL_II-lens_specifications.html"
+      },
+      {
+        "id": 1331,
+        "name": "Voigtlander Hyper Wide Heliar 10 mm f/5.6 Aspherical E",
+        "url": "https://www.lenstip.com/1331-Voigtlander_Hyper_Wide_Heliar_10_mm_f_5.6_Aspherical_E-lens_specifications.html"
+      },
+      {
+        "id": 1332,
+        "name": "Voigtlander Hyper Wide Heliar 10 mm f/5.6 Aspherical VM",
+        "url": "https://www.lenstip.com/1332-Voigtlander_Hyper_Wide_Heliar_10_mm_f_5.6_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 1961,
+        "name": "Voigtlander Macro Apo-Ultron 35 mm f/2",
+        "url": "https://www.lenstip.com/1961-Voigtlander_Macro_Apo-Ultron_35_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 707,
+        "name": "Voigtlander Macro Dynar AF 100 mm f/3.5",
+        "url": "https://www.lenstip.com/707-Voigtlander_Macro_Dynar_AF_100_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 1245,
+        "name": "Voigtlander Nokton 10.5 mm f/0.95",
+        "url": "https://www.lenstip.com/1245-Voigtlander_Nokton_10.5_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 1032,
+        "name": "Voigtlander Nokton 17.5 mm f/0.95 Aspherical",
+        "url": "https://www.lenstip.com/1032-Voigtlander_Nokton_17.5_mm_f_0.95_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1606,
+        "name": "Voigtlander Nokton 21 mm f/1.4 Aspherical",
+        "url": "https://www.lenstip.com/1606-Voigtlander_Nokton_21_mm_f_1.4_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1923,
+        "name": "Voigtlander Nokton 23 mm f/1.2",
+        "url": "https://www.lenstip.com/1923-Voigtlander_Nokton_23_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 945,
+        "name": "Voigtlander Nokton 25 mm f/0.95",
+        "url": "https://www.lenstip.com/945-Voigtlander_Nokton_25_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 2192,
+        "name": "Voigtlander Nokton 28 mm f/1.5 Aspherical",
+        "url": "https://www.lenstip.com/2192-Voigtlander_Nokton_28_mm_f_1.5_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 2032,
+        "name": "Voigtlander Nokton 35 mm f/0.9 Aspherical",
+        "url": "https://www.lenstip.com/2032-Voigtlander_Nokton_35_mm_f_0.9_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 698,
+        "name": "Voigtlander Nokton 35 mm f/1.2",
+        "url": "https://www.lenstip.com/698-Voigtlander_Nokton_35_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 976,
+        "name": "Voigtlander Nokton 35 mm f/1.2 Aspherical II",
+        "url": "https://www.lenstip.com/976-Voigtlander_Nokton_35_mm_f_1.2_Aspherical_II-lens_specifications.html"
+      },
+      {
+        "id": 1682,
+        "name": "Voigtlander Nokton 35 mm f/1.2 Aspherical III VM",
+        "url": "https://www.lenstip.com/1682-Voigtlander_Nokton_35_mm_f_1.2_Aspherical_III_VM-lens_specifications.html"
+      },
+      {
+        "id": 2221,
+        "name": "Voigtlander Nokton 35 mm f/1.2 Aspherical IV VM",
+        "url": "https://www.lenstip.com/2221-Voigtlander_Nokton_35_mm_f_1.2_Aspherical_IV_VM-lens_specifications.html"
+      },
+      {
+        "id": 1689,
+        "name": "Voigtlander Nokton 35 mm f/1.2 SE",
+        "url": "https://www.lenstip.com/1689-Voigtlander_Nokton_35_mm_f_1.2_SE-lens_specifications.html"
+      },
+      {
+        "id": 1856,
+        "name": "Voigtlander Nokton 35 mm f/1.2 X / Z",
+        "url": "https://www.lenstip.com/1856-Voigtlander_Nokton_35_mm_f_1.2_X___Z-lens_specifications.html"
+      },
+      {
+        "id": 688,
+        "name": "Voigtlander Nokton 35 mm f/1.4",
+        "url": "https://www.lenstip.com/688-Voigtlander_Nokton_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1485,
+        "name": "Voigtlander Nokton 40 mm f/1.2",
+        "url": "https://www.lenstip.com/1485-Voigtlander_Nokton_40_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 1690,
+        "name": "Voigtlander Nokton 40 mm f/1.2 Aspherical",
+        "url": "https://www.lenstip.com/1690-Voigtlander_Nokton_40_mm_f_1.2_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 2222,
+        "name": "Voigtlander Nokton 40 mm f/1.2 Aspherical II VM",
+        "url": "https://www.lenstip.com/2222-Voigtlander_Nokton_40_mm_f_1.2_Aspherical_II_VM-lens_specifications.html"
+      },
+      {
+        "id": 699,
+        "name": "Voigtlander Nokton 40 mm f/1.4",
+        "url": "https://www.lenstip.com/699-Voigtlander_Nokton_40_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1131,
+        "name": "Voigtlander Nokton 42.5 mm f/0.95",
+        "url": "https://www.lenstip.com/1131-Voigtlander_Nokton_42.5_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 2018,
+        "name": "Voigtlander Nokton 50 mm f/1",
+        "url": "https://www.lenstip.com/2018-Voigtlander_Nokton_50_mm_f_1-lens_specifications.html"
+      },
+      {
+        "id": 1909,
+        "name": "Voigtlander Nokton 50 mm f/1 Aspherical VM",
+        "url": "https://www.lenstip.com/1909-Voigtlander_Nokton_50_mm_f_1_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 866,
+        "name": "Voigtlander Nokton 50 mm f/1.1",
+        "url": "https://www.lenstip.com/866-Voigtlander_Nokton_50_mm_f_1.1-lens_specifications.html"
+      },
+      {
+        "id": 1601,
+        "name": "Voigtlander Nokton 50 mm f/1.2 Aspherical",
+        "url": "https://www.lenstip.com/1601-Voigtlander_Nokton_50_mm_f_1.2_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 2223,
+        "name": "Voigtlander Nokton 50 mm f/1.2 Aspherical II VM",
+        "url": "https://www.lenstip.com/2223-Voigtlander_Nokton_50_mm_f_1.2_Aspherical_II_VM-lens_specifications.html"
+      },
+      {
+        "id": 1522,
+        "name": "Voigtlander Nokton 50 mm f/1.2 Aspherical VM",
+        "url": "https://www.lenstip.com/1522-Voigtlander_Nokton_50_mm_f_1.2_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 1691,
+        "name": "Voigtlander Nokton 50 mm f/1.2 X / SE",
+        "url": "https://www.lenstip.com/1691-Voigtlander_Nokton_50_mm_f_1.2_X___SE-lens_specifications.html"
+      },
+      {
+        "id": 700,
+        "name": "Voigtlander Nokton 50 mm f/1.5",
+        "url": "https://www.lenstip.com/700-Voigtlander_Nokton_50_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 1109,
+        "name": "Voigtlander Nokton 50 mm f/1.5 Asph.",
+        "url": "https://www.lenstip.com/1109-Voigtlander_Nokton_50_mm_f_1.5_Asph.-lens_specifications.html"
+      },
+      {
+        "id": 1751,
+        "name": "Voigtlander Nokton 50mm f/1.5 Aspherical II",
+        "url": "https://www.lenstip.com/1751-Voigtlander_Nokton_50mm_f_1.5_Aspherical_II-lens_specifications.html"
+      },
+      {
+        "id": 2030,
+        "name": "Voigtlander Nokton 55 mm f/1.2 SL II S",
+        "url": "https://www.lenstip.com/2030-Voigtlander_Nokton_55_mm_f_1.2_SL_II_S-lens_specifications.html"
+      },
+      {
+        "id": 661,
+        "name": "Voigtlander Nokton 58 mm f/1.4 SL II",
+        "url": "https://www.lenstip.com/661-Voigtlander_Nokton_58_mm_f_1.4_SL_II-lens_specifications.html"
+      },
+      {
+        "id": 1415,
+        "name": "Voigtlander Nokton 58 mm f/1.4 SL II S",
+        "url": "https://www.lenstip.com/1415-Voigtlander_Nokton_58_mm_f_1.4_SL_II_S-lens_specifications.html"
+      },
+      {
+        "id": 1680,
+        "name": "Voigtlander Nokton 60 mm f/0.95",
+        "url": "https://www.lenstip.com/1680-Voigtlander_Nokton_60_mm_f_0.95-lens_specifications.html"
+      },
+      {
+        "id": 2117,
+        "name": "Voigtlander Nokton 75 mm f/1.5",
+        "url": "https://www.lenstip.com/2117-Voigtlander_Nokton_75_mm_f_1.5-lens_specifications.html"
+      },
+      {
+        "id": 1607,
+        "name": "Voigtlander Nokton 75 mm f/1.5 Aspherical VM",
+        "url": "https://www.lenstip.com/1607-Voigtlander_Nokton_75_mm_f_1.5_Aspherical_VM-lens_specifications.html"
+      },
+      {
+        "id": 1497,
+        "name": "Voigtlander Nokton Classic 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1497-Voigtlander_Nokton_Classic_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1621,
+        "name": "Voigtlander Nokton Classic 35 mm f/1.4 II VM",
+        "url": "https://www.lenstip.com/1621-Voigtlander_Nokton_Classic_35_mm_f_1.4_II_VM-lens_specifications.html"
+      },
+      {
+        "id": 2098,
+        "name": "Voigtlander Nokton Vintage Line 28 mm f/1.5 VM Type I / Type II",
+        "url": "https://www.lenstip.com/2098-Voigtlander_Nokton_Vintage_Line_28_mm_f_1.5_VM_Type_I___Type_II-lens_specifications.html"
+      },
+      {
+        "id": 1986,
+        "name": "Voigtlander Nokton Vintage Line 35 mm f/1.5 Aspherical VM Type I / Type II",
+        "url": "https://www.lenstip.com/1986-Voigtlander_Nokton_Vintage_Line_35_mm_f_1.5_Aspherical_VM_Type_I___Type_II-lens_specifications.html"
+      },
+      {
+        "id": 2231,
+        "name": "Voigtlander Portrait Heliar 75 mm f/1.8",
+        "url": "https://www.lenstip.com/2231-Voigtlander_Portrait_Heliar_75_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 703,
+        "name": "Voigtlander SC Skopar 21 mm f/4.0",
+        "url": "https://www.lenstip.com/703-Voigtlander_SC_Skopar_21_mm_f_4.0-lens_specifications.html"
+      },
+      {
+        "id": 704,
+        "name": "Voigtlander SC Skopar 25 mm f/4.0",
+        "url": "https://www.lenstip.com/704-Voigtlander_SC_Skopar_25_mm_f_4.0-lens_specifications.html"
+      },
+      {
+        "id": 705,
+        "name": "Voigtlander SC Skopar 35 mm f/2.5",
+        "url": "https://www.lenstip.com/705-Voigtlander_SC_Skopar_35_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 715,
+        "name": "Voigtlander SL Apo Lanthar 180 mm f/4",
+        "url": "https://www.lenstip.com/715-Voigtlander_SL_Apo_Lanthar_180_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 718,
+        "name": "Voigtlander SL Apo Lanthar 90 mm f/3.5",
+        "url": "https://www.lenstip.com/718-Voigtlander_SL_Apo_Lanthar_90_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 714,
+        "name": "Voigtlander SL Color Heliar 75 mm f/2.5",
+        "url": "https://www.lenstip.com/714-Voigtlander_SL_Color_Heliar_75_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 716,
+        "name": "Voigtlander SL Macro Apo Lanthar 125 mm f/2.5",
+        "url": "https://www.lenstip.com/716-Voigtlander_SL_Macro_Apo_Lanthar_125_mm_f_2.5-lens_specifications.html"
+      },
+      {
+        "id": 717,
+        "name": "Voigtlander SL Ultron 40 mm f/2",
+        "url": "https://www.lenstip.com/717-Voigtlander_SL_Ultron_40_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 2312,
+        "name": "Voigtlander Septon 40 mm f/2 Aspherical",
+        "url": "https://www.lenstip.com/2312-Voigtlander_Septon_40_mm_f_2_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 708,
+        "name": "Voigtlander Skopar AF  28-80 mm f/3.5-5.6",
+        "url": "https://www.lenstip.com/708-Voigtlander_Skopar_AF__28-80_mm_f_3.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 709,
+        "name": "Voigtlander Skopar AF Tele 70-300 mm f/4.5-5.6",
+        "url": "https://www.lenstip.com/709-Voigtlander_Skopar_AF_Tele_70-300_mm_f_4.5-5.6-lens_specifications.html"
+      },
+      {
+        "id": 1771,
+        "name": "Voigtlander Super Nokton 29 mm f/0.8",
+        "url": "https://www.lenstip.com/1771-Voigtlander_Super_Nokton_29_mm_f_0.8_-lens_specifications.html"
+      },
+      {
+        "id": 690,
+        "name": "Voigtlander Super Wide Heliar 15 mm f/4.5",
+        "url": "https://www.lenstip.com/690-Voigtlander_Super_Wide_Heliar_15_mm_f_4.5-lens_specifications.html"
+      },
+      {
+        "id": 1328,
+        "name": "Voigtlander Super Wide Heliar 15 mm f/4.5 Aspherical III",
+        "url": "https://www.lenstip.com/1328-Voigtlander_Super_Wide_Heliar_15_mm_f_4.5_Aspherical_III-lens_specifications.html"
+      },
+      {
+        "id": 710,
+        "name": "Voigtlander Telomar AF  100-300 mm f/5.6-6.7",
+        "url": "https://www.lenstip.com/710-Voigtlander_Telomar_AF__100-300_mm_f_5.6-6.7-lens_specifications.html"
+      },
+      {
+        "id": 689,
+        "name": "Voigtlander Ultra Wide Heliar 12 mm f/5.6 Aspherical",
+        "url": "https://www.lenstip.com/689-Voigtlander_Ultra_Wide_Heliar_12_mm_f_5.6_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 901,
+        "name": "Voigtlander Ultra Wide Heliar 12 mm f/5.6 Aspherical II",
+        "url": "https://www.lenstip.com/901-Voigtlander_Ultra_Wide_Heliar_12_mm_f_5.6_Aspherical_II-lens_specifications.html"
+      },
+      {
+        "id": 1329,
+        "name": "Voigtlander Ultra Wide Heliar 12 mm f/5.6 Aspherical III E",
+        "url": "https://www.lenstip.com/1329-Voigtlander_Ultra_Wide_Heliar_12_mm_f_5.6_Aspherical_III_E-lens_specifications.html"
+      },
+      {
+        "id": 1330,
+        "name": "Voigtlander Ultra Wide Heliar 12 mm f/5.6 Aspherical III VM",
+        "url": "https://www.lenstip.com/1330-Voigtlander_Ultra_Wide_Heliar_12_mm_f_5.6_Aspherical_III_VM-lens_specifications.html"
+      },
+      {
+        "id": 711,
+        "name": "Voigtlander Ultragon AF II 19-35 mm f/3.5-4.5",
+        "url": "https://www.lenstip.com/711-Voigtlander_Ultragon_AF_II_19-35_mm_f_3.5-4.5-lens_specifications.html"
+      },
+      {
+        "id": 712,
+        "name": "Voigtlander Ultron 105 AF  28-105 mm f/2.8-3.8",
+        "url": "https://www.lenstip.com/712-Voigtlander_Ultron_105_AF__28-105_mm_f_2.8-3.8-lens_specifications.html"
+      },
+      {
+        "id": 1064,
+        "name": "Voigtlander Ultron 21 mm f/1.8",
+        "url": "https://www.lenstip.com/1064-Voigtlander_Ultron_21_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 2031,
+        "name": "Voigtlander Ultron 27 mm f/2",
+        "url": "https://www.lenstip.com/2031-Voigtlander_Ultron_27_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 694,
+        "name": "Voigtlander Ultron 28 mm f/1.9",
+        "url": "https://www.lenstip.com/694-Voigtlander_Ultron_28_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 1829,
+        "name": "Voigtlander Ultron 28 mm f/2 Aspherical VM Vintage Line",
+        "url": "https://www.lenstip.com/1829-Voigtlander_Ultron_28_mm_f_2_Aspherical_VM_Vintage_Line-lens_specifications.html"
+      },
+      {
+        "id": 827,
+        "name": "Voigtlander Ultron 28 mm f/2.0",
+        "url": "https://www.lenstip.com/827-Voigtlander_Ultron_28_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 695,
+        "name": "Voigtlander Ultron 35 mm f/1.7",
+        "url": "https://www.lenstip.com/695-Voigtlander_Ultron_35_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 1246,
+        "name": "Voigtlander Ultron 35 mm f/1.7 Vinatge Line",
+        "url": "https://www.lenstip.com/1246-Voigtlander_Ultron_35_mm_f_1.7_Vinatge_Line-lens_specifications.html"
+      },
+      {
+        "id": 1588,
+        "name": "Voigtlander Ultron 35 mm f/2 Aspherical VM Vintage Line",
+        "url": "https://www.lenstip.com/1588-Voigtlander_Ultron_35_mm_f_2_Aspherical_VM_Vintage_Line-lens_specifications.html"
+      },
+      {
+        "id": 1809,
+        "name": "Voigtlander Ultron 35 mm f/2 Aspherical VM Vintage Line II",
+        "url": "https://www.lenstip.com/1809-Voigtlander_Ultron_35_mm_f_2_Aspherical_VM_Vintage_Line_II-lens_specifications.html"
+      },
+      {
+        "id": 660,
+        "name": "Voigtlander Ultron 40 mm f/2 SL II Aspherical",
+        "url": "https://www.lenstip.com/660-Voigtlander_Ultron_40_mm_f_2_SL_II_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 1476,
+        "name": "Voigtlander Ultron 40 mm f/2 SL II S Aspherical",
+        "url": "https://www.lenstip.com/1476-Voigtlander_Ultron_40_mm_f_2_SL_II_S_Aspherical-lens_specifications.html"
+      },
+      {
+        "id": 2019,
+        "name": "Voigtlander Ultron 75 mm f/1.9",
+        "url": "https://www.lenstip.com/2019-Voigtlander_Ultron_75_mm_f_1.9-lens_specifications.html"
+      },
+      {
+        "id": 713,
+        "name": "Voigtlander Ultron AF 400  100-400 mm f/4.5-6.7",
+        "url": "https://www.lenstip.com/713-Voigtlander_Ultron_AF_400__100-400_mm_f_4.5-6.7-lens_specifications.html"
+      }
+    ],
+    "Yashica": [
+      {
+        "id": 728,
+        "name": "Yashica Auto Yashinon 135 mm f/2.8",
+        "url": "https://www.lenstip.com/728-Yashica_Auto_Yashinon_135_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 719,
+        "name": "Yashica Auto Yashinon 20 mm f/3.3",
+        "url": "https://www.lenstip.com/719-Yashica_Auto_Yashinon_20_mm_f_3.3-lens_specifications.html"
+      },
+      {
+        "id": 729,
+        "name": "Yashica Auto Yashinon 200 mm f/4",
+        "url": "https://www.lenstip.com/729-Yashica_Auto_Yashinon_200_mm_f_4-lens_specifications.html"
+      },
+      {
+        "id": 722,
+        "name": "Yashica Auto Yashinon 28 mm f/2.8",
+        "url": "https://www.lenstip.com/722-Yashica_Auto_Yashinon_28_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 730,
+        "name": "Yashica Auto Yashinon 300 mm f/5.6",
+        "url": "https://www.lenstip.com/730-Yashica_Auto_Yashinon_300_mm_f_5.6-lens_specifications.html"
+      },
+      {
+        "id": 721,
+        "name": "Yashica Auto Yashinon 35 mm f/2.8",
+        "url": "https://www.lenstip.com/721-Yashica_Auto_Yashinon_35_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 735,
+        "name": "Yashica Auto Yashinon 45-135 mm f/3.5",
+        "url": "https://www.lenstip.com/735-Yashica_Auto_Yashinon_45-135_mm_f_3.5-lens_specifications.html"
+      },
+      {
+        "id": 723,
+        "name": "Yashica Auto Yashinon 50 mm f/1.4",
+        "url": "https://www.lenstip.com/723-Yashica_Auto_Yashinon_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 724,
+        "name": "Yashica Auto Yashinon 50 mm f/1.7",
+        "url": "https://www.lenstip.com/724-Yashica_Auto_Yashinon_50_mm_f_1.7-lens_specifications.html"
+      },
+      {
+        "id": 725,
+        "name": "Yashica Auto Yashinon 50 mm f/2.0",
+        "url": "https://www.lenstip.com/725-Yashica_Auto_Yashinon_50_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 726,
+        "name": "Yashica Auto Yashinon 55 mm f/1.2",
+        "url": "https://www.lenstip.com/726-Yashica_Auto_Yashinon_55_mm_f_1.2-lens_specifications.html"
+      },
+      {
+        "id": 736,
+        "name": "Yashica Auto Yashinon 75-230 mm f/4.5",
+        "url": "https://www.lenstip.com/736-Yashica_Auto_Yashinon_75-230_mm_f_4.5-lens_specifications.html"
+      },
+      {
+        "id": 727,
+        "name": "Yashica Macro Yashinon 60 mm f/2.8",
+        "url": "https://www.lenstip.com/727-Yashica_Macro_Yashinon_60_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 734,
+        "name": "Yashica Reflex Yashinon 1000 mm f/11",
+        "url": "https://www.lenstip.com/734-Yashica_Reflex_Yashinon_1000_mm_f_11-lens_specifications.html"
+      },
+      {
+        "id": 733,
+        "name": "Yashica Reflex Yashinon 500 mm f/8",
+        "url": "https://www.lenstip.com/733-Yashica_Reflex_Yashinon_500_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 731,
+        "name": "Yashica Super Yashinon 600 mm f/8",
+        "url": "https://www.lenstip.com/731-Yashica_Super_Yashinon_600_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 732,
+        "name": "Yashica Super Yashinon 800 mm f/8",
+        "url": "https://www.lenstip.com/732-Yashica_Super_Yashinon_800_mm_f_8-lens_specifications.html"
+      },
+      {
+        "id": 720,
+        "name": "Yashica Yashinon 21 mm f/3.3",
+        "url": "https://www.lenstip.com/720-Yashica_Yashinon_21_mm_f_3.3-lens_specifications.html"
+      }
+    ],
+    "Yongnuo": [
+      {
+        "id": 1412,
+        "name": "Yongnuo YN 100 mm f/2",
+        "url": "https://www.lenstip.com/1412-Yongnuo_YN_100_mm_f_2-lens_specifications.html"
+      },
+      {
+        "id": 1474,
+        "name": "Yongnuo YN 100 mm f/2N",
+        "url": "https://www.lenstip.com/1474-Yongnuo_YN_100_mm_f_2N-lens_specifications.html"
+      },
+      {
+        "id": 2105,
+        "name": "Yongnuo YN 11 mm f/1.8S DA DSM WL",
+        "url": "https://www.lenstip.com/2105-Yongnuo_YN_11_mm_f_1.8S_DA_DSM_WL-lens_specifications.html"
+      },
+      {
+        "id": 2037,
+        "name": "Yongnuo YN 12-35 mm f/2.8-4 M",
+        "url": "https://www.lenstip.com/2037-Yongnuo_YN_12-35_mm_f_2.8-4_M-lens_specifications.html"
+      },
+      {
+        "id": 1498,
+        "name": "Yongnuo YN 14 mm f/2.8",
+        "url": "https://www.lenstip.com/1498-Yongnuo_YN_14_mm_f_2.8-lens_specifications.html"
+      },
+      {
+        "id": 2002,
+        "name": "Yongnuo YN 16 mm f/1.8S DA DSM",
+        "url": "https://www.lenstip.com/2002-Yongnuo_YN_16_mm_f_1.8S_DA_DSM-lens_specifications.html"
+      },
+      {
+        "id": 2151,
+        "name": "Yongnuo YN 17 mm f/1.7 MFT",
+        "url": "https://www.lenstip.com/2151-Yongnuo_YN_17_mm_f_1.7_MFT-lens_specifications.html"
+      },
+      {
+        "id": 2153,
+        "name": "Yongnuo YN 23 mm f/1.4 DA DSM WL Pro",
+        "url": "https://www.lenstip.com/2153-Yongnuo_YN_23_mm_f_1.4_DA_DSM_WL_Pro-lens_specifications.html"
+      },
+      {
+        "id": 1806,
+        "name": "Yongnuo YN 25 mm f/1.7 STM ASPH",
+        "url": "https://www.lenstip.com/1806-Yongnuo_YN_25_mm_f_1.7_STM_ASPH-lens_specifications.html"
+      },
+      {
+        "id": 2139,
+        "name": "Yongnuo YN 33 mm f/1.4 DA DSM WL Pro",
+        "url": "https://www.lenstip.com/2139-Yongnuo_YN_33_mm_f_1.4_DA_DSM_WL_Pro-lens_specifications.html"
+      },
+      {
+        "id": 1585,
+        "name": "Yongnuo YN 35 mm f/1.4",
+        "url": "https://www.lenstip.com/1585-Yongnuo_YN_35_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 2173,
+        "name": "Yongnuo YN 35 mm f/1.8 DA DSM WL",
+        "url": "https://www.lenstip.com/2173-Yongnuo_YN_35_mm_f_1.8_DA_DSM_WL-lens_specifications.html"
+      },
+      {
+        "id": 1999,
+        "name": "Yongnuo YN 35 mm f/2 Z DF DSM",
+        "url": "https://www.lenstip.com/1999-Yongnuo_YN_35_mm_f_2_Z_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1257,
+        "name": "Yongnuo YN 35 mm f/2.0",
+        "url": "https://www.lenstip.com/1257-Yongnuo_YN_35_mm_f_2.0-lens_specifications.html"
+      },
+      {
+        "id": 1759,
+        "name": "Yongnuo YN 35 mm f/2.0 FE DF DSM",
+        "url": "https://www.lenstip.com/1759-Yongnuo_YN_35_mm_f_2.0_FE_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1855,
+        "name": "Yongnuo YN 35 mm f/2.0R DF DSM",
+        "url": "https://www.lenstip.com/1855-Yongnuo_YN_35_mm_f_2.0R_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1475,
+        "name": "Yongnuo YN 40 mm f/2.8N",
+        "url": "https://www.lenstip.com/1475-Yongnuo_YN_40_mm_f_2.8N-lens_specifications.html"
+      },
+      {
+        "id": 1259,
+        "name": "Yongnuo YN 50 mm f/1.4",
+        "url": "https://www.lenstip.com/1259-Yongnuo_YN_50_mm_f_1.4-lens_specifications.html"
+      },
+      {
+        "id": 1258,
+        "name": "Yongnuo YN 50 mm f/1.8",
+        "url": "https://www.lenstip.com/1258-Yongnuo_YN_50_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1685,
+        "name": "Yongnuo YN 50 mm f/1.8 DA DSM II",
+        "url": "https://www.lenstip.com/1685-Yongnuo_YN_50_mm_f_1.8_DA_DSM_II-lens_specifications.html"
+      },
+      {
+        "id": 1903,
+        "name": "Yongnuo YN 50 mm f/1.8 DF DSM",
+        "url": "https://www.lenstip.com/1903-Yongnuo_YN_50_mm_f_1.8_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1535,
+        "name": "Yongnuo YN 50 mm f/1.8 II",
+        "url": "https://www.lenstip.com/1535-Yongnuo_YN_50_mm_f_1.8_II-lens_specifications.html"
+      },
+      {
+        "id": 2062,
+        "name": "Yongnuo YN 50 mm f/1.8X DA DSM Pro",
+        "url": "https://www.lenstip.com/2062-Yongnuo_YN_50_mm_f_1.8X_DA_DSM_Pro-lens_specifications.html"
+      },
+      {
+        "id": 2108,
+        "name": "Yongnuo YN 50 mm f/1.8Z DA DSM",
+        "url": "https://www.lenstip.com/2108-Yongnuo_YN_50_mm_f_1.8Z_DA_DSM-lens_specifications.html"
+      },
+      {
+        "id": 2214,
+        "name": "Yongnuo YN 56 mm f/1.4 DA DSM WL Prp",
+        "url": "https://www.lenstip.com/2214-Yongnuo_YN_56_mm_f_1.4_DA_DSM_WL_Prp-lens_specifications.html"
+      },
+      {
+        "id": 1533,
+        "name": "Yongnuo YN 60 mm f/2 MF",
+        "url": "https://www.lenstip.com/1533-Yongnuo_YN_60_mm_f_2_MF-lens_specifications.html"
+      },
+      {
+        "id": 1426,
+        "name": "Yongnuo YN 85 mm f/1.8",
+        "url": "https://www.lenstip.com/1426-Yongnuo_YN_85_mm_f_1.8-lens_specifications.html"
+      },
+      {
+        "id": 1841,
+        "name": "Yongnuo YN 85 mm f/1.8R DF DSM",
+        "url": "https://www.lenstip.com/1841-Yongnuo_YN_85_mm_f_1.8R_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1741,
+        "name": "Yongnuo YN 85 mm f/1.8S DF DSM",
+        "url": "https://www.lenstip.com/1741-Yongnuo_YN_85_mm_f_1.8S_DF_DSM-lens_specifications.html"
+      },
+      {
+        "id": 1931,
+        "name": "Yongnuo YN 85 mm f/1.8Z DF DSM",
+        "url": "https://www.lenstip.com/1931-Yongnuo_YN_85_mm_f_1.8Z_DF_DSM-lens_specifications.html"
+      }
+    ]
+  }
+}

--- a/tools/lenstip/search.py
+++ b/tools/lenstip/search.py
@@ -1,0 +1,137 @@
+"""Search the local LensTip lens index.
+
+Finds LensTip spec page URLs by fuzzy-matching lens names against
+the local index built by build_index.py.
+
+Usage:
+    py tools/lenstip/search.py "Viltrox 56mm"
+    py tools/lenstip/search.py "XF 90mm f/2"
+    py tools/lenstip/search.py "Sigma 56mm" --brand Sigma
+    py tools/lenstip/search.py "TTartisan 50mm" --limit 5
+
+Requires: tools/lenstip/lenstip-index.json (run build_index.py first)
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+INDEX_FILE = Path(__file__).parent / "lenstip-index.json"
+
+
+def normalize(text: str) -> str:
+    """Normalize a lens name for fuzzy matching."""
+    t = text.lower()
+    # Normalize common variants
+    t = t.replace("f/", "f").replace("f /", "f")
+    t = t.replace("-", " ").replace("_", " ")
+    # Split number+unit clusters: "56mm" → "56 mm", "f1.4" → "f 1.4"
+    t = re.sub(r"(\d)(mm|cm)\b", r"\1 \2", t)
+    t = re.sub(r"(f)([\d])", r"\1 \2", t)
+    # Remove extra whitespace
+    t = " ".join(t.split())
+    return t
+
+
+def tokenize(text: str) -> list[str]:
+    """Split normalized text into word-boundary tokens."""
+    return text.split()
+
+
+def score_match(query_terms: list[str], name_normalized: str) -> float:
+    """Score how well query terms match a lens name. Higher is better.
+
+    Uses word-boundary matching: "56" matches the token "56" in
+    "viltrox af 56 mm f1.4 xf" but not "156" or "560".
+    """
+    name_tokens = tokenize(name_normalized)
+    matched = 0
+    for term in query_terms:
+        # Exact token match (word boundary) scores higher
+        if term in name_tokens:
+            matched += 1.0
+        # Substring match (e.g. "56mm" in "56") scores partial
+        elif term in name_normalized:
+            matched += 0.5
+    if matched == 0:
+        return 0.0
+    coverage = matched / len(query_terms)
+    # Bonus for shorter names (more specific match)
+    brevity = 1.0 / (1.0 + len(name_normalized) / 100)
+    return coverage + brevity * 0.1
+
+
+def search(
+    query: str,
+    *,
+    brand_filter: str | None = None,
+    limit: int = 10,
+) -> list[dict]:
+    """Search the index for lenses matching the query."""
+    if not INDEX_FILE.exists():
+        print(
+            "Index not found. Run: py tools/lenstip/build_index.py",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    index = json.loads(INDEX_FILE.read_text(encoding="utf-8"))
+    query_normalized = normalize(query)
+    query_terms = query_normalized.split()
+
+    results = []
+    for brand_name, lenses in index.get("brands", {}).items():
+        if brand_filter and brand_filter.lower() not in brand_name.lower():
+            continue
+        for lens in lenses:
+            name_normalized = normalize(lens["name"])
+            # Also match against brand + name combined
+            full_normalized = normalize(f"{brand_name} {lens['name']}")
+            score = max(
+                score_match(query_terms, name_normalized),
+                score_match(query_terms, full_normalized),
+            )
+            if score > 0:
+                results.append({
+                    "brand": brand_name,
+                    "name": lens["name"],
+                    "url": lens["url"],
+                    "id": lens["id"],
+                    "score": score,
+                })
+
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results[:limit]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Search the LensTip lens index"
+    )
+    parser.add_argument("query", help="Lens name to search for")
+    parser.add_argument(
+        "--brand", type=str, help="Filter to a single brand"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=10, help="Max results (default: 10)"
+    )
+    args = parser.parse_args()
+
+    results = search(args.query, brand_filter=args.brand, limit=args.limit)
+
+    if not results:
+        print(f"No matches for: {args.query}")
+        sys.exit(1)
+
+    print(f"Results for: {args.query}\n")
+    for i, r in enumerate(results, 1):
+        print(f"  {i}. [{r['brand']}] {r['name']}")
+        print(f"     {r['url']}")
+        if i < len(results):
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lookup.py
+++ b/tools/lookup.py
@@ -1,0 +1,180 @@
+"""Unified lens lookup — generate research URLs for all major sources.
+
+Given a lens name, outputs direct links and search URLs for every source
+in the PLAYBOOK 2.8 priority list. Uses the local LensTip index for
+exact matches; generates search URLs for everything else.
+
+Usage:
+    py tools/lookup.py "Viltrox 56mm f/1.4"
+    py tools/lookup.py "XF 90mm f/2"
+    py tools/lookup.py "Sirui Sniper 23mm f/1.2"
+    py tools/lookup.py "TTartisan 50mm f/0.95" --open   # open top result in browser
+"""
+
+import argparse
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+LENSTIP_INDEX = Path(__file__).parent / "lenstip" / "lenstip-index.json"
+
+
+def url_encode(query: str) -> str:
+    return urllib.parse.quote_plus(query)
+
+
+def lenstip_lookup(query: str) -> str | None:
+    """Look up a lens in the local LensTip index. Returns URL or None."""
+    if not LENSTIP_INDEX.exists():
+        return None
+    # Import search module
+    sys.path.insert(0, str(Path(__file__).parent / "lenstip"))
+    from search import search
+    results = search(query, limit=1)
+    if results and results[0]["score"] > 0.8:
+        return results[0]["url"]
+    return None
+
+
+def lenstip_search_url(query: str) -> str:
+    """Generate a Google site-search URL for LensTip."""
+    return f"https://www.google.com/search?q=site%3Alenstip.com+{url_encode(query)}"
+
+
+def generate_urls(query: str) -> list[tuple[str, str, str]]:
+    """Generate research URLs for a lens query.
+
+    Returns list of (source_name, url, note) tuples.
+    """
+    q = url_encode(query)
+    urls = []
+
+    # --- Priority sources (PLAYBOOK 2.8 order) ---
+
+    # LensTip — local index first, then search fallback
+    lenstip_url = lenstip_lookup(query)
+    if lenstip_url:
+        urls.append(("LensTip (index match)", lenstip_url, "spec page"))
+    else:
+        urls.append(("LensTip (search)", lenstip_search_url(query), "no index match"))
+
+    # Radojuva
+    urls.append((
+        "Radojuva",
+        f"https://www.google.com/search?q=site%3Aradojuva.com+{q}",
+        "hands-on measurements",
+    ))
+
+    # Phillip Reeve
+    urls.append((
+        "Phillip Reeve",
+        f"https://www.google.com/search?q=site%3Aphillipreeve.net+{q}",
+        "manual focus specialist",
+    ))
+
+    # DPReview
+    urls.append((
+        "DPReview",
+        f"https://www.google.com/search?q=site%3Adpreview.com+{q}+specifications",
+        "spec database (archived)",
+    ))
+
+    # Official manufacturer (generic search)
+    urls.append((
+        "Official page",
+        f"https://www.google.com/search?q={q}+official+specifications",
+        "manufacturer specs",
+    ))
+
+    # Dustin Abbott
+    urls.append((
+        "Dustin Abbott",
+        f"https://www.google.com/search?q=site%3Adustinabbott.net+{q}",
+        "trust-3 field + lab",
+    ))
+
+    # Opticallimits
+    urls.append((
+        "Opticallimits",
+        f"https://www.google.com/search?q=site%3Aopticallimits.com+{q}",
+        "lab MTF (ex-photozone)",
+    ))
+
+    # Lensrentals (Roger Cicala)
+    urls.append((
+        "Lensrentals",
+        f"https://www.google.com/search?q=site%3Alensrentals.com+{q}+blog",
+        "optical bench MTF",
+    ))
+
+    # Photography Life
+    urls.append((
+        "Photography Life",
+        f"https://www.google.com/search?q=site%3Aphotographylife.com+{q}",
+        "spec tables + diagrams",
+    ))
+
+    # digitalkamera.de
+    urls.append((
+        "digitalkamera.de",
+        f"https://www.google.com/search?q=site%3Adigitalkamera.de+{q}+Datenblatt",
+        "dimensions (German)",
+    ))
+
+    # Mobile01
+    urls.append((
+        "Mobile01",
+        f"https://www.google.com/search?q=site%3Amobile01.com+{q}",
+        "Taiwan forum, construction diagrams",
+    ))
+
+    # Google Image Search for diagrams/MTF
+    urls.append((
+        "Construction diagram",
+        f"https://www.google.com/search?q={q}+optical+construction+diagram&tbm=isch",
+        "image search",
+    ))
+    urls.append((
+        "MTF chart",
+        f"https://www.google.com/search?q={q}+MTF+chart&tbm=isch",
+        "image search",
+    ))
+
+    # DuckDuckGo fallback (no CAPTCHAs)
+    urls.append((
+        "DuckDuckGo",
+        f"https://html.duckduckgo.com/html/?q={q}+lens+specifications",
+        "fallback if Google blocks",
+    ))
+
+    return urls
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate research URLs for a lens across all sources"
+    )
+    parser.add_argument("query", help="Lens name to look up")
+    parser.add_argument(
+        "--open", action="store_true",
+        help="Open the top LensTip result in the default browser",
+    )
+    args = parser.parse_args()
+
+    urls = generate_urls(args.query)
+
+    print(f"Research URLs for: {args.query}\n")
+    for source, url, note in urls:
+        print(f"  {source} ({note})")
+        print(f"    {url}")
+        print()
+
+    if args.open:
+        import webbrowser
+        # Open first URL (LensTip match or search)
+        webbrowser.open(urls[0][1])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lookup.py
+++ b/tools/lookup.py
@@ -37,15 +37,22 @@ def lenstip_lookup(query: str) -> str | None:
     return None
 
 
+def ddg_site_search(site: str, query: str) -> str:
+    """Generate a DuckDuckGo HTML site-search URL (no CAPTCHAs, works with fetch-page.py)."""
+    return f"https://html.duckduckgo.com/html/?q=site%3A{site}+{url_encode(query)}"
+
+
 def lenstip_search_url(query: str) -> str:
-    """Generate a Google site-search URL for LensTip."""
-    return f"https://www.google.com/search?q=site%3Alenstip.com+{url_encode(query)}"
+    """Generate a DuckDuckGo site-search URL for LensTip."""
+    return ddg_site_search("lenstip.com", query)
 
 
 def generate_urls(query: str) -> list[tuple[str, str, str]]:
     """Generate research URLs for a lens query.
 
     Returns list of (source_name, url, note) tuples.
+    Uses DuckDuckGo HTML for site-searches (no CAPTCHAs, works with
+    fetch-page.py via plain urllib). Google only for image search.
     """
     q = url_encode(query)
     urls = []
@@ -62,74 +69,74 @@ def generate_urls(query: str) -> list[tuple[str, str, str]]:
     # Radojuva
     urls.append((
         "Radojuva",
-        f"https://www.google.com/search?q=site%3Aradojuva.com+{q}",
+        ddg_site_search("radojuva.com", query),
         "hands-on measurements",
     ))
 
     # Phillip Reeve
     urls.append((
         "Phillip Reeve",
-        f"https://www.google.com/search?q=site%3Aphillipreeve.net+{q}",
+        ddg_site_search("phillipreeve.net", query),
         "manual focus specialist",
     ))
 
     # DPReview
     urls.append((
         "DPReview",
-        f"https://www.google.com/search?q=site%3Adpreview.com+{q}+specifications",
+        ddg_site_search("dpreview.com", f"{query} specifications"),
         "spec database (archived)",
     ))
 
     # Official manufacturer (generic search)
     urls.append((
         "Official page",
-        f"https://www.google.com/search?q={q}+official+specifications",
+        f"https://html.duckduckgo.com/html/?q={q}+official+specifications",
         "manufacturer specs",
     ))
 
     # Dustin Abbott
     urls.append((
         "Dustin Abbott",
-        f"https://www.google.com/search?q=site%3Adustinabbott.net+{q}",
+        ddg_site_search("dustinabbott.net", query),
         "trust-3 field + lab",
     ))
 
     # Opticallimits
     urls.append((
         "Opticallimits",
-        f"https://www.google.com/search?q=site%3Aopticallimits.com+{q}",
+        ddg_site_search("opticallimits.com", query),
         "lab MTF (ex-photozone)",
     ))
 
     # Lensrentals (Roger Cicala)
     urls.append((
         "Lensrentals",
-        f"https://www.google.com/search?q=site%3Alensrentals.com+{q}+blog",
+        ddg_site_search("lensrentals.com", f"{query} blog"),
         "optical bench MTF",
     ))
 
     # Photography Life
     urls.append((
         "Photography Life",
-        f"https://www.google.com/search?q=site%3Aphotographylife.com+{q}",
+        ddg_site_search("photographylife.com", query),
         "spec tables + diagrams",
     ))
 
     # digitalkamera.de
     urls.append((
         "digitalkamera.de",
-        f"https://www.google.com/search?q=site%3Adigitalkamera.de+{q}+Datenblatt",
+        ddg_site_search("digitalkamera.de", f"{query} Datenblatt"),
         "dimensions (German)",
     ))
 
     # Mobile01
     urls.append((
         "Mobile01",
-        f"https://www.google.com/search?q=site%3Amobile01.com+{q}",
+        ddg_site_search("mobile01.com", query),
         "Taiwan forum, construction diagrams",
     ))
 
-    # Google Image Search for diagrams/MTF
+    # Google Image Search for diagrams/MTF (no DDG equivalent)
     urls.append((
         "Construction diagram",
         f"https://www.google.com/search?q={q}+optical+construction+diagram&tbm=isch",
@@ -139,13 +146,6 @@ def generate_urls(query: str) -> list[tuple[str, str, str]]:
         "MTF chart",
         f"https://www.google.com/search?q={q}+MTF+chart&tbm=isch",
         "image search",
-    ))
-
-    # DuckDuckGo fallback (no CAPTCHAs)
-    urls.append((
-        "DuckDuckGo",
-        f"https://html.duckduckgo.com/html/?q={q}+lens+specifications",
-        "fallback if Google blocks",
     ))
 
     return urls


### PR DESCRIPTION
## Summary
- **LensTip index scraper** (`tools/lenstip/build_index.py`) — scrapes all 42 manufacturer pages, builds a 2302-lens JSON index mapping names to spec page URLs with opaque numeric IDs
- **LensTip search** (`tools/lenstip/search.py`) — fuzzy word-boundary search against the local index
- **Unified lens lookup** (`tools/lookup.py`) — generates research URLs for all PLAYBOOK 2.8 sources (LensTip, Radojuva, DPReview, Dustin Abbott, etc.) in one command, using DuckDuckGo HTML (no CAPTCHAs)
- **Specs-log audit** (`tools/lenstip/audit_specslog.py`) — cross-references "Not covered" entries against the index; found 10 false negatives (2 AstrHori, 2 Kamlan, 6 Mitakon)
- **PLAYBOOK 2.8 restructured** — 4 clear phases (Prepare, Research, Commit, Maintenance) + source reference table + mandatory 5-source checklist
- **CLAUDE.md** — documented new tools, added "Check open PRs" to session startup

Closes #846

## Test plan
- [x] `py tools/lenstip/build_index.py` — 2302 lenses across 42 brands
- [x] `py tools/lenstip/search.py "Sirui Sniper 23mm"` — correct #1 result
- [x] `py tools/lookup.py "Kamlan 50mm f/1.1"` — LensTip index match + DDG URLs
- [x] `py tools/lenstip/audit_specslog.py --fix` — 10 false negatives found
- [x] DDG site-search URLs work with `fetch-page.py` (plain urllib)
- [x] `npm run validate` passes

Generated with [Claude Code](https://claude.com/claude-code)