### PR TITLE
fix: parse comma-formatted Fujifilm weights in extract_physical (#906)

### DIFF
--- a/tools/fujifilm/extractor.py
+++ b/tools/fujifilm/extractor.py
@@ -112,8 +112,11 @@ class FujifilmExtractor(BrandExtractor):
             out["apertureBlades"] = blades
         if (mag := self._num(text, r"Max\.?\s*magnification\s*([\d.]+)\s*x")) is not None:
             out["maxMagnification"] = mag
-        if w := self._num(text, r"Weight[^=g]*?([\d.]+)\s*g"):
-            out["weight"] = w
+        # Weights >=1000g are printed with a comma thousands separator
+        # ("2,265g"); capture commas and strip them before parsing so the
+        # leading digits are not dropped.
+        if wm := re.search(r"Weight[^=g]*?([\d,.]+)\s*g", text, re.IGNORECASE):
+            out["weight"] = float(wm.group(1).replace(",", ""))
         if ft := self._num(text, r"Filter size[^\d]*([\d.]+)\s*mm"):
             out["filterThread"] = ft
         # dimensions: "Diameter x Length ... 65mm x 58.4mm"

--- a/tools/fujifilm/tests/test_extractor.py
+++ b/tools/fujifilm/tests/test_extractor.py
@@ -96,6 +96,20 @@ def test_extract_physical_zoom_focal_range(extractor):
     assert phys["focalLengthMax"] == 24
 
 
+def test_extract_physical_comma_weight(extractor):
+    # Weights >=1000g use a comma thousands separator on the spec page
+    # (e.g. XF 200mm f/2 reads "2,265g") — the digits before the comma
+    # must not be dropped (#906).
+    html = "<td>Weight *2 (approx.)</td><td>2,265g</td>"
+    assert extractor.extract_physical(html)["weight"] == 2265
+
+
+def test_extract_physical_plain_weight_unaffected(extractor):
+    # Sub-1000g weights have no separator and must still parse.
+    html = "<td>Weight</td><td>375g</td>"
+    assert extractor.extract_physical(html)["weight"] == 375
+
+
 def test_named_image_urls_cross_and_specifications(extractor, html):
     urls = extractor.extract_image_urls(html, LENS_URL + "specifications/")
     assert any(u.endswith("xf16mmf14-r-wr_cross.webp") for u in urls["construction"])


### PR DESCRIPTION
Closes #906.

## What

The weight regex in `tools/fujifilm/extractor.py` (`extract_physical`) captured `([\d.]+)`, which excludes the comma thousands separator. On Fujifilm spec pages, weights ≥1000g are printed as `2,265g`, so the lazy prefix consumed up to the comma and only the digits after it were captured (`2,265g` → `265`).

Fix: capture commas in the weight group and strip them before `float()`.

## Why this mattered

Surfaced while working #896 (Fujifilm rounded weights). The bug made `py tools/fujifilm/fetch_specs.py --verify` untrustworthy — ~12 heavy lenses reported garbage "page" weights (e.g. XF 200mm f/2 `265`, GF 110mm f/2 `10`, MKX 18-55mm `100`). Blindly applying those would have corrupted correct stored data and masked the genuine weight-rounding deltas #896 targets.

Verified against the live XF 200mm f/2 page (`Weight 2,265g`). After the fix, `--verify` heavy-lens weight false positives are gone:
- XF 200mm f/2: weight mismatch cleared (only the genuine blades 11→9 remains)
- XF 100-400mm / XF 150-600mm / GF 110mm f/2 / GF 500mm: weight mismatches cleared
- MKX cine "100" reads were the same bug (`1,100g`) — also cleared

`--verify` went from 22 clean / 44 issues to **24 clean / 42 issues**, with the remaining 42 now being genuine data deltas (the #896 scope).

## Tests

Added two regression tests to `fujifilm/tests/test_extractor.py`:
- `test_extract_physical_comma_weight` — `2,265g` → 2265
- `test_extract_physical_plain_weight_unaffected` — `375g` → 375

```
14 passed in 0.08s
```

## Acceptance criteria

- [x] `extract_physical` parses comma-formatted weights (`2,265g` → 2265)
- [x] Regression test covering a comma-formatted weight
- [x] MKX cine weight read investigated — same comma bug, resolved by this fix
- [x] `--verify` heavy-lens weight false positives gone

Note: `tools/` is excluded from the front-end quality gate (`.prettierignore` / `eslint.config.js` / ci.yml path filter); verified with `py -m pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)