### PR TITLE
fix: exclude scraped HTML fixtures and Python caches from Prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 .claude/
 coverage/
 __pycache__/
+.pytest_cache/
 .cache/
 reports/
 .lighthouseci/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,10 @@ node_modules/
 docs/solid-ai-templates/
 docs/prototype/
 downloaded_files/
+
+# Scraped HTML test fixtures — raw captured pages, must stay byte-for-byte
+tools/**/tests/fixtures/
+
+# Python tooling caches — generated, never committed
+**/.pytest_cache/
+**/__pycache__/


### PR DESCRIPTION
## What

Adds `tools/**/tests/fixtures/` and `.pytest_cache/` / `__pycache__/` to `.prettierignore`, and `.pytest_cache/` to `.gitignore`.

## Why

The Python tooling refactor (#893, #895, #898) committed scraped HTML test fixtures under `tools/*/tests/fixtures/`. `prettier --check` now fails on all 10 of them, which fails `npm run validate` and has **broken the main deploy for the last 3 commits**. These fixtures are raw captured manufacturer pages used as test inputs — they must stay byte-for-byte as captured, so they are ignored rather than reformatted.

While fixing this, `prettier --check` also surfaced `tools/.pytest_cache/README.md` — a generated Python cache that should never be committed or formatted. Added `.pytest_cache/` alongside the existing `__pycache__/` ignore rule in both files.

## Acceptance criteria

- [x] `npm run validate` passes locally (lint, format, check, test, build, check:links — 461 pages)
- [ ] CI green on this PR
- [ ] main deploy green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)