### PR TITLE
Implement extract_physical across 8 brands + expand to all page-verifiable specs (#779)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,7 @@ Project-specific overrides and additions follow below.
 - `public/` — static assets (favicon, icons, CNAME, robots.txt)
 - `docs/audits/` — 360-degree audits (timestamped) and SEO test plan
 - `docs/optical-specs/` — verified per-lens optical reference data, one subfolder per lens (ADR-031, ADR-033): `analysis.md` (MTF readings, predictions), `scoring-log.md` (per-lens scoring justification), `specs-log.md` (mandatory technical specs provenance log), construction diagrams and MTF charts as PNG or SVG
-- `tools/fujifilm/` — Fujifilm optical spec extraction (fetch_specs, audit, Playwright-based)
-- `tools/samyang/` — Samyang optical spec extraction (fetch_specs, audit, plain urllib)
-- `tools/sigma/` — Sigma optical spec extraction (fetch_specs, audit, plain urllib)
-- `tools/tamron/` — Tamron optical spec extraction (fetch_specs, audit, plain urllib, dual-page parsing)
-- `tools/tokina/` — Tokina optical spec extraction (fetch_specs, audit, alt-text scraping); migrated onto `brandkit` + `pagefetch` (TokinaExtractor strategy, ADR-035)
-- `tools/ttartisan/` — TTartisan optical spec extraction (fetch_specs, audit, plain urllib, spec table + prose parsing)
-- `tools/viltrox/` — Viltrox optical spec extraction (fetch_specs, audit, download_images, Shopify JSON + HTML scraping)
-- `tools/zeiss/` — Carl Zeiss optical spec extraction (fetch_specs, audit, PDF datasheet download)
-- `tools/mitakon/` — Mitakon optical spec extraction (fetch_specs, audit, SeleniumBase UC for zyoptics.net)
+- `tools/<brand>/` — per-brand optical spec extraction, all 11 migrated onto `brandkit` + `pagefetch` (ADR-035): each is a `<Brand>Extractor(BrandExtractor)` in `extractor.py` plus thin `fetch_specs.py`/`audit.py` that delegate to the shared brandkit runners. Brands: fujifilm (Playwright + live-page image fallback), samyang, sigma, tamron (dual-page via `extra_paths`), tokina, ttartisan, viltrox (Shopify JSON + `download_images.py` theme scraper), zeiss (PDF-only, `save_pdf`), mitakon (UC), venus (UC), voigtlander (Playwright). Transport per brand via `BrandConfig.transport`; import the extractor brand-qualified (`from tokina.extractor import ...`). `extract_physical` (#779 cross-validation) implemented for 8 brands; sigma/viltrox pending (#897), zeiss N/A
 - `tools/lenstip/` — LensTip lens index (build_index, search); local JSON index of 2300+ lenses for instant ID lookup
 - `tools/lookup.py` — unified lens lookup; generates research URLs for all PLAYBOOK 2.8 sources in one shot
 - `tools/crop-artifact.py` — content-aware cropper for construction diagrams / MTF charts; detects content bbox from corner-median background (no hand-guessed pixel coords), splits composites (`--split --left/--right`), supports explicit `--region`, `--margin`, advisory `--check`

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -288,10 +288,14 @@ py tools/tamron/audit.py --missing                 # show only incomplete lenses
 
 **Fetch Tokina optical specs (urllib, alt-text scraping):**
 
-Migrated onto the `pagefetch` + `brandkit` architecture (ADR-035) — the
-brand parsing lives in `tools/tokina/extractor.py`, the pipeline in
-`brandkit`. The `--verify` flag (#779) cross-validates stored physical
-specs against the official page.
+All 11 brands are migrated onto the `pagefetch` + `brandkit` architecture
+(ADR-035) — brand parsing lives in `tools/<brand>/extractor.py`, the pipeline
+in `brandkit`; `fetch_specs.py`/`audit.py` are thin delegators. The same
+flags work for every brand (substitute the brand directory below). The
+`--verify` flag (#779) cross-validates stored physical specs against the
+official page — implemented for 8 brands (fujifilm, samyang, tamron, tokina,
+ttartisan, voigtlander, venus, mitakon); sigma/viltrox pending (#897),
+zeiss N/A (PDF-only). Tokina shown as the example:
 
 ```bash
 py tools/tokina/fetch_specs.py                    # fetch all specs + images

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -3123,3 +3123,34 @@ Issues created: solid-ai-templates#329 (no-force-push convention)
 - Open the PR for `refactor/pagefetch-brandkit` when ready (maintainer to decide one PR vs. split); install `pytest-cov` to confirm #887's 90% coverage before merge.
 - After merge: #891 (urllib brands), #892 (browser brands + Zeiss PDF), then #779 per-brand `extract_physical`.
 - Backlog carried over: #884 (specs-log backfill), Trust Score #882, fetch-page cache #881.
+
+---
+
+### Session 90 — Brand Migrations and Physical-Spec Verification
+
+- Continued the tooling theme. Merged PR #893 (pagefetch + brandkit + Tokina) and PR #895 (10 remaining brands migrated). Then implemented #779 physical-spec extraction across 8 brands on branch `feat/779-extract-physical` (PR #898, open).
+- Issues: closed #886–890 (PR #893), #891/#892 (PR #895); created #896 (data-cleanup from --verify findings), #897 (Sigma+Viltrox extract_physical, deferred), #898 PR. #779 stays open pending #898 merge + #897.
+
+#### Key changes
+
+- **All 11 brands migrated onto pagefetch + brandkit** (#891 PR #895, #892 within it): each brand is now a `<Brand>Extractor(BrandExtractor)` + thin delegators; ~250 lines/brand of duplicated scaffolding removed. Net −2122 lines while migrating 10 brands.
+- **Shared brandkit runners** extracted: `cli.run` (fetch/verify) and `audit.audit` — each brand's `fetch_specs.py`/`audit.py` is ~15 lines.
+- **#779 physical-spec verification** (PR #898): expanded scope from the ticket's 5 numeric fields to all page-verifiable specs (dimensions, core optical, build booleans, afMotor, tilt-shift) via a typed `PHYSICAL_SPEC_FIELDS` registry + typed `diff_physical` (numeric tolerance / boolean exact / string case-insensitive). Implemented + real-page-verified `extract_physical` for 8 brands (Tokina, TTartisan, Samyang, Fujifilm, Tamron, Voigtlander, Venus, Mitakon).
+- `--verify` now catches real data discrepancies (Fujifilm rounded weights, Voigtlander diameter typo, Tamron weight, per-mount divergences) — tracked in #896.
+
+#### Key decisions
+
+- Contract generalizations solved once and reused across brands, never special-cased: `extract_image_urls(content, url)` (Sigma/Tamron URL codes), `BrandConfig.extra_paths` (Tamron dual-page), JSON-via-content (Viltrox), `BrandConfig.transport` (Playwright/UC), `BrandConfig.needs_live_page` + `extract_images_live(page)` (Fujifilm — the one documented contract bend; brandkit owns the browser page, pagefetch stays pure transport).
+- `extract_physical` returns a boolean ONLY when the page affirmatively states it — so a stored `false` for an unmentioned flag is never falsely flagged (the "absent = false" stored default vs page-silence asymmetry).
+- Sigma + Viltrox `extract_physical` deferred (#897): their pages weren't cached and there was no network to verify offline; shipping unverified parsers would break the real-page-verification discipline held for the other 8. Zeiss is a deliberate no-op (PDF-only).
+- The --verify discrepancies are a data-quality signal, not noise to suppress — kept the strict tolerance and filed #896 rather than widening it to mask errors.
+
+#### Post-mortems
+
+- Module-name collision (P2): brand `extractor.py` modules all imported as bare `extractor` collided under one pytest interpreter (Samyang's test imported Tokina's class). **Root cause:** bare `from extractor import` + no per-brand package. **Fix:** brand-qualified imports (`tokina.extractor`) + `__init__.py` per brand dir (PR #895). **Why missed:** Tokina alone (the proof brand) never triggered it. **Prevention:** brand-qualified imports are now the pattern for all brands.
+
+#### Next
+
+- Merge PR #898 (#779 8-brand physical extraction); then #897 (Sigma+Viltrox) when network is available to close #779.
+- Data cleanup #896 (triage --verify findings: real errors vs per-mount differences).
+- Backlog carried over: #894 (Python toolchain spike), #884 (specs-log backfill), pagefetch `download_bytes` escalation for Venus images, pagefetch→submodule extraction.

--- a/tools/brandkit/__init__.py
+++ b/tools/brandkit/__init__.py
@@ -25,7 +25,14 @@ from .audit import audit
 from .cli import format_ts_fields, run
 from .diff import Mismatch, diff_physical
 from .extractor import BrandConfig, BrandExtractor
-from .lenses import PHYSICAL_FIELDS, LensEntry, LensesFile
+from .lenses import (
+    FIELD_KIND,
+    PHYSICAL_FIELDS,
+    PHYSICAL_SPEC_FIELDS,
+    LensEntry,
+    LensesFile,
+    PhysicalValue,
+)
 from .slug import model_to_slug
 from .specs_dir import (
     detect_ext,
@@ -45,7 +52,10 @@ __all__ = [
     "BrandConfig",
     "LensesFile",
     "LensEntry",
+    "PhysicalValue",
     "PHYSICAL_FIELDS",
+    "PHYSICAL_SPEC_FIELDS",
+    "FIELD_KIND",
     "model_to_slug",
     "diff_physical",
     "Mismatch",

--- a/tools/brandkit/diff.py
+++ b/tools/brandkit/diff.py
@@ -5,13 +5,21 @@ official product page, and reports mismatches. Born from Session 76, where
 swapped weights and wrong magnification values went undetected because no
 tool compared stored data against the source.
 
-Numeric comparison uses a small relative tolerance so that rounding
-differences (e.g. a weight stored as 276 vs a page that says 275.8) do not
-register as mismatches, while genuine errors (swapped values, wrong by tens
-of grams) do.
+Comparison is typed (see lenses.PHYSICAL_SPEC_FIELDS):
+- numeric: small relative tolerance, so rounding (276 vs 275.8) is not a
+  mismatch but real errors (swapped values, wrong by tens) are;
+- boolean: exact;
+- string: case-insensitive exact.
+
+A field is compared only when present on BOTH sides — a spec the page does
+not expose is unknown, not a mismatch. (Stored booleans default to False per
+the Lens-type contract; the extractor returns a boolean only when the page
+affirmatively confirms it, so unmentioned flags are naturally skipped.)
 """
 
 from dataclasses import dataclass
+
+from .lenses import FIELD_KIND, PhysicalValue
 
 # Relative tolerance for numeric fields; magnification needs a looser
 # absolute floor because its values are tiny (e.g. 0.1).
@@ -22,8 +30,8 @@ _ABS_FLOOR = {"maxMagnification": 0.005}
 @dataclass(frozen=True)
 class Mismatch:
     field: str
-    stored: float
-    extracted: float
+    stored: PhysicalValue
+    extracted: PhysicalValue
 
     def __str__(self) -> str:
         return f"{self.field}: stored={self.stored} page={self.extracted}"
@@ -31,11 +39,11 @@ class Mismatch:
 
 def _is_number(value: object) -> bool:
     """True for real numeric values. bool is excluded (it is an int subclass
-    but never a valid spec value)."""
+    but never a valid numeric spec value)."""
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
-def _values_agree(field: str, stored: float, extracted: float) -> bool:
+def _numbers_agree(field: str, stored: float, extracted: float) -> bool:
     if stored == extracted:
         return True
     abs_floor = _ABS_FLOOR.get(field, 0.0)
@@ -47,19 +55,33 @@ def _values_agree(field: str, stored: float, extracted: float) -> bool:
     return abs(stored - extracted) / scale <= _REL_TOLERANCE
 
 
+def _agree(field: str, stored: PhysicalValue, extracted: PhysicalValue) -> bool:
+    """Compare one field's values according to its kind. Unknown/ill-typed
+    pairs are treated as agreeing (not a mismatch)."""
+    kind = FIELD_KIND.get(field, "numeric")
+    if kind == "boolean":
+        if not isinstance(stored, bool) or not isinstance(extracted, bool):
+            return True
+        return stored == extracted
+    if kind == "string":
+        if not isinstance(stored, str) or not isinstance(extracted, str):
+            return True
+        return stored.strip().lower() == extracted.strip().lower()
+    # numeric
+    if not _is_number(stored) or not _is_number(extracted):
+        return True
+    return _numbers_agree(field, stored, extracted)
+
+
 def diff_physical(
-    stored: dict[str, float], extracted: dict[str, float]
+    stored: dict[str, PhysicalValue], extracted: dict[str, PhysicalValue]
 ) -> list[Mismatch]:
     """Return a mismatch for each field present in BOTH dicts whose values
-    disagree beyond tolerance. Fields missing from either side are skipped —
-    a value the page does not expose is not a mismatch, it is unknown.
-    Non-numeric values on either side are skipped too: a field an extractor
-    could not parse into a number is unknown, not a mismatch."""
+    disagree. A field absent from either side is skipped (unknown)."""
     mismatches: list[Mismatch] = []
     for field, extracted_value in extracted.items():
-        stored_value = stored.get(field)
-        if not _is_number(stored_value) or not _is_number(extracted_value):
+        if field not in stored:
             continue
-        if not _values_agree(field, stored_value, extracted_value):
-            mismatches.append(Mismatch(field, stored_value, extracted_value))
+        if not _agree(field, stored[field], extracted_value):
+            mismatches.append(Mismatch(field, stored[field], extracted_value))
     return mismatches

--- a/tools/brandkit/extractor.py
+++ b/tools/brandkit/extractor.py
@@ -52,12 +52,16 @@ class BrandExtractor(ABC):
         special (list[str]), coating (list[str]). Brands without a given
         field simply omit it (or return an empty list)."""
 
-    def extract_physical(self, content: str) -> dict[str, float]:
+    def extract_physical(self, content: str) -> dict:
         """Parse physical specs for cross-validation (#779).
 
-        Returns a subset of weight, maxMagnification, minFocusDistance,
-        filterThread, apertureBlades, diameter, length. The base default
-        returns nothing, so a brand can migrate before implementing this."""
+        Returns any subset of the page-verifiable specs in
+        lenses.PHYSICAL_SPEC_FIELDS — dimensions, core optical specs, build
+        flags (booleans), afMotor (string), tilt-shift geometry. Return a
+        boolean ONLY when the page affirmatively confirms it (a flag the page
+        does not mention must be omitted, not returned False). The base
+        default returns nothing, so a brand can migrate before implementing
+        this."""
         return {}
 
     def extract_image_urls(self, content: str, url: str) -> dict[str, list[str]]:

--- a/tools/brandkit/lenses.py
+++ b/tools/brandkit/lenses.py
@@ -8,23 +8,67 @@ cross-validate against.
 The file is not valid JSON, so it is parsed with targeted regexes over
 brand-delimited blocks — the same approach every brand common.py used,
 extracted here once.
+
+"Physical specs" here means fields a manufacturer publishes and we can
+verify against their page — dimensions, core optical specs, build flags,
+AF motor, and tilt-shift geometry. It deliberately excludes our scored
+OQ/MTF measurements, price, and genre data.
 """
 
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
-# Physical spec fields cross-validated by #779. Each maps to a lenses.ts key.
-PHYSICAL_FIELDS = (
-    "weight",
-    "maxMagnification",
-    "minFocusDistance",
-    "filterThread",
-    "apertureBlades",
-    "diameter",
-    "length",
+FieldKind = Literal["numeric", "boolean", "string"]
+
+# Every page-verifiable physical spec, with its lenses.ts key and value kind.
+# Booleans follow the Lens-type contract "absent = false".
+PHYSICAL_SPEC_FIELDS: tuple[tuple[str, FieldKind], ...] = (
+    # dimensions
+    ("weight", "numeric"),
+    ("diameter", "numeric"),
+    ("length", "numeric"),
+    ("filterThread", "numeric"),
+    ("apertureBlades", "numeric"),
+    ("maxMagnification", "numeric"),
+    ("minFocusDistance", "numeric"),
+    # core optical specs
+    ("focalLengthMin", "numeric"),
+    ("focalLengthMax", "numeric"),
+    ("maxAperture", "numeric"),
+    # build flags (absent = false)
+    ("hasOis", "boolean"),
+    ("isWeatherSealed", "boolean"),
+    ("hasApertureRing", "boolean"),
+    ("isApertureClickless", "boolean"),
+    ("hasFocusRing", "boolean"),
+    ("isFocusByWire", "boolean"),
+    ("hasDistanceScale", "boolean"),
+    ("hasCircularAperture", "boolean"),
+    ("hasTripodMount", "boolean"),
+    ("hasRotatingFront", "boolean"),
+    # autofocus
+    ("afMotor", "string"),
+    # tilt-shift geometry
+    ("isTiltShift", "boolean"),
+    ("shiftRange", "numeric"),
+    ("tiltAngle", "numeric"),
+    ("imageCircle", "numeric"),
 )
+
+# Kind lookup by key, for the diff layer.
+FIELD_KIND: dict[str, FieldKind] = {key: kind for key, kind in PHYSICAL_SPEC_FIELDS}
+
+# Booleans that the data omits when false — used to fill "absent = false".
+_BOOLEAN_KEYS = tuple(key for key, kind in PHYSICAL_SPEC_FIELDS if kind == "boolean")
+
+# Backwards-compatible alias: the original numeric-only field set (#779 v1).
+PHYSICAL_FIELDS = tuple(
+    key for key, kind in PHYSICAL_SPEC_FIELDS if kind == "numeric"
+)
+
+PhysicalValue = float | bool | str
 
 
 @dataclass(frozen=True)
@@ -33,7 +77,7 @@ class LensEntry:
 
     model: str
     url: str  # officialUrl, after any brand normalization
-    physical: dict[str, float] = field(default_factory=dict)
+    physical: dict[str, PhysicalValue] = field(default_factory=dict)
 
 
 def _split_brand_blocks(content: str) -> list[str]:
@@ -59,6 +103,10 @@ class LensesFile:
         self._path = path
         self._content = path.read_text(encoding="utf-8")
 
+    @property
+    def path(self) -> Path:
+        return self._path
+
     def entries_for(
         self, brand: str, normalize_url: Callable[[str], str] | None = None
     ) -> list[LensEntry]:
@@ -83,13 +131,29 @@ class LensesFile:
         return entries
 
     @staticmethod
-    def _physical_from_block(block: str) -> dict[str, float]:
-        """Extract the stored physical-spec values present in a block."""
-        physical: dict[str, float] = {}
-        for key in PHYSICAL_FIELDS:
-            m = re.search(rf"\b{key}:\s*([0-9.]+)", block)
-            if m:
-                value = _parse_number(m.group(1))
-                if value is not None:
-                    physical[key] = value
+    def _physical_from_block(block: str) -> dict[str, PhysicalValue]:
+        """Extract every stored physical spec present in a block, typed.
+
+        Booleans absent from the block default to False (the Lens-type
+        contract: absent boolean = false). Numerics and strings that are
+        absent stay absent (unknown, not a value)."""
+        physical: dict[str, PhysicalValue] = {}
+        for key, kind in PHYSICAL_SPEC_FIELDS:
+            if kind == "numeric":
+                m = re.search(rf"\b{key}:\s*([0-9.]+)", block)
+                if m:
+                    value = _parse_number(m.group(1))
+                    if value is not None:
+                        physical[key] = value
+            elif kind == "string":
+                m = re.search(rf'\b{key}:\s*"([^"]+)"', block)
+                if m:
+                    physical[key] = m.group(1)
+            else:  # boolean
+                m = re.search(rf"\b{key}:\s*(true|false)\b", block)
+                if m:
+                    physical[key] = m.group(1) == "true"
+        # Fill absent booleans as False per the type contract.
+        for key in _BOOLEAN_KEYS:
+            physical.setdefault(key, False)
         return physical

--- a/tools/brandkit/tests/test_diff.py
+++ b/tools/brandkit/tests/test_diff.py
@@ -72,5 +72,47 @@ def test_non_numeric_stored_value_is_skipped():
 
 
 def test_bool_is_not_treated_as_number():
-    # bool is an int subclass; a stray True must not be diffed as 1.
+    # apertureBlades is numeric; a stray True must not be diffed as 1.
     assert diff_physical({"apertureBlades": 9}, {"apertureBlades": True}) == []
+
+
+# --- typed comparison: booleans ---
+
+
+def test_boolean_match_no_mismatch():
+    assert diff_physical({"hasOis": True}, {"hasOis": True}) == []
+    assert diff_physical({"isWeatherSealed": False}, {"isWeatherSealed": False}) == []
+
+
+def test_boolean_mismatch_caught():
+    # Stored says weather-sealed; page says it is not.
+    m = diff_physical({"isWeatherSealed": True}, {"isWeatherSealed": False})
+    assert len(m) == 1
+    assert m[0].field == "isWeatherSealed"
+
+
+def test_boolean_skipped_when_page_silent():
+    # The extractor only returns a flag it confirmed; if it omits hasOis, the
+    # stored False is not compared (page did not address it).
+    assert diff_physical({"hasOis": False}, {}) == []
+
+
+# --- typed comparison: strings (afMotor) ---
+
+
+def test_string_match_case_insensitive():
+    assert diff_physical({"afMotor": "STM"}, {"afMotor": "stm"}) == []
+
+
+def test_string_mismatch_caught():
+    m = diff_physical({"afMotor": "STM"}, {"afMotor": "LM"})
+    assert len(m) == 1
+    assert m[0].field == "afMotor"
+
+
+def test_mixed_field_set_reports_each_kind():
+    stored = {"weight": 276, "hasOis": False, "afMotor": "STM"}
+    extracted = {"weight": 300, "hasOis": True, "afMotor": "STM"}
+    fields = {m.field for m in diff_physical(stored, extracted)}
+    # weight off by ~9%, OIS flipped; afMotor agrees.
+    assert fields == {"weight", "hasOis"}

--- a/tools/brandkit/tests/test_lenses.py
+++ b/tools/brandkit/tests/test_lenses.py
@@ -49,11 +49,18 @@ def test_physical_fields_extracted(lenses_sample_path):
     assert entry.physical["minFocusDistance"] == 300
 
 
-def test_missing_physical_fields_omitted(lenses_sample_path):
+def test_missing_numeric_fields_omitted_but_booleans_default_false(lenses_sample_path):
     lf = LensesFile(lenses_sample_path)
-    # The 33mm entry only declares weight.
+    # The 33mm entry only declares weight among the numeric specs.
     entry = lf.entries_for("Tokina")[1]
-    assert entry.physical == {"weight": 285.0}
+    # Numeric/string specs absent from the block stay absent (unknown)...
+    assert entry.physical["weight"] == 285.0
+    assert "diameter" not in entry.physical
+    assert "afMotor" not in entry.physical
+    # ...but booleans default to False per the Lens-type contract.
+    assert entry.physical["hasOis"] is False
+    assert entry.physical["isWeatherSealed"] is False
+    assert entry.physical["isTiltShift"] is False
 
 
 def test_other_brand_isolated(lenses_sample_path):

--- a/tools/fujifilm/extractor.py
+++ b/tools/fujifilm/extractor.py
@@ -87,6 +87,51 @@ class FujifilmExtractor(BrandExtractor):
         specs["coating"] = self._coating(text)
         return specs
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from the Fujifilm specifications page (#779).
+
+        The spec table's two-column layout shifts on multi-value rows, so
+        these use targeted patterns over the de-tagged text rather than
+        cell-pairing. minFocusDistance takes the closer of the Normal/Macro
+        focus ranges (Macro = the lens's true minimum)."""
+        text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", content))
+        text = text.replace("&#8211;", "-").replace("&nbsp;", " ")
+        # Drop other HTML numeric entities (e.g. &#8709; diameter sign, &#8734;
+        # infinity) so their digits don't get mistaken for spec values.
+        text = re.sub(r"&#\d+;", " ", text)
+        out: dict = {}
+
+        # focal length: "f=14mm" or "f=10-24mm"
+        fl = re.search(r"f=\s*([\d.]+)(?:\s*-\s*([\d.]+))?\s*mm", text, re.IGNORECASE)
+        if fl:
+            out["focalLengthMin"] = float(fl.group(1))
+            out["focalLengthMax"] = float(fl.group(2) or fl.group(1))
+        if ap := self._num(text, r"Max\.?\s*aperture\s*F/?([\d.]+)"):
+            out["maxAperture"] = ap
+        if blades := self._num(text, r"(\d+)\s*\(rounded diaphragm"):
+            out["apertureBlades"] = blades
+        if (mag := self._num(text, r"Max\.?\s*magnification\s*([\d.]+)\s*x")) is not None:
+            out["maxMagnification"] = mag
+        if w := self._num(text, r"Weight[^=g]*?([\d.]+)\s*g"):
+            out["weight"] = w
+        if ft := self._num(text, r"Filter size[^\d]*([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        # dimensions: "Diameter x Length ... 65mm x 58.4mm"
+        dims = re.search(r"Diameter x Length[^\d]*?([\d.]+)\s*mm\s*x\s*([\d.]+)\s*mm", text, re.IGNORECASE)
+        if dims:
+            out["diameter"] = float(dims.group(1))
+            out["length"] = float(dims.group(2))
+        # focus range: take the closer of Normal/Macro (cm -> mm).
+        ranges = [float(x) for x in re.findall(r"(?:Normal|Macro)\s*([\d.]+)\s*cm", text, re.IGNORECASE)]
+        if ranges:
+            out["minFocusDistance"] = round(min(ranges) * 10)  # cm -> mm
+        return out
+
+    @staticmethod
+    def _num(text: str, pattern: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE)
+        return float(m.group(1)) if m else None
+
     @staticmethod
     def _coating(text: str) -> list[str]:
         # Every Fujifilm lens has Super EBC; Nano-GI / HT-EBC are optional.

--- a/tools/fujifilm/tests/fixtures/fujifilm-xf16mm-spec.html
+++ b/tools/fujifilm/tests/fixtures/fujifilm-xf16mm-spec.html
@@ -3,9 +3,19 @@
 <head><title>XF16mmF1.4 R WR Specifications</title></head>
 <body>
   <table class="spec">
-    <tr><th>Lens configuration</th><td>13 elements in 11 groups
+    <tr><td>Lens construction</td><td>13 elements in 11 groups
         (2 aspherical and 3 ED elements)</td></tr>
-    <tr><th>Coating</th><td>Super EBC, Nano-GI coating</td></tr>
+    <tr><td>Focal length</td><td>f=16mm (24mm in 35mm format equivalent)</td></tr>
+    <tr><td>Max. aperture</td><td>F1.4</td></tr>
+    <tr><td>Aperture control</td><td>Number of blades</td></tr>
+    <tr><td>9(rounded diaphragm opening)</td><td>Stop size</td></tr>
+    <tr><td>Focus range</td><td>Normal 60cm - &#8734; Macro 15cm - &#8734;</td></tr>
+    <tr><td>Max. magnification</td><td>0.21x</td></tr>
+    <tr><td>External dimensions : Diameter x Length (approx.)</td>
+        <td>&#8709;73.4mm x 73mm</td></tr>
+    <tr><td>Weight (approx.)</td><td>375g</td></tr>
+    <tr><td>Filter size</td><td>&#8709;67mm</td></tr>
+    <tr><td>Coating</td><td>Super EBC, Nano-GI coating</td></tr>
   </table>
   <div class="diagrams">
     <img src="https://fujifilm.b-cdn.net/xf16mmf14-r-wr_cross.webp">

--- a/tools/fujifilm/tests/test_extractor.py
+++ b/tools/fujifilm/tests/test_extractor.py
@@ -71,6 +71,31 @@ def test_coating_super_ebc_when_page_silent(extractor):
     assert specs["coating"] == ["Super EBC"]
 
 
+def test_extract_physical_full_spec_table(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["focalLengthMin"] == 16
+    assert phys["focalLengthMax"] == 16
+    assert phys["maxAperture"] == 1.4
+    assert phys["apertureBlades"] == 9
+    assert phys["maxMagnification"] == 0.21
+    assert phys["weight"] == 375
+    assert phys["filterThread"] == 67
+    assert phys["diameter"] == 73.4
+    assert phys["length"] == 73
+
+
+def test_extract_physical_min_focus_takes_macro(extractor, html):
+    # Focus range "Normal 60cm - inf  Macro 15cm - inf" -> closer is 15cm.
+    assert extractor.extract_physical(html)["minFocusDistance"] == 150  # 15cm -> mm
+
+
+def test_extract_physical_zoom_focal_range(extractor):
+    html = "<td>Focal length</td><td>f=10-24mm (15-36mm equivalent)</td>"
+    phys = extractor.extract_physical(html)
+    assert phys["focalLengthMin"] == 10
+    assert phys["focalLengthMax"] == 24
+
+
 def test_named_image_urls_cross_and_specifications(extractor, html):
     urls = extractor.extract_image_urls(html, LENS_URL + "specifications/")
     assert any(u.endswith("xf16mmf14-r-wr_cross.webp") for u in urls["construction"])

--- a/tools/mitakon/extractor.py
+++ b/tools/mitakon/extractor.py
@@ -20,6 +20,8 @@ from brandkit import BrandConfig, BrandExtractor
 _TEXT_NUMS = {
     "one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
     "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10",
+    "eleven": "11", "twelve": "12", "thirteen": "13", "fourteen": "14",
+    "fifteen": "15", "sixteen": "16",
 }
 
 _SINGLE_PATTERNS = [
@@ -76,6 +78,49 @@ class MitakonExtractor(BrandExtractor):
         specs["special"] = self._special(self._normalize(full_text))
         specs["coating"] = self._coating(full_text)
         return specs
+
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from a zyoptics.net (GFX) product page (#779).
+
+        Inline label-value spec run, e.g. 'Filter Thread 72 mm
+        Dimensions (DxL) 82x 96mm Weight 1,050 g', plus 'Maximum
+        Magnification 0.25x', 'Minimum Focus Distance 70 cm', an
+        'Eleven-Bladed Diaphragm' (text number), and 'Aperture range f/1.4'.
+        Dimensions are (DxL) = diameter x length; weight carries a comma."""
+        text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", content)).replace("&nbsp;", " ")
+        out: dict = {}
+
+        if ft := self._num(text, r"Filter Thread\s*([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        # Dimensions "(DxL) 82x 96mm" -> diameter x length.
+        dims = re.search(r"Dimensions\s*\(?D\s*x\s*L\)?\s*([\d.]+)\s*x\s*([\d.]+)\s*mm", text, re.IGNORECASE)
+        if dims:
+            out["diameter"] = float(dims.group(1))
+            out["length"] = float(dims.group(2))
+        # Weight carries a thousands comma ("1,050 g").
+        wm = re.search(r"Weight\s*([\d,]+(?:\.\d+)?)\s*g", text, re.IGNORECASE)
+        if wm:
+            out["weight"] = float(wm.group(1).replace(",", ""))
+        if (mag := self._num(text, r"Maximum Magnification\s*([\d.]+)\s*x")) is not None:
+            out["maxMagnification"] = mag
+        if (mfd := self._num(text, r"Minimum Focus(?:ing)?\s*Distance\s*([\d.]+)\s*cm")) is not None:
+            out["minFocusDistance"] = round(mfd * 10)  # cm -> mm
+        if ap := self._num(text, r"Aperture range\s*f/?([\d.]+)"):
+            out["maxAperture"] = ap
+        # Blades: "Eleven-Bladed Diaphragm" (text number) or "11 blades".
+        bm = re.search(r"(\w+)[- ]Bladed", text, re.IGNORECASE)
+        if bm:
+            n = _TEXT_NUMS.get(bm.group(1).lower())
+            if n:
+                out["apertureBlades"] = float(n)
+        elif blades := self._num(text, r"(\d+)\s*(?:aperture\s*)?blades?"):
+            out["apertureBlades"] = blades
+        return out
+
+    @staticmethod
+    def _num(text: str, pattern: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE)
+        return float(m.group(1)) if m else None
 
     @staticmethod
     def _normalize(text: str) -> str:

--- a/tools/mitakon/tests/fixtures/mitakon-35mm-sample.html
+++ b/tools/mitakon/tests/fixtures/mitakon-35mm-sample.html
@@ -9,6 +9,9 @@
   </div>
   <div class="woocommerce-Tabs-panel woocommerce-Tabs-panel--specifications">
     <table><tr><td>Lens structure</td><td>11 elements in 9 groups</td></tr></table>
+    <p>Maximum Magnification 0.25x Minimum Focus Distance 70 cm
+       Aperture range f/1.4 Eleven-Bladed Diaphragm
+       Filter Thread 72 mm Dimensions (DxL) 82x 96mm Weight 1,050 g</p>
   </div>
 </body>
 </html>

--- a/tools/mitakon/tests/test_extractor.py
+++ b/tools/mitakon/tests/test_extractor.py
@@ -64,3 +64,19 @@ def test_hri_plain_only():
 
 def test_no_diagrams_empty_images(extractor, html):
     assert extractor.extract_image_urls(html, "https://x") == {"mtf": [], "construction": []}
+
+
+def test_extract_physical_inline_run(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["filterThread"] == 72
+    assert phys["maxMagnification"] == 0.25
+    assert phys["minFocusDistance"] == 700  # 70cm -> mm
+    assert phys["maxAperture"] == 1.4
+    assert phys["diameter"] == 82  # (DxL) -> diameter first
+    assert phys["length"] == 96
+
+
+def test_extract_physical_text_bladed_and_comma_weight(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["apertureBlades"] == 11  # "Eleven-Bladed"
+    assert phys["weight"] == 1050  # "1,050 g" comma stripped

--- a/tools/samyang/extractor.py
+++ b/tools/samyang/extractor.py
@@ -73,6 +73,58 @@ class SamyangExtractor(BrandExtractor):
         specs["coating"] = self._coating(block, text)
         return specs
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from Samyang's th2/td2 spec rows (#779).
+
+        Rows are <td class="th2">Label</td><td class="td2">value</td>. The
+        same lens ships in several mounts, so some rows (Weight) list a value
+        per mount — we take the first numeric value (mount-specific weights
+        differ slightly; --verify surfaces any real divergence)."""
+        rows = self._spec_rows(content)
+        out: dict = {}
+
+        if ft := self._num(rows.get("Filter Size"), r"([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        if dia := self._num(rows.get("Maximum Diameter"), r"([\d.]+)\s*mm"):
+            out["diameter"] = dia
+        if length := self._num(rows.get("Length"), r"([\d.]+)\s*mm"):
+            out["length"] = length
+        if blades := self._num(rows.get("Number of Diaphragm Blades"), r"(\d+)"):
+            out["apertureBlades"] = blades
+        if (mfd := self._num(rows.get("Minimum Focusing Distance"), r"([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mfd * 1000)
+        # Weight: first numeric (mounts listed left-to-right).
+        if w := self._num(rows.get("Weight"), r"([\d.]+)\s*g"):
+            out["weight"] = w
+        # "Aperture Range" reads "F2.0 ~ 22" — the first value is max aperture.
+        if ap := self._num(rows.get("Aperture Range"), r"F/?([\d.]+)"):
+            out["maxAperture"] = ap
+        if (mag := self._num(rows.get("Maximum Magnification Ratio"), r"([\d.]+)")) is not None:
+            out["maxMagnification"] = mag
+        return out
+
+    @staticmethod
+    def _spec_rows(content: str) -> dict[str, str]:
+        """Label -> value from the th2/td2 spec table. First value per label
+        wins (mount columns trail the first value)."""
+        rows: dict[str, str] = {}
+        for m in re.finditer(
+            r'<td[^>]*class="th2"[^>]*>(.*?)</td>\s*<td[^>]*class="td2"[^>]*>(.*?)</td>',
+            content, re.DOTALL,
+        ):
+            label = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(1))).strip()
+            value = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(2))).strip()
+            if label and value and label not in rows:
+                rows[label] = value
+        return rows
+
+    @staticmethod
+    def _num(value: str | None, pattern: str) -> float | None:
+        if not value:
+            return None
+        m = re.search(pattern, value)
+        return float(m.group(1)) if m else None
+
     @staticmethod
     def _spec_block(text: str) -> str:
         """The spec table sits between these two headings; isolate it to

--- a/tools/samyang/tests/fixtures/samyang-14mm-sample.html
+++ b/tools/samyang/tests/fixtures/samyang-14mm-sample.html
@@ -12,5 +12,15 @@
   <li class="optical-construction"><strong>Optical Construction</strong>
       <img src="/upload/editor/1234"></li>
   <div><strong>MTF Chart</strong><img src="/upload/editor/5678"></div>
+
+  <table class="spec-table">
+    <tr><td class="th2">Aperture Range</td><td class="td2">F2.8 ~ 22</td></tr>
+    <tr><td class="th2">Minimum Focusing Distance</td><td class="td2">0.28 m</td></tr>
+    <tr><td class="th2">Filter Size</td><td class="td2">- mm</td></tr>
+    <tr><td class="th2">Maximum Diameter</td><td class="td2">87.0mm</td></tr>
+    <tr><td class="th2">Length</td><td class="td2">96.1mm</td></tr>
+    <tr><td class="th2">Mount</td><td class="td2">Canon EF</td><td class="td2">Nikon F</td></tr>
+    <tr><td class="th2">Weight</td><td class="td2">550g</td><td class="td2">552g</td></tr>
+  </table>
 </body>
 </html>

--- a/tools/samyang/tests/test_extractor.py
+++ b/tools/samyang/tests/test_extractor.py
@@ -61,3 +61,21 @@ def test_image_urls_resolved(extractor, html):
 
 def test_no_spec_block_returns_empty(extractor):
     assert extractor.extract_optical("<html><body>nothing here</body></html>") == {}
+
+
+def test_extract_physical_from_th2_td2_rows(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["diameter"] == 87.0
+    assert phys["length"] == 96.1
+    assert phys["minFocusDistance"] == 280  # 0.28m -> mm
+    assert phys["maxAperture"] == 2.8  # "F2.8 ~ 22"
+
+
+def test_extract_physical_weight_first_mount_value(extractor, html):
+    # Weight row lists per-mount values; take the first.
+    assert extractor.extract_physical(html)["weight"] == 550
+
+
+def test_extract_physical_omits_dashed_filter(extractor, html):
+    # The 14mm has no filter thread ("- mm") — must be omitted, not 0.
+    assert "filterThread" not in extractor.extract_physical(html)

--- a/tools/tamron/extractor.py
+++ b/tools/tamron/extractor.py
@@ -81,6 +81,53 @@ class TamronExtractor(BrandExtractor):
         specs["coating"] = self._coating(text)
         return specs
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from Tamron's spec.html th/td table (#779).
+
+        The spec sub-page (fetched + concatenated via config.extra_paths) has
+        clean <th>label</th><td>value</td> rows. Multi-mount lenses list
+        per-mount values ('86.2mm / ... (for Sony E-mount)'); the first value
+        wins. Magnification 'N:M' -> decimal; MOD metres -> mm."""
+        rows = self._spec_rows(content)
+        out: dict = {}
+
+        if ft := self._num(rows.get("Filter Size"), r"([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        if dia := self._num(rows.get("Maximum Diameter"), r"([\d.]+)\s*mm"):
+            out["diameter"] = dia
+        for key in ("Length", "Length *", "Overall Length"):
+            if length := self._num(rows.get(key), r"([\d.]+)\s*mm"):
+                out["length"] = length
+                break
+        if w := self._num(rows.get("Weight"), r"([\d.]+)\s*g"):
+            out["weight"] = w
+        if blades := self._num(rows.get("Aperture Blades"), r"(\d+)"):
+            out["apertureBlades"] = blades
+        # MOD: first value (WIDE) in "0.15m (5.9 in) (WIDE) / 0.24m (TELE)".
+        if (mod := self._num(rows.get("Minimum Object Distance"), r"([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mod * 1000)
+        mag = re.search(r"1\s*:\s*([\d.]+)", rows.get("Maximum Magnification Ratio", ""))
+        if mag:
+            out["maxMagnification"] = round(1 / float(mag.group(1)), 3)
+        return out
+
+    @staticmethod
+    def _spec_rows(content: str) -> dict[str, str]:
+        rows: dict[str, str] = {}
+        for m in re.finditer(r"<th[^>]*>(.*?)</th>\s*<td[^>]*>(.*?)</td>", content, re.DOTALL):
+            label = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(1))).strip()
+            value = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(2))).strip()
+            if label and value and label not in rows:
+                rows[label] = value
+        return rows
+
+    @staticmethod
+    def _num(value: str | None, pattern: str) -> float | None:
+        if not value:
+            return None
+        m = re.search(pattern, value)
+        return float(m.group(1)) if m else None
+
     @staticmethod
     def _special(text: str) -> list[str]:
         special: list[str] = []

--- a/tools/tamron/tests/fixtures/tamron-17-70-spec.html
+++ b/tools/tamron/tests/fixtures/tamron-17-70-spec.html
@@ -4,6 +4,13 @@
 <body>
   <table class="spec">
     <tr><th>Lens construction</th><td>16 elements in 12 groups</td></tr>
+    <tr><th>Minimum Object Distance</th><td>0.19m (7.5 in) (WIDE) / 0.39m (TELE)</td></tr>
+    <tr><th>Maximum Magnification Ratio</th><td>1:4.8 (WIDE) / 1:5.2 (TELE)</td></tr>
+    <tr><th>Filter Size</th><td>&#8709;67mm</td></tr>
+    <tr><th>Maximum Diameter</th><td>&#8709;74.6mm</td></tr>
+    <tr><th>Length *</th><td>119.3mm / 4.7in (for Sony E-mount)</td></tr>
+    <tr><th>Weight</th><td>525g / 18.5oz (for Sony E-mount)</td></tr>
+    <tr><th>Aperture Blades</th><td>9 (circular diaphragm)</td></tr>
   </table>
   <div class="diagrams">
     <img src="https://s3-ap-northeast-1.amazonaws.com/tamron-docs/b070_lens-construction_en.svg">

--- a/tools/tamron/tests/test_extractor.py
+++ b/tools/tamron/tests/test_extractor.py
@@ -60,6 +60,22 @@ def test_coating_bbar_g2_and_fluorine(extractor):
     assert "fluorine" in specs["coating"]
 
 
+def test_extract_physical_from_spec_table(extractor):
+    phys = extractor.extract_physical(MAIN + SPEC)
+    assert phys["filterThread"] == 67
+    assert phys["diameter"] == 74.6
+    assert phys["length"] == 119.3  # first (Sony E) value
+    assert phys["weight"] == 525  # first per-mount value
+    assert phys["apertureBlades"] == 9
+    assert phys["minFocusDistance"] == 190  # 0.19m WIDE -> mm
+    assert phys["maxMagnification"] == round(1 / 4.8, 3)  # 1:4.8 WIDE
+
+
+def test_extract_physical_omits_filter_entity_digits(extractor):
+    # The &#8709; diameter sign must not leak its digits into filterThread.
+    assert extractor.extract_physical(MAIN + SPEC)["filterThread"] == 67
+
+
 def test_image_urls_svg_with_code(extractor):
     urls = extractor.extract_image_urls(MAIN + SPEC, LENS_URL)
     assert len(urls["construction"]) == 1

--- a/tools/tokina/extractor.py
+++ b/tools/tokina/extractor.py
@@ -56,6 +56,50 @@ class TokinaExtractor(BrandExtractor):
             return url
         return prefix + url[len(prefix):].replace("-", "_")
 
+    def extract_physical(self, content: str) -> dict[str, float]:
+        """Parse physical specs from the property_list spec table (#779).
+
+        Rows are <_title>/<_value> cell pairs; the page repeats some labels
+        in a related-products widget above the real table, so the LAST value
+        for each label wins. Units are normalized to the lenses.ts convention
+        (weight g, distances mm, magnification ratio -> decimal)."""
+        rows = re.findall(
+            r'_title"[^>]*>(.*?)</div>.*?_value"[^>]*>(.*?)</div>',
+            content, re.DOTALL,
+        )
+        specs: dict[str, str] = {}
+        for raw_title, raw_value in rows:
+            title = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", raw_title)).strip()
+            value = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", raw_value)).strip()
+            if title and value:
+                specs[title] = value  # last occurrence wins
+
+        out: dict[str, float] = {}
+        if w := self._num(specs.get("Weight"), r"([\d.]+)\s*g"):
+            out["weight"] = w
+        if ft := self._num(specs.get("Filter Size"), r"([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        if blades := self._num(specs.get("Aperture Blades"), r"(\d+)"):
+            out["apertureBlades"] = blades
+        if (mfd := self._num(specs.get("Minimum Focusing Distance"), r"([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mfd * 1000)  # metres -> mm
+        macro = specs.get("Macro Ratio", "")
+        mr = re.search(r"1\s*:\s*([\d.]+)", macro)
+        if mr:
+            out["maxMagnification"] = round(1 / float(mr.group(1)), 3)
+        dims = re.search(r"([\d.]+)\s*x\s*([\d.]+)", specs.get("Dimensions", ""))
+        if dims:
+            out["diameter"] = float(dims.group(1))
+            out["length"] = float(dims.group(2))
+        return out
+
+    @staticmethod
+    def _num(value: str | None, pattern: str) -> float | None:
+        if not value:
+            return None
+        m = re.search(pattern, value)
+        return float(m.group(1)) if m else None
+
     def extract_optical(self, content: str) -> dict:
         # Tokina puts special-element names in image alt text, so fold alt
         # attributes into the searchable text before stripping tags.

--- a/tools/tokina/extractor.py
+++ b/tools/tokina/extractor.py
@@ -56,13 +56,63 @@ class TokinaExtractor(BrandExtractor):
             return url
         return prefix + url[len(prefix):].replace("-", "_")
 
-    def extract_physical(self, content: str) -> dict[str, float]:
+    def extract_physical(self, content: str) -> dict:
         """Parse physical specs from the property_list spec table (#779).
 
         Rows are <_title>/<_value> cell pairs; the page repeats some labels
         in a related-products widget above the real table, so the LAST value
-        for each label wins. Units are normalized to the lenses.ts convention
-        (weight g, distances mm, magnification ratio -> decimal)."""
+        for each label wins. Numerics are normalized to the lenses.ts
+        convention (weight g, distances mm, magnification ratio -> decimal);
+        build flags are returned only when the page states them (a flag the
+        page omits is left out, never returned False)."""
+        specs = self._spec_rows(content)
+        out: dict = {}
+
+        # --- dimensions ---
+        if w := self._num(specs.get("Weight"), r"([\d.]+)\s*g"):
+            out["weight"] = w
+        if ft := self._num(specs.get("Filter Size"), r"([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        if blades := self._num(specs.get("Aperture Blades"), r"(\d+)"):
+            out["apertureBlades"] = blades
+        if (mfd := self._num(specs.get("Minimum Focusing Distance"), r"([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mfd * 1000)  # metres -> mm
+        mr = re.search(r"1\s*:\s*([\d.]+)", specs.get("Macro Ratio", ""))
+        if mr:
+            out["maxMagnification"] = round(1 / float(mr.group(1)), 3)
+        dims = re.search(r"([\d.]+)\s*x\s*([\d.]+)", specs.get("Dimensions", ""))
+        if dims:
+            out["diameter"] = float(dims.group(1))
+            out["length"] = float(dims.group(2))
+
+        # --- core optical ---
+        if ap := self._num(specs.get("Maximum Aperture"), r"f/?([\d.]+)"):
+            out["maxAperture"] = ap
+        focal = re.search(r"([\d.]+)\s*-\s*([\d.]+)\s*mm|([\d.]+)\s*mm",
+                          specs.get("Main specifications", ""))
+        if focal:
+            if focal.group(1):  # zoom range
+                out["focalLengthMin"] = float(focal.group(1))
+                out["focalLengthMax"] = float(focal.group(2))
+            else:  # prime
+                fl = float(focal.group(3))
+                out["focalLengthMin"] = out["focalLengthMax"] = fl
+
+        # --- build flags (only when the page states them) ---
+        yes = lambda v: bool(v) and v.strip().lower() in ("yes", "true")
+        if "Manual Aperture Ring" in specs:
+            out["hasApertureRing"] = yes(specs["Manual Aperture Ring"])
+        if "Aperture De-Click" in specs:
+            out["isApertureClickless"] = yes(specs["Aperture De-Click"])
+        if "Manual Focusing Ring" in specs:
+            out["hasFocusRing"] = yes(specs["Manual Focusing Ring"])
+        if "Image Stabilization" in specs:
+            out["hasOis"] = yes(specs["Image Stabilization"])
+        return out
+
+    @staticmethod
+    def _spec_rows(content: str) -> dict[str, str]:
+        """Title/value pairs from the property_list table; last value wins."""
         rows = re.findall(
             r'_title"[^>]*>(.*?)</div>.*?_value"[^>]*>(.*?)</div>',
             content, re.DOTALL,
@@ -72,26 +122,8 @@ class TokinaExtractor(BrandExtractor):
             title = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", raw_title)).strip()
             value = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", raw_value)).strip()
             if title and value:
-                specs[title] = value  # last occurrence wins
-
-        out: dict[str, float] = {}
-        if w := self._num(specs.get("Weight"), r"([\d.]+)\s*g"):
-            out["weight"] = w
-        if ft := self._num(specs.get("Filter Size"), r"([\d.]+)\s*mm"):
-            out["filterThread"] = ft
-        if blades := self._num(specs.get("Aperture Blades"), r"(\d+)"):
-            out["apertureBlades"] = blades
-        if (mfd := self._num(specs.get("Minimum Focusing Distance"), r"([\d.]+)\s*m")) is not None:
-            out["minFocusDistance"] = round(mfd * 1000)  # metres -> mm
-        macro = specs.get("Macro Ratio", "")
-        mr = re.search(r"1\s*:\s*([\d.]+)", macro)
-        if mr:
-            out["maxMagnification"] = round(1 / float(mr.group(1)), 3)
-        dims = re.search(r"([\d.]+)\s*x\s*([\d.]+)", specs.get("Dimensions", ""))
-        if dims:
-            out["diameter"] = float(dims.group(1))
-            out["length"] = float(dims.group(2))
-        return out
+                specs[title] = value
+        return specs
 
     @staticmethod
     def _num(value: str | None, pattern: str) -> float | None:

--- a/tools/tokina/tests/fixtures/tokina-23mm-sample.html
+++ b/tools/tokina/tests/fixtures/tokina-23mm-sample.html
@@ -29,6 +29,26 @@
 
   <div class="property_list spec">
     <div class="property_list_row">
+      <div class="property_list_cell _title">Main specifications</div>
+      <div class="property_list_cell _value">23mm</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Maximum Aperture</div>
+      <div class="property_list_cell _value">f/1.4</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Manual Aperture Ring</div>
+      <div class="property_list_cell _value">Yes</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Aperture De-Click</div>
+      <div class="property_list_cell _value">Yes</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Manual Focusing Ring</div>
+      <div class="property_list_cell _value">Yes</div>
+    </div>
+    <div class="property_list_row">
       <div class="property_list_cell _title">Minimum Focusing Distance</div>
       <div class="property_list_cell _value">0.3m</div>
     </div>

--- a/tools/tokina/tests/fixtures/tokina-23mm-sample.html
+++ b/tools/tokina/tests/fixtures/tokina-23mm-sample.html
@@ -17,5 +17,41 @@
     <img src="/uploads/images/catalog/product/atx-m/23mm/atxm_23_mtf.jpg"
          alt="atx-m 23mm MTF chart">
   </div>
+
+  <!-- Related-products widget: repeats some labels with junk values; the
+       real spec table below must win (last occurrence). -->
+  <div class="related property_list">
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Weight</div>
+      <div class="property_list_cell _value">atx-m 23mm F1.4 X PLUS</div>
+    </div>
+  </div>
+
+  <div class="property_list spec">
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Minimum Focusing Distance</div>
+      <div class="property_list_cell _value">0.3m</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Macro Ratio</div>
+      <div class="property_list_cell _value">1 : 10</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Filter Size</div>
+      <div class="property_list_cell _value">52mm</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Aperture Blades</div>
+      <div class="property_list_cell _value">9</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Dimensions</div>
+      <div class="property_list_cell _value">65x72 mm</div>
+    </div>
+    <div class="property_list_row">
+      <div class="property_list_cell _title">Weight</div>
+      <div class="property_list_cell _value">276g</div>
+    </div>
+  </div>
 </body>
 </html>

--- a/tools/tokina/tests/test_extractor.py
+++ b/tools/tokina/tests/test_extractor.py
@@ -76,7 +76,7 @@ def test_extract_image_urls_empty_when_no_diagrams(extractor):
     assert urls == {"mtf": [], "construction": []}
 
 
-def test_extract_physical_all_fields(extractor, html):
+def test_extract_physical_dimensions(extractor, html):
     phys = extractor.extract_physical(html)
     assert phys["weight"] == 276  # last-occurrence wins over the widget junk
     assert phys["filterThread"] == 52
@@ -85,6 +85,26 @@ def test_extract_physical_all_fields(extractor, html):
     assert phys["maxMagnification"] == 0.1  # 1:10 -> decimal
     assert phys["diameter"] == 65
     assert phys["length"] == 72
+
+
+def test_extract_physical_optical_and_flags(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["maxAperture"] == 1.4
+    assert phys["focalLengthMin"] == 23  # prime -> min == max
+    assert phys["focalLengthMax"] == 23
+    assert phys["hasApertureRing"] is True
+    assert phys["isApertureClickless"] is True
+    assert phys["hasFocusRing"] is True
+
+
+def test_extract_physical_omits_unstated_flags(extractor, html):
+    # The Tokina page does not state OIS / weather-sealing / AF motor for this
+    # lens — they must be omitted, not returned False (so the stored False is
+    # never falsely flagged as a mismatch).
+    phys = extractor.extract_physical(html)
+    assert "hasOis" not in phys
+    assert "isWeatherSealed" not in phys
+    assert "afMotor" not in phys
 
 
 def test_physical_diff_catches_swapped_weight(extractor, html):

--- a/tools/tokina/tests/test_extractor.py
+++ b/tools/tokina/tests/test_extractor.py
@@ -76,6 +76,36 @@ def test_extract_image_urls_empty_when_no_diagrams(extractor):
     assert urls == {"mtf": [], "construction": []}
 
 
+def test_extract_physical_all_fields(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["weight"] == 276  # last-occurrence wins over the widget junk
+    assert phys["filterThread"] == 52
+    assert phys["apertureBlades"] == 9
+    assert phys["minFocusDistance"] == 300  # 0.3m -> mm
+    assert phys["maxMagnification"] == 0.1  # 1:10 -> decimal
+    assert phys["diameter"] == 65
+    assert phys["length"] == 72
+
+
+def test_physical_diff_catches_swapped_weight(extractor, html):
+    # The Session-76 bug: 23mm stored with the 33mm's weight (285). verify()
+    # must flag it. Here we diff the extracted 276 against a wrong stored 285.
+    from brandkit import diff_physical
+
+    extracted = extractor.extract_physical(html)
+    stored_wrong = {"weight": 285}  # the swapped value
+    mismatches = diff_physical(stored_wrong, extracted)
+    assert any(m.field == "weight" for m in mismatches)
+
+
+def test_physical_clean_when_stored_matches(extractor, html):
+    from brandkit import diff_physical
+
+    extracted = extractor.extract_physical(html)
+    stored_correct = {"weight": 276, "filterThread": 52, "apertureBlades": 9}
+    assert diff_physical(stored_correct, extracted) == []
+
+
 def test_numbered_fallback_for_zoom_lenses(extractor):
     html = (
         '<img src="/uploads/images/catalog/product/atx-m/11-18/05_1.png">'

--- a/tools/ttartisan/extractor.py
+++ b/tools/ttartisan/extractor.py
@@ -56,6 +56,47 @@ class TTArtisanExtractor(BrandExtractor):
         specs["coating"] = self._coating(_strip(content))
         return specs
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from TTartisan's inline label-value spec block
+        (#779). Values appear as 'Label value' in running text, e.g.
+        'Filter size 52mm  Maximum aperture F1.4  Weight Around 341~350g'."""
+        text = _strip(content)
+        out: dict = {}
+
+        if ft := self._num(text, r"Filter size\s*([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        if blades := self._num(text, r"Diaphragm Blades\s*(\d+)"):
+            out["apertureBlades"] = blades
+        if ap := self._num(text, r"Maximum aperture\s*F/?([\d.]+)"):
+            out["maxAperture"] = ap
+        # Weight is often a range ("341~350g"); take the larger (final) value.
+        wm = re.search(r"Weight\s*(?:Around\s*)?(?:[\d.]+\s*~\s*)?([\d.]+)\s*g", text, re.IGNORECASE)
+        if wm:
+            out["weight"] = float(wm.group(1))
+        if (mfd := self._num(text, r"Closest focus distance\s*([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mfd * 1000)  # metres -> mm
+        # Magnification: "Magnification 2:1" (>life-size) or "1:4".
+        mag = re.search(r"Magnification\s*([\d.]+)\s*:\s*([\d.]+)", text, re.IGNORECASE)
+        if mag:
+            a, b = float(mag.group(1)), float(mag.group(2))
+            out["maxMagnification"] = round(a / b, 3) if b else 0.0
+
+        # Focal length: "Focal length 50mm" (prime) or "Focal length 11-20mm".
+        fl = re.search(r"Focal length\s*([\d.]+)(?:\s*-\s*([\d.]+))?\s*mm", text, re.IGNORECASE)
+        if fl:
+            out["focalLengthMin"] = float(fl.group(1))
+            out["focalLengthMax"] = float(fl.group(2) or fl.group(1))
+
+        # Tilt-shift geometry (only on T-S lenses).
+        if tilt := self._num(text, r"Tilt Angle\s*([\d.]+)"):
+            out["tiltAngle"] = tilt
+        return out
+
+    @staticmethod
+    def _num(text: str, pattern: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE)
+        return float(m.group(1)) if m else None
+
     @staticmethod
     def _elements_groups(html: str) -> tuple[int, int] | None:
         """Counts: spec table first, then any table mentioning elements/groups,

--- a/tools/ttartisan/tests/fixtures/ttartisan-90mm-sample.html
+++ b/tools/ttartisan/tests/fixtures/ttartisan-90mm-sample.html
@@ -11,6 +11,12 @@
        2 high-refractive elements, with 4 Sets of Achromatic Doublets.</p>
     <p>MC Multi-Layer Coatings reduce flare.</p>
   </div>
+  <div class="spec-inline">
+    <p>Focal length 90mm Filter size 67mm Maximum aperture F1.25
+       Closest focus distance 0.9m Minimum aperture F16 Diaphragm Blades 12pcs
+       Frame Full Frame Magnification 1:5 Weight Around 620~640g
+       Optical Design 11 Elements in 8 Groups Mount E/X/Z/RF</p>
+  </div>
   <div class="diagrams">
     <img src="/static/upload/other/AB12/Specification-OD-EN.webp">
     <img src="/static/upload/other/AB12/Specification-MTF.webp">

--- a/tools/ttartisan/tests/test_extractor.py
+++ b/tools/ttartisan/tests/test_extractor.py
@@ -67,3 +67,24 @@ def test_slr_variants_excluded(extractor, html):
 def test_relative_urls_resolved(extractor, html):
     urls = extractor.extract_image_urls(html)
     assert all(u.startswith("https://www.ttartisan.com/") for u in urls["mtf"])
+
+
+def test_extract_physical_inline_specs(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["filterThread"] == 67
+    assert phys["apertureBlades"] == 12
+    assert phys["maxAperture"] == 1.25
+    assert phys["minFocusDistance"] == 900  # 0.9m -> mm
+    assert phys["focalLengthMin"] == 90
+    assert phys["focalLengthMax"] == 90
+    assert phys["maxMagnification"] == 0.2  # 1:5
+
+
+def test_extract_physical_weight_range_takes_higher(extractor, html):
+    # "Around 620~640g" -> the higher (final) value.
+    assert extractor.extract_physical(html)["weight"] == 640
+
+
+def test_extract_physical_tilt_angle_when_present(extractor):
+    html = "<p>Focal length 35mm Maximum aperture F1.4 Tilt Angle 8 Weight Around 350g</p>"
+    assert extractor.extract_physical(html)["tiltAngle"] == 8

--- a/tools/venus/extractor.py
+++ b/tools/venus/extractor.py
@@ -75,6 +75,46 @@ class VenusExtractor(BrandExtractor):
         specs["coating"] = self._coating(text)
         return specs
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from Venus Laowa's inline label-value block
+        (#779), e.g. 'Aperture Blades 7 Min. Focusing Distance 12cm
+        Magnification 1:7.5 Filter Thread 49mm Dimensions 60 x 53mm
+        Weight 215g'. NOTE: Venus lists Dimensions as length x diameter
+        (the reverse of most brands). Magnification 'N:M' -> decimal."""
+        text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", content))
+        out: dict = {}
+
+        if blades := self._num(text, r"Aperture Blades\s*(\d+)"):
+            out["apertureBlades"] = blades
+        if (mfd := self._num(text, r"Min(?:imum|\.)?\s*Focus(?:ing)?\s*Distance\s*([\d.]+)\s*cm")) is not None:
+            out["minFocusDistance"] = round(mfd * 10)  # cm -> mm
+        mag = re.search(r"Magnification\s*([\d.]+)\s*:\s*([\d.]+)", text, re.IGNORECASE)
+        if mag:
+            a, b = float(mag.group(1)), float(mag.group(2))
+            out["maxMagnification"] = round(a / b, 3) if b else 0.0
+        if ft := self._num(text, r"Filter Thread\s*([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        # Dimensions are "length x diameter" for Venus (reverse of Tokina).
+        dims = re.search(r"Dimensions\s*([\d.]+)\s*x\s*([\d.]+)\s*mm", text, re.IGNORECASE)
+        if dims:
+            out["length"] = float(dims.group(1))
+            out["diameter"] = float(dims.group(2))
+        if w := self._num(text, r"Weight\s*([\d.]+)\s*g"):
+            out["weight"] = w
+        # Focal length and aperture from "Focal Length 9mm" / "Maximum Aperture F2.8".
+        fl = re.search(r"Focal Length\s*([\d.]+)(?:\s*-\s*([\d.]+))?\s*mm", text, re.IGNORECASE)
+        if fl:
+            out["focalLengthMin"] = float(fl.group(1))
+            out["focalLengthMax"] = float(fl.group(2) or fl.group(1))
+        if ap := self._num(text, r"Maximum Aperture\s*F/?([\d.]+)"):
+            out["maxAperture"] = ap
+        return out
+
+    @staticmethod
+    def _num(text: str, pattern: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE)
+        return float(m.group(1)) if m else None
+
     @staticmethod
     def _special(text: str) -> list[str]:
         # Parenthetical right after the structure line is the most reliable.

--- a/tools/venus/tests/fixtures/venus-argus-sample.html
+++ b/tools/venus/tests/fixtures/venus-argus-sample.html
@@ -9,6 +9,9 @@
        (2 pcs of Aspherical Elements + 3 pcs of Extra-low Dispersion Elements
         + a pair of UHR elements)</p>
     <p>Frog Eye Coating repels water and oil.</p>
+    <p>Focal Length 33mm Maximum Aperture F0.95 Aperture Blades 9
+       Min. Focusing Distance 35cm Magnification 1:4 Filter Thread 62mm
+       Dimensions 71.5 x 72mm Weight 587g</p>
   </div>
   <div class="diagrams">
     <img data-lazy-src="/uploads/Argus-33mm-MTF.png">

--- a/tools/venus/tests/test_extractor.py
+++ b/tools/venus/tests/test_extractor.py
@@ -69,3 +69,22 @@ def test_construction_url_encoded_chinese(extractor):
     html = '<img src="/uploads/%E5%85%89%E8%B7%AF%E5%9B%BE-33mm.png">'
     urls = extractor.extract_image_urls(html)
     assert len(urls["construction"]) == 1
+
+
+def test_extract_physical_inline_block(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["apertureBlades"] == 9
+    assert phys["minFocusDistance"] == 350  # 35cm -> mm
+    assert phys["maxMagnification"] == 0.25  # 1:4
+    assert phys["filterThread"] == 62
+    assert phys["weight"] == 587
+    assert phys["focalLengthMin"] == 33
+    assert phys["maxAperture"] == 0.95
+
+
+def test_extract_physical_dimensions_length_x_diameter(extractor, html):
+    # Venus lists Dimensions as length x diameter (reverse of most brands):
+    # "71.5 x 72mm" -> length 71.5, diameter 72.
+    phys = extractor.extract_physical(html)
+    assert phys["length"] == 71.5
+    assert phys["diameter"] == 72

--- a/tools/voigtlander/extractor.py
+++ b/tools/voigtlander/extractor.py
@@ -34,6 +34,46 @@ class VoigtlanderExtractor(BrandExtractor):
             return {"elements": int(m.group(1)), "groups": int(m.group(2))}
         return {}
 
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from Voigtlander's inline label-value run
+        (#779). Specs appear as 'Label value' in the rendered Divi text, e.g.
+        'Aperture blades 12 Close focusing distance 0.18 m Max. Diameter
+        59.3 mm Length 43.8 mm Weight 214 g Filter size diameter 46 mm'."""
+        text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", content))
+        text = text.replace("&nbsp;", " ")
+        text = re.sub(r"&#\d+;", " ", text)  # drop entity digits (diameter sign)
+        out: dict = {}
+
+        if blades := self._num(text, r"Aperture blades\s*(\d+)"):
+            out["apertureBlades"] = blades
+        if (mfd := self._num(text, r"Close focusing distance\s*([\d.]+)\s*m")) is not None:
+            out["minFocusDistance"] = round(mfd * 1000)  # metres -> mm
+        # Diameter and length: the page gives them adjacently ("Maximum
+        # diameter 59.3 mm Length 43.8 mm"). Anchor length to the diameter so
+        # the focal-length prose elsewhere ("35mm lens ... Length") can't match.
+        dl = re.search(
+            r"(?:Max\.?\s*|Maximum\s*)Diameter\s*([\d.]+)\s*mm\s*Length\s*([\d.]+)\s*mm",
+            text, re.IGNORECASE,
+        )
+        if dl:
+            out["diameter"] = float(dl.group(1))
+            out["length"] = float(dl.group(2))
+        if w := self._num(text, r"Weight\s*([\d.]+)\s*g"):
+            out["weight"] = w
+        # "Filter size diameter 46 mm" or "Filter size ? 46 mm".
+        if ft := self._num(text, r"Filter size(?:\s*diameter)?\s*([\d.]+)\s*mm"):
+            out["filterThread"] = ft
+        # "Largest magnification 1:N" or a decimal, when present with a value.
+        mag = re.search(r"Largest magnification\s*1\s*:\s*([\d.]+)", text, re.IGNORECASE)
+        if mag:
+            out["maxMagnification"] = round(1 / float(mag.group(1)), 3)
+        return out
+
+    @staticmethod
+    def _num(text: str, pattern: str) -> float | None:
+        m = re.search(pattern, text, re.IGNORECASE)
+        return float(m.group(1)) if m else None
+
     def extract_image_urls(self, content: str, url: str = "") -> dict[str, list[str]]:
         # Voigtlander publishes construction diagrams only (no MTF charts);
         # filenames use English or German terms.

--- a/tools/voigtlander/tests/fixtures/voigtlander-nokton-sample.html
+++ b/tools/voigtlander/tests/fixtures/voigtlander-nokton-sample.html
@@ -3,7 +3,10 @@
 <head><title>NOKTON 35mm F1.2 X</title></head>
 <body>
   <div class="et_pb_toggle_content">
-    <p>Optischer Aufbau: 10 elements in 8 groups</p>
+    <p>A 35mm lens. Optischer Aufbau: 10 elements in 8 groups
+       Aperture blades 12 Close focusing distance 0.30 m
+       Largest magnification 1:2 Maximum diameter 69.6 mm Length 39.8 mm
+       Weight 340 g Filter size diameter 58 mm</p>
   </div>
   <div class="diagrams">
     <img src="/wp-content/uploads/Linsenschnitt-Nokton-35.png">

--- a/tools/voigtlander/tests/test_extractor.py
+++ b/tools/voigtlander/tests/test_extractor.py
@@ -52,3 +52,19 @@ def test_construction_german_filename(extractor, html):
 
 def test_no_match_returns_empty(extractor):
     assert extractor.extract_optical("<p>no spec here</p>") == {}
+
+
+def test_extract_physical_inline_run(extractor, html):
+    phys = extractor.extract_physical(html)
+    assert phys["apertureBlades"] == 12
+    assert phys["minFocusDistance"] == 300  # 0.30m -> mm
+    assert phys["maxMagnification"] == 0.5  # 1:2
+    assert phys["diameter"] == 69.6
+    assert phys["weight"] == 340
+    assert phys["filterThread"] == 58
+
+
+def test_extract_physical_length_not_focal(extractor, html):
+    # 'A 35mm lens' precedes the spec run; physical Length must be 39.8 (from
+    # the diameter-anchored dimensions), not the focal length 35.
+    assert extractor.extract_physical(html)["length"] == 39.8


### PR DESCRIPTION
Delivers #779's final acceptance criterion: physical-spec extraction. Expands the scope (per maintainer request) from the ticket's 5 numeric fields to **all page-verifiable specs** — dimensions, core optical, build flags, afMotor, tilt-shift geometry — and implements extract_physical for 8 of 11 brands, each verified against real pages.

## Core (typed verification)

- `brandkit/lenses.py`: `PHYSICAL_SPEC_FIELDS` typed registry (numeric/boolean/string) with `FIELD_KIND`; booleans default to False per the Lens-type contract.
- `brandkit/diff.py`: typed comparison — numeric (tolerance), boolean (exact), string (case-insensitive); a field is compared only when present on both sides, so a flag the page omits is never falsely flagged.

## Brands implemented (8, real-page-verified)

Tokina, TTartisan, Samyang, Fujifilm, Tamron, Voigtlander, Venus, Mitakon — each parses its own spec format (clean th/td or property_list tables, inline label-value runs, marketing prose, Shopify-style blocks), with unit conversions (metres/cm → mm, ratio → decimal, comma weights, text-number blades) and per-brand quirks (Venus dimensions are length×diameter; Samyang/Tamron multi-mount values; Fujifilm Macro focus range). Each has tests against a committed fixture.

## The payoff: --verify now catches real data issues

Across the 8 brands, `--verify` surfaced genuine discrepancies (logged in #896 for a cleanup pass): Fujifilm weights rounded to ~100g + an XF 33mm filterThread error; Voigtlander Nokton 35mm diameter 59.6 vs 69.6 (likely a typo); Tamron 150-500mm weight 1725 vs 725; Samyang/Venus/Mitakon per-mount divergences. The cross-validation has teeth.

## Bugs caught by tests during the work

- HTML numeric-entity digits (`&#8709;` diameter sign, `&#8734;` infinity) leaking into filterThread/diameter — stripped before matching (Fujifilm, Voigtlander).
- Physical `length` confused with focal length in prose — anchored to the diameter (Voigtlander).

## Not in this PR (deferred)

- **Sigma + Viltrox** (#897): their pages weren't cached and there was no network to fetch + verify offline; shipping unverified parsers would break the real-page-verification discipline held for the other 8.
- **Zeiss**: PDF-only — `extract_physical` is a deliberate no-op.
- **Data cleanup** (#896): the discrepancies `--verify` found are tracked for a separate triage pass (some are real errors, some per-mount differences a single stored value can't capture).

## Testing

204 Python tests pass (`cd tools && py -m pytest`); astro check clean. Every extractor verified against real cached pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)