### PR TITLE
fix: exclude tools/ from the front-end quality gate

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,9 +5,9 @@ docs/solid-ai-templates/
 docs/prototype/
 downloaded_files/
 
-# Scraped HTML test fixtures — raw captured pages, must stay byte-for-byte
-tools/**/tests/fixtures/
+# Python tooling — own pytest suites, not part of the front-end gate
+tools/
 
-# Python tooling caches — generated, never committed
+# Python caches — generated, never committed
 **/.pytest_cache/
 **/__pycache__/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import sonarjs from "eslint-plugin-sonarjs";
 import unicorn from "eslint-plugin-unicorn";
 
 export default [
-  { ignores: ["dist", ".astro"] },
+  { ignores: ["dist", ".astro", "tools"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   sonarjs.configs.recommended,


### PR DESCRIPTION
## What

Excludes `tools/` from prettier (`.prettierignore`) and eslint (`eslint.config.js`). Replaces the narrow fixtures-only ignore added in #899 with a whole-`tools/` exclusion.

## Why

`tools/` is Python tooling — `brandkit`, `pagefetch`, and the per-brand extractors — each with its own pytest suite. It is **not** part of the Astro/TypeScript front end and should never be scanned by the front-end formatter/linter gate. Prettier was walking `tools/` and failing on committed HTML test fixtures, which **broke the main deploy three times** (#893, #895, #898).

This aligns the gate with the existing `ci.yml` `changes` path-filter, which already excludes `tools/` from triggering the `build` job. After this change the two agree: a `tools/`-only change does not invoke the front-end `validate` gate, and `validate` no longer reaches into `tools/`.

Root cause analysis of the three red deploys is captured in the dev journal.

## Acceptance criteria

- [x] `npm run validate` passes locally (461 pages built, links checked)
- [x] prettier no longer matches any file under `tools/`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)