### PR TITLE
feat: re-source ViltroxExtractor from Shopify JSON to theme HTML (#901)

### DIFF
--- a/docs/decisions/036-viltrox-html-spec-source.md
+++ b/docs/decisions/036-viltrox-html-spec-source.md
@@ -1,0 +1,84 @@
+# ADR-036: Viltrox specs sourced from theme HTML, not Shopify JSON
+
+**Status:** Accepted
+**Date:** 2026-05-28
+
+## Context
+
+Viltrox runs a Shopify storefront. The original `ViltroxExtractor`
+(ADR-035) read specs from the Shopify product JSON API: `normalize_url`
+appended `.json` to the product URL, and `extract_optical` parsed the
+`product.body_html` field, which once held a small spec table.
+
+Verifying `extract_physical` for Viltrox (#897, split out as #901) found
+that Viltrox has since moved its specs. The `.json` endpoint's
+`body_html` is now ~250–400 characters of marketing prose — no element
+count, filter size, weight, blades, or magnification. The current
+extractor only still passed its tests because its committed fixture was a
+stale JSON capture from before the change; against live pages it returned
+almost nothing.
+
+The specs now live in a `<table>` rendered in the **theme HTML** of the
+product page. This is the same split the image scraper already documented
+(`download_images.py`, ADR-035): Shopify themes embed content that the
+JSON API does not expose.
+
+Two properties of the table complicate parsing:
+
+- It lists **one value column per mount** the lens ships in, in **no
+  fixed order** — e.g. `E / Z / XF` on the 27mm, `E / X / EF-M / Z` on
+  the 33mm. The X-mount column is not at a fixed index.
+- Labels and units **drift across product generations**: `Lens Size` vs
+  `Outer Diameter Size`, `Filter Size` as `φ67mm` vs `Φ52` (lower/upper
+  phi, with or without `mm`), `Number of Aperture Blades` vs `Aperture
+Blades`, `Shooting Distance` vs `Focus Range`, `Max.Magnification`
+  `0.15X` vs `0.1`.
+
+## Decision
+
+Re-source `ViltroxExtractor` from the Shopify JSON to the theme HTML
+product page.
+
+- `normalize_url` becomes identity — the `lenses.ts` Viltrox URLs are
+  already the HTML page URLs (the image scraper fetches them directly).
+- `_spec_rows` parses the spec `<table>` into `{label: value}`, selecting
+  the **X-mount column** dynamically: it reads the `Mount Type` row, finds
+  the cell containing `X-mount`, and uses that column index for every row.
+  Single-value rows use their one value; with no `Mount Type` row the last
+  column wins.
+- `extract_optical` and `extract_physical` read from the table, using
+  **synonym sets** per field to absorb label drift, and numeric parses
+  that ignore the `Φ`/`φ` sign, the `≈`/`=` weight prefix, and a trailing
+  `X` on magnification.
+- Special-element counts are scanned **only in the product description
+  block** (`.product__description` / `.rte`), never the full page. The
+  766 KB theme page is full of CSS/JS hex (a color-scheme UUID ending
+  `…b953ed` would otherwise read as `953 ED`). Most pages name no counts,
+  so `[]` is the common, correct result.
+
+## Alternatives considered
+
+- **Keep the JSON source.** Rejected — the JSON no longer carries specs;
+  the extractor would silently return nothing against live pages.
+- **Hard-code the X-mount column index.** Rejected — the column order
+  differs per lens; a fixed index reads the wrong mount's values.
+- **Scan the whole page for special elements.** Rejected — produces
+  garbage from CSS/JS hex (`953 ED`, `5 HR`). Scoping to the description
+  block and accepting `[]` when no count is named is honest; missing is
+  better than wrong.
+
+## Consequences
+
+- `extract_physical` works for Viltrox, verified live against all 13
+  lenses (7 clean, 6 with stored-data divergences triaged into #902).
+- The extractor reflects Viltrox's current site; the stale JSON fixture is
+  removed in favour of two trimmed HTML fixtures covering both column
+  orderings and the label/unit drift.
+- Special-element counts are no longer extracted from Viltrox pages
+  (they are not structurally present). Existing `specialElements` in
+  `lenses.ts` are unaffected; future entries rely on review sources for
+  this field, per the optical rubric.
+- Viltrox is the only brand whose spec source is theme HTML rather than a
+  structured page or API; the synonym-set + dynamic-column approach is
+  contained in `ViltroxExtractor` and does not affect the brandkit
+  contract.

--- a/tools/viltrox/extractor.py
+++ b/tools/viltrox/extractor.py
@@ -1,15 +1,24 @@
 """ViltroxExtractor — the Viltrox BrandExtractor strategy.
 
-Viltrox runs a Shopify storefront: specs live in the product JSON API at
-/products/{handle}.json, inside product.body_html. So this extractor's
-"content" is the raw JSON text — it json.loads it itself, then parses the
-embedded HTML. normalize_url appends ".json" so brandkit fetches the API
-endpoint. Viltrox publishes no MTF/construction diagrams (has_diagrams
-False), and every AF lens uses the same "HD Nano multilayer coating" — when
-a page omits it, the coating is inferred (flagged via coating_inferred).
+Viltrox runs a Shopify storefront. Historically specs lived in the product
+JSON API (/products/{handle}.json, inside product.body_html), but Viltrox
+moved them into a spec table rendered in the theme HTML of the product page
+(#901). So this extractor fetches the HTML page (normalize_url is identity)
+and parses a <table> whose rows are 'Label | per-mount values...'.
+
+The table lists one value column per mount the lens ships in, in no fixed
+order (e.g. E, Z, XF on one lens; E, X, EF-M, Z on another). The X-mount
+column is selected from the 'Mount Type' row; for a single-value row the one
+value is used. Labels and units drift across product generations ('Lens
+Size' vs 'Outer Diameter Size', 'Filter Size' φ67mm vs Φ52, 'Aperture
+Blades' vs 'Number of Aperture Blades'), so lookups use synonym sets and the
+numeric parse ignores the Φ/φ diameter sign.
+
+Viltrox publishes no MTF/construction diagrams (has_diagrams False), and
+every AF lens uses the same 'HD Nano multilayer coating' — when a page omits
+it, the coating is inferred (flagged via coating_inferred).
 """
 
-import json
 import re
 
 from pagefetch import ContentMode, Transport
@@ -25,68 +34,158 @@ _SPECIAL_PATTERNS = [
     ("LD", r"(\d+)\s*(?:LD|Low[- ]Dispersion)\b"),
 ]
 
-
-def url_to_handle(url: str) -> str:
-    """Shopify product handle: https://viltrox.com/products/af-9mm-f2-8-xf
-    -> af-9mm-f2-8-xf"""
-    return url.rstrip("/").split("/products/")[-1]
+# Label synonyms across product generations -> canonical spec key.
+_FILTER_LABELS = ("Filter Size",)
+_DIM_LABELS = ("Lens Size", "Outer Diameter Size", "Dimensions")
+_WEIGHT_LABELS = ("Weight",)
+_BLADES_LABELS = ("Number of Aperture Blades", "Aperture Blades")
+_MAG_LABELS = ("Max.Magnification", "Maximum Magnification", "Magnification")
+_MFD_LABELS = ("Shooting Distance", "Focus Range", "Focusing Range")
+_ELEMENTS_LABELS = ("Lens Elements", "Lens Structure", "Optical Design")
+_MOTOR_LABELS = ("Focus Motor",)
 
 
 class ViltroxExtractor(BrandExtractor):
     config = BrandConfig(
         name="Viltrox",
         slug_prefix="viltrox",
-        content_mode=ContentMode.HTML,  # the JSON endpoint returns raw text
+        content_mode=ContentMode.HTML,
         transport=Transport.AUTO,
         has_diagrams=False,
     )
 
-    def normalize_url(self, url: str) -> str:
-        """Fetch the Shopify product JSON, not the HTML page."""
-        return url.rstrip("/") + ".json"
-
     def extract_optical(self, content: str) -> dict:
-        body = self._body_html(content)
-        if body is None:
-            return {}
-        text = re.sub(r"\s+", " ", re.sub(r"&nbsp;", " ", re.sub(r"<[^>]+>", " ", body))).strip()
-
+        rows = self._spec_rows(content)
         specs: dict = {}
-        self._elements_groups(text, specs)
+        for label in _ELEMENTS_LABELS:
+            m = re.search(r"(\d+)\s*/\s*(\d+)", rows.get(label, ""))
+            if m:
+                specs["elements"], specs["groups"] = int(m.group(1)), int(m.group(2))
+                break
+        # Special elements, when named at all, appear in the product
+        # description prose — never the spec table. Scan only that block: the
+        # full theme page is full of CSS/JS hex (e.g. a color-scheme UUID
+        # '...b953ed' would otherwise read as '953 ED'). Most pages name no
+        # counts, so [] is the common, correct result.
+        desc = self._description(content)
         specs["special"] = [
             f"{m.group(1)} {label}"
             for label, pat in _SPECIAL_PATTERNS
-            if (m := re.search(pat, text, re.IGNORECASE))
+            if (m := re.search(pat, desc, re.IGNORECASE))
         ]
-        self._coating(text, specs)
+        self._coating(desc, specs)
         return specs
 
     @staticmethod
-    def _body_html(content: str) -> str | None:
-        """Pull product.body_html out of the Shopify JSON text."""
-        try:
-            data = json.loads(content)
-        except (ValueError, TypeError):
-            return None
-        return data.get("product", {}).get("body_html", "")
+    def _description(content: str) -> str:
+        """The product description prose (the .rte / product__description
+        block), tags stripped. Empty string if not found."""
+        m = re.search(
+            r'<div[^>]*class="[^"]*(?:product__description|rte)[^"]*"[^>]*>(.*?)</div>',
+            content,
+            re.DOTALL | re.IGNORECASE,
+        )
+        if not m:
+            return ""
+        return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", m.group(1))).strip()
+
+    def extract_physical(self, content: str) -> dict:
+        """Parse physical specs from Viltrox's theme spec table (#901).
+
+        Picks the X-mount column per row. Filter/dimensions ignore the Φ/φ
+        sign; dimensions are 'φDIAxLENmm' (x or ×); weight drops the ≈/=
+        prefix; magnification drops a trailing 'X'; MFD ('0.28m-∞') is metres
+        -> mm. afMotor is the focus-motor cell verbatim."""
+        rows = self._spec_rows(content)
+        out: dict = {}
+
+        if ft := self._num(self._first(rows, _FILTER_LABELS), r"([\d.]+)"):
+            out["filterThread"] = ft
+        dims = self._first(rows, _DIM_LABELS)
+        if dims:
+            dm = re.search(r"([\d.]+)\s*[x×]\s*([\d.]+)\s*mm", dims)
+            if dm:
+                out["diameter"] = float(dm.group(1))
+                out["length"] = float(dm.group(2))
+        if w := self._num(self._first(rows, _WEIGHT_LABELS), r"([\d,]+\.?\d*)\s*g"):
+            out["weight"] = w
+        if blades := self._num(self._first(rows, _BLADES_LABELS), r"(\d+)"):
+            out["apertureBlades"] = blades
+        if (mag := self._num(self._first(rows, _MAG_LABELS), r"([\d.]+)")) is not None:
+            out["maxMagnification"] = mag
+        mfd = self._first(rows, _MFD_LABELS)
+        if mfd and (mm := re.search(r"([\d.]+)\s*m\b", mfd)):
+            out["minFocusDistance"] = round(float(mm.group(1)) * 1000)
+        if motor := self._first(rows, _MOTOR_LABELS):
+            out["afMotor"] = motor
+        return out
 
     @staticmethod
-    def _elements_groups(text: str, specs: dict) -> None:
-        # Pattern 1: "N elements in M groups".
-        m = re.search(r"(\d+)\s*elements?\s+(?:in\s+)?(\d+)\s*groups?", text, re.IGNORECASE)
-        if m:
-            specs["elements"], specs["groups"] = int(m.group(1)), int(m.group(2))
-            return
-        # Pattern 2: "N/M Elements" / "N/M Optical Design" (elements/groups order).
-        m = re.search(r"(\d+)/(\d+)\s*(?:Elements|Optical\s+Design)", text, re.IGNORECASE)
-        if m:
-            specs["elements"], specs["groups"] = int(m.group(1)), int(m.group(2))
-            return
-        # Pattern 3: "N/M Elements" where the larger number is elements.
-        m = re.search(r"(\d+)/(\d+)\s*Elements?", text, re.IGNORECASE)
-        if m:
-            a, b = int(m.group(1)), int(m.group(2))
-            specs["elements"], specs["groups"] = (a, b) if a > b else (b, a)
+    def _spec_rows(content: str) -> dict[str, str]:
+        """Parse the spec <table> into {label: x-mount value}.
+
+        Each <tr> is 'Label | mount-1 value | mount-2 value | ...'. The
+        X-mount column index comes from the 'Mount Type' row (the cell
+        containing 'X-mount'); rows with a single value use it directly,
+        and when no Mount Type row is found the last value wins."""
+        table = ViltroxExtractor._spec_table(content)
+        if not table:
+            return {}
+        parsed: list[tuple[str, list[str]]] = []
+        for tr in re.finditer(r"<tr[^>]*>(.*?)</tr>", table, re.DOTALL):
+            cells = [
+                re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", c)).strip()
+                for c in re.findall(r"<t[dh][^>]*>(.*?)</t[dh]>", tr.group(1), re.DOTALL)
+            ]
+            if cells and cells[0]:
+                parsed.append((cells[0], cells[1:]))
+
+        col = ViltroxExtractor._x_mount_col(parsed)
+        rows: dict[str, str] = {}
+        for label, values in parsed:
+            if not values:
+                continue
+            value = values[col] if col is not None and col < len(values) else values[-1]
+            if label not in rows:
+                rows[label] = value
+        return rows
+
+    @staticmethod
+    def _spec_table(content: str) -> str | None:
+        """The product spec table — the one containing the elements row."""
+        for labels in (_ELEMENTS_LABELS,):
+            for label in labels:
+                i = content.find(label)
+                if i < 0:
+                    continue
+                start = content.rfind("<table", 0, i)
+                end = content.find("</table>", i)
+                if start >= 0 and end >= 0:
+                    return content[start : end + len("</table>")]
+        return None
+
+    @staticmethod
+    def _x_mount_col(parsed: list[tuple[str, list[str]]]) -> int | None:
+        for label, values in parsed:
+            if label.strip().lower() == "mount type":
+                for idx, val in enumerate(values):
+                    if re.search(r"\bX[- ]?mount\b", val, re.IGNORECASE):
+                        return idx
+        return None
+
+    @staticmethod
+    def _first(rows: dict[str, str], labels: tuple[str, ...]) -> str | None:
+        for label in labels:
+            if label in rows:
+                return rows[label]
+        return None
+
+    @staticmethod
+    def _num(value: str | None, pattern: str) -> float | None:
+        if not value:
+            return None
+        m = re.search(pattern, value)
+        return float(m.group(1).replace(",", "")) if m else None
 
     @staticmethod
     def _coating(text: str, specs: dict) -> None:

--- a/tools/viltrox/tests/fixtures/viltrox-27mm-page.html
+++ b/tools/viltrox/tests/fixtures/viltrox-27mm-page.html
@@ -1,0 +1,26 @@
+<!--
+  Trimmed Viltrox product-page markup (AF 27mm f/1.2 Pro), captured from
+  viltrox.com. Multi-mount spec table where the columns are E / Z / XF, so
+  the X-mount column is LAST. Keeps the real Unicode (φ) and the ≈ weight
+  prefix the live pages serve. Description block included so the
+  special-element scan has a realistic (count-free) target.
+-->
+<div class="product__description rte">
+  <p>The AF 27mm F1.2 Pro lens is part of Viltrox's Pro flagship series,
+  offering an ultra-large F1.2 aperture, with an aspherical lens for
+  distortion control.</p>
+</div>
+<table class="spec">
+  <tr><td>Model</td><td>AF 27/1.2 Pro E</td><td>AF 27/1.2 Pro Z</td><td>AF 27/1.2 Pro XF</td></tr>
+  <tr><td>Mount Type</td><td>E-mount</td><td>Z-mount</td><td>X-mount</td></tr>
+  <tr><td>Sensor Format</td><td>APS-C</td><td>APS-C</td><td>APS-C</td></tr>
+  <tr><td>Lens Elements</td><td>15/11</td><td>15/11</td><td>15/11</td></tr>
+  <tr><td>Aperture</td><td>F1.2~F16</td><td>F1.2~F16</td><td>F1.2~F16</td></tr>
+  <tr><td>Number of Aperture Blades</td><td>11</td><td>11</td><td>11</td></tr>
+  <tr><td>Shooting Distance</td><td>0.28m~∞</td><td>0.28m~∞</td><td>0.28m-∞</td></tr>
+  <tr><td>Focus Motor</td><td>STM+Lead screw</td><td>STM+Lead screw</td><td>STM+Lead screw</td></tr>
+  <tr><td>Max.Magnification</td><td>0.15X</td><td>0.15X</td><td>0.15X</td></tr>
+  <tr><td>Filter Size</td><td>φ67mm</td><td>φ67mm</td><td>φ67mm</td></tr>
+  <tr><td>Lens Size</td><td>φ82x92mm</td><td>φ82x94mm</td><td>φ82x92mm</td></tr>
+  <tr><td>Weight</td><td>≈565g</td><td>≈605g</td><td>≈560g</td></tr>
+</table>

--- a/tools/viltrox/tests/fixtures/viltrox-27mm-product.json
+++ b/tools/viltrox/tests/fixtures/viltrox-27mm-product.json
@@ -1,8 +1,0 @@
-{
-  "product": {
-    "id": 123456,
-    "title": "VILTROX AF 27mm F1.2 Pro",
-    "handle": "af-27mm-f1-2-pro-xf",
-    "body_html": "<p>The VILTROX AF 27mm F1.2 Pro features a 15 elements in 11 groups optical design.</p><ul><li>2 aspherical elements</li><li>1 ED element</li><li>3 HR (High Refractive) elements</li></ul><p>An HD Nano multilayer coating reduces flare and ghosting.</p>"
-  }
-}

--- a/tools/viltrox/tests/fixtures/viltrox-33mm-page.html
+++ b/tools/viltrox/tests/fixtures/viltrox-33mm-page.html
@@ -1,0 +1,24 @@
+<!--
+  Trimmed Viltrox product-page markup (AF 33mm f/1.4 STM), captured from
+  viltrox.com. Multi-mount spec table where the columns are E / X / EF-M / Z,
+  so the X-mount column is the SECOND value (not last) — exercises dynamic
+  X-mount column detection. Uses the label/unit drift the live pages show:
+  'Aperture Blades' (not 'Number of ...'), 'Outer Diameter Size' (not 'Lens
+  Size'), 'Focus Range' (not 'Shooting Distance'), uppercase Φ, 'Φ52' with no
+  'mm', magnification '0.1' with no 'X', '×' dimension sign.
+-->
+<div class="product__description rte">
+  <p>The AF 33mm F1.4 delivers excellent image quality across the frame.</p>
+</div>
+<table class="spec">
+  <tr><td>Mount Type</td><td>E-mount</td><td>X-mount</td><td>EF-M-mount</td><td>Z-mount</td></tr>
+  <tr><td>Lens Elements</td><td>10/9</td><td>10/9</td><td>10/9</td><td>10/9</td></tr>
+  <tr><td>Aperture</td><td>F1.4-16</td><td>F1.4-16</td><td>F1.4-16</td><td>F1.4-16</td></tr>
+  <tr><td>Aperture Blades</td><td>9</td><td>9</td><td>9</td><td>9</td></tr>
+  <tr><td>Focus Range</td><td>0.4m-∞</td><td>0.4m-∞</td><td>0.4m-∞</td><td>0.4m-∞</td></tr>
+  <tr><td>Focus Motor</td><td>STM+Lead screw</td><td>STM+Lead screw</td><td>STM+Lead screw</td><td>STM+Lead screw</td></tr>
+  <tr><td>Max.Magnification</td><td>0.1</td><td>0.1</td><td>0.1</td><td>0.1</td></tr>
+  <tr><td>Filter Size</td><td>Φ52</td><td>Φ52</td><td>Φ52</td><td>Φ52</td></tr>
+  <tr><td>Outer Diameter Size</td><td>Φ65×72mm</td><td>Φ65×72mm</td><td>Φ65×72mm</td><td>Φ69×73mm</td></tr>
+  <tr><td>Weight</td><td>≈270g</td><td>≈270g</td><td>≈270g</td><td>≈310g</td></tr>
+</table>

--- a/tools/viltrox/tests/test_extractor.py
+++ b/tools/viltrox/tests/test_extractor.py
@@ -1,4 +1,10 @@
-"""ViltroxExtractor tests — JSON content + inferred-coating default."""
+"""ViltroxExtractor tests — theme-HTML spec table (#901).
+
+Viltrox moved its specs out of the Shopify JSON into a spec table in the
+theme HTML. These exercise the X-mount column selection (the table lists one
+column per mount, in no fixed order), the label/unit drift across product
+generations, and the inferred-coating default.
+"""
 
 import sys
 from pathlib import Path
@@ -9,14 +15,11 @@ TOOLS_DIR = Path(__file__).resolve().parent.parent.parent
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
-from viltrox.extractor import ViltroxExtractor, url_to_handle  # noqa: E402
+from viltrox.extractor import ViltroxExtractor  # noqa: E402
 
-FIXTURE = Path(__file__).resolve().parent / "fixtures" / "viltrox-27mm-product.json"
-
-
-@pytest.fixture
-def product_json() -> str:
-    return FIXTURE.read_text(encoding="utf-8")
+FIXDIR = Path(__file__).resolve().parent / "fixtures"
+PAGE_27 = FIXDIR / "viltrox-27mm-page.html"  # columns E / Z / XF (X last)
+PAGE_33 = FIXDIR / "viltrox-33mm-page.html"  # columns E / X / EF-M / Z (X 2nd)
 
 
 @pytest.fixture
@@ -29,56 +32,96 @@ def test_config_no_diagrams(extractor):
     assert extractor.config.has_diagrams is False
 
 
-def test_normalize_url_appends_json(extractor):
-    assert (
-        extractor.normalize_url("https://viltrox.com/products/af-27mm-f1-2-pro-xf")
-        == "https://viltrox.com/products/af-27mm-f1-2-pro-xf.json"
-    )
+def test_normalize_url_is_identity(extractor):
+    # Specs now live on the HTML page; no .json suffix (#901).
+    url = "https://viltrox.com/products/viltrox-af-27mm-f-1-2-pro-xf-mount"
+    assert extractor.normalize_url(url) == url
 
 
-def test_url_to_handle():
-    assert url_to_handle("https://viltrox.com/products/af-9mm-f2-8-xf") == "af-9mm-f2-8-xf"
+# --- extract_optical ----------------------------------------------------
 
 
-def test_elements_groups_from_json_body(extractor, product_json):
-    specs = extractor.extract_optical(product_json)
+def test_elements_groups_from_spec_table(extractor):
+    specs = extractor.extract_optical(PAGE_27.read_text(encoding="utf-8"))
     assert specs["elements"] == 15
     assert specs["groups"] == 11
 
 
-def test_special_elements(extractor, product_json):
-    specs = extractor.extract_optical(product_json)
-    assert "2 aspherical" in specs["special"]
-    assert "1 ED" in specs["special"]
-    assert "3 HR" in specs["special"]
+def test_elements_groups_label_drift(extractor):
+    # 33mm page uses the same 'Lens Elements' label but a different column order.
+    specs = extractor.extract_optical(PAGE_33.read_text(encoding="utf-8"))
+    assert specs["elements"] == 10
+    assert specs["groups"] == 9
 
 
-def test_coating_read_from_page_not_inferred(extractor, product_json):
-    specs = extractor.extract_optical(product_json)
-    assert specs["coating"] == ["HD Nano multilayer coating"]
-    assert "coating_inferred" not in specs
+def test_special_empty_when_description_names_no_counts(extractor):
+    # The 33mm description names no special-element counts -> [].
+    specs = extractor.extract_optical(PAGE_33.read_text(encoding="utf-8"))
+    assert specs["special"] == []
 
 
-def test_coating_inferred_when_absent(extractor):
-    # No coating mention → brand default, flagged inferred.
-    body = '{"product": {"body_html": "<p>10 elements in 8 groups.</p>"}}'
-    specs = extractor.extract_optical(body)
+def test_special_ignores_page_hex_noise(extractor):
+    # A CSS color-scheme UUID ending '...b953ed' must NOT read as '953 ED':
+    # the scan is scoped to the description block, not the whole page.
+    html = (
+        '<style>.x{--scheme-45d804b953ed:#000}</style>'
+        '<div class="product__description rte"><p>A fine lens.</p></div>'
+        '<table><tr><td>Lens Elements</td><td>9/8</td></tr></table>'
+    )
+    assert extractor.extract_optical(html)["special"] == []
+
+
+def test_special_counts_from_description(extractor):
+    html = (
+        '<div class="product__description rte">'
+        '<p>Built with 2 aspherical and 1 ED element.</p></div>'
+        '<table><tr><td>Lens Elements</td><td>9/8</td></tr></table>'
+    )
+    special = extractor.extract_optical(html)["special"]
+    assert "2 aspherical" in special
+    assert "1 ED" in special
+
+
+def test_coating_brand_default_inferred(extractor):
+    # Pages don't list the coating; the brand default fills it, flagged.
+    specs = extractor.extract_optical(PAGE_27.read_text(encoding="utf-8"))
     assert specs["coating"] == ["HD Nano multilayer coating"]
     assert specs["coating_inferred"] is True
 
 
-def test_slash_format_elements_groups(extractor):
-    body = '{"product": {"body_html": "<p>Optical Design: 9/11 Elements</p>"}}'
-    specs = extractor.extract_optical(body)
-    # Pattern 2 reads N/M as elements/groups.
-    assert specs["elements"] == 9
-    assert specs["groups"] == 11
+# --- extract_physical (#901 / #779) -------------------------------------
 
 
-def test_malformed_json_returns_empty(extractor):
-    assert extractor.extract_optical("not json at all") == {}
+def test_extract_physical_x_mount_column_last(extractor):
+    # 27mm columns are E / Z / XF -> X-mount is the LAST value.
+    phys = extractor.extract_physical(PAGE_27.read_text(encoding="utf-8"))
+    assert phys["filterThread"] == 67
+    assert phys["diameter"] == 82.0
+    assert phys["length"] == 92.0
+    assert phys["weight"] == 560  # XF column, not the E column's 565
+    assert phys["apertureBlades"] == 11
+    assert phys["maxMagnification"] == 0.15  # "0.15X" -> 0.15
+    assert phys["minFocusDistance"] == 280  # 0.28m -> mm
+    assert phys["afMotor"] == "STM+Lead screw"
 
 
-def test_no_images(extractor, product_json):
-    # has_diagrams False → base default empty image dict.
-    assert extractor.extract_image_urls(product_json, "https://x") == {"mtf": [], "construction": []}
+def test_extract_physical_x_mount_column_middle(extractor):
+    # 33mm columns are E / X / EF-M / Z -> X-mount is the SECOND value.
+    phys = extractor.extract_physical(PAGE_33.read_text(encoding="utf-8"))
+    assert phys["filterThread"] == 52  # "Φ52" (no mm) -> 52
+    assert phys["diameter"] == 65.0  # X-mount col, not the Z col's 69
+    assert phys["length"] == 72.0
+    assert phys["weight"] == 270  # X-mount col, not the Z col's 310
+    assert phys["apertureBlades"] == 9
+    assert phys["maxMagnification"] == 0.1  # "0.1" (no X) -> 0.1
+    assert phys["minFocusDistance"] == 400  # 0.4m -> mm
+
+
+def test_extract_physical_empty_without_table(extractor):
+    assert extractor.extract_physical("<p>no spec table</p>") == {}
+
+
+def test_no_images(extractor):
+    # has_diagrams False -> base default empty image dict.
+    page = PAGE_27.read_text(encoding="utf-8")
+    assert extractor.extract_image_urls(page, "https://x") == {"mtf": [], "construction": []}


### PR DESCRIPTION
## What

Re-sources `ViltroxExtractor` from the Shopify product JSON to the product page's theme HTML, and adds `extract_physical`.

## Why

Verifying Viltrox `extract_physical` (#897) found Viltrox **moved its specs out of the Shopify JSON** — `body_html` is now ~250–400 chars of marketing prose. The JSON-based extractor returned nothing against live pages; it only passed on a stale fixture. Specs now live in a `<table>` in the theme HTML (the same JSON-vs-theme split the image scraper already documents).

## How

- `normalize_url` is now identity (the `lenses.ts` URLs are the HTML pages).
- `_spec_rows` parses the spec `<table>`, selecting the **X-mount column dynamically** from the `Mount Type` row — column order differs per lens (`E/Z/XF` on the 27mm, `E/X/EF-M/Z` on the 33mm), so a fixed index would read the wrong mount.
- `extract_optical` + `extract_physical` use **per-field synonym sets** for label drift (`Lens Size`/`Outer Diameter Size`, `Aperture Blades`/`Number of Aperture Blades`, `Shooting Distance`/`Focus Range`); numeric parses ignore the `Φ`/`φ` sign, `≈`/`=` weight prefix, and trailing `X` on magnification.
- Special-element scan is **scoped to the description block**, not the whole page — a CSS color-scheme UUID ending `…b953ed` otherwise read as `953 ED`. Most pages name no counts, so `[]` is the honest, common result.

## Test plan

- [x] 12 Viltrox extractor tests pass (X-mount column last AND middle, label/unit drift, hex-noise rejection, empty-table)
- [x] Full `tools/` pytest: 206 passed
- [x] `npm run validate` exits 0
- [x] Verified live: `py tools/viltrox/fetch_specs.py --verify` across all 13 lenses — 7 clean, 6 stored-data divergences tracked in #902

## Notes

- **ADR-036** records the JSON→HTML source change.
- Stale JSON fixture replaced with two trimmed HTML fixtures covering both column orderings.
- Special-element counts are no longer extracted from Viltrox (not structurally present on the page); existing `specialElements` in `lenses.ts` are unaffected.

Closes #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)