### PR TITLE
docs: session 92 release-gate + v0.7.0 wrap-up

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -1020,9 +1020,24 @@ merges:
 ```bash
 git checkout main && git pull
 git tag vA.B.C && git push origin vA.B.C
+
+# Verify the manifest version matches the tag (base/git.md post-release check)
+node -p "require('./package.json').version"   # must equal A.B.C
+git describe --tags --abbrev=0                 # must be vA.B.C
+
+# Create the GitHub Release — a pushed tag alone does NOT create one
+gh release create vA.B.C --title "vA.B.C" --generate-notes
+
+# Clean up the release branch
 git branch -d chore/release-vA.B.C
 git push origin --delete chore/release-vA.B.C
 ```
+
+The git **tag** and the GitHub **Release** are separate artifacts: pushing
+the tag creates the git ref; `gh release create` creates the Releases-page
+entry with notes auto-generated from the PRs merged since the previous tag.
+The deploy (§5.2) runs on the release-bump merge to `main`, independent of
+the tag.
 
 ### 5.2 Deploy
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -548,6 +548,12 @@ Pipeline steps (exits on first failure):
 | Build      | `npm run build`       | Astro build — full static site generation         |
 | Link check | `npm run check:links` | Trailing slash validation on internal links       |
 
+Manual / scheduled (network — not in `validate`):
+
+| Check          | Command                        | What it checks                                                                                                                                                                                                                                 |
+| -------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External links | `npm run check:external-links` | Every external URL in `src/data/*.ts` (officialUrl + review links) is reachable. Bot-blocked/rate-limited hosts (403/429/503/timeout) report as UNVERIFIABLE, not dead. Runs weekly via `external-links.yml`; also a pre-release check (§5.1). |
+
 ### 3.2 Pre-commit hooks (husky + lint-staged)
 
 Every commit is gated by `.husky/pre-commit`. Runs automatically — no manual

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -3210,8 +3210,62 @@ Issues created: solid-ai-templates#329 (no-force-push convention)
 
 - **Rebased a pushed branch (process slip, no impact).** **Symptom:** attempted to delete+re-push a pushed branch to replace rebased history; blocked by the force-push guard. **Root cause:** rebased `fix/896` (already pushed, stacked on #906) onto main to drop the duplicate commit — contradicting the standing rule "never force push; use merge not rebase on pushed branches." **Why it didn't bite:** the branch had no open PR yet and the guard caught the circumvention. **Fix:** recovered without rewriting remote history — cut a fresh branch off main, cherry-picked only the data commit, opened a clean data-only PR (#910), closed the stacked PR (#909). **Prevention:** for a feature branch that needs to drop an already-merged dependency commit, branch fresh off main and cherry-pick the wanted commit — never rebase the pushed branch.
 
+#### Release gate + v0.7.0 (same session, continued)
+
+After the data arc, ran a full pre-release gate and shipped **v0.7.0**
+(PRs #916 gate-hardening, #917 release bump; tag `v0.7.0` + published
+GitHub Release with auto-generated notes; deploy green).
+
+- **External link check (new):** `scripts/check-external-links.ts` +
+  `npm run check:external-links` + weekly `external-links.yml` cron (the
+  release-relevant gap — lychee in CI only checks internal links offline).
+  It classifies 403/429/503/timeouts/TLS errors as UNVERIFIABLE
+  (bot-block/rate-limit), only genuine 404/410/dead-DNS as broken, so the
+  cron does not cry wolf. Not part of `validate` (network calls). First run
+  flagged 39 URLs; only 3 were genuinely dead (opticallimits.com Samyang
+  14/35/85mm — old `/canon_eos_ff/` paths now 404; current opticallimits
+  reviews are AF-FE versions = different lenses), removed; each lens keeps
+  its other source(s). The other 36 were bot-blocks verified live via
+  `pagefetch`.
+- **360-degree analysis:** four parallel role agents. Value A-, Quality B,
+  Viability B+, Discovery B; **overall B, zero critical findings** →
+  release-clearing. Stored as a verbose dated report
+  `docs/audits/2026-05-28-360.md` (per-dimension findings tables + per-grade
+  rationale). Fixed during the gate: dead `genreEntries` var in
+  `lenses/[slug].astro`; Node floor 20+→22+ in README/ONBOARDING
+  (lint-staged@17 needs >=22.22.1). Non-blockers filed: #912 (hero copy vs
+  ~49% OQ coverage), #913 (privacy/analytics page), #914 (per-page OG +
+  twitter:site), #915 (vitest coverage scope + devDep audit).
+- **Structure audit:** all §5.2 MUSTs pass.
+
+#### Key decisions (release gate)
+
+- **Pre-release gate wired into PLAYBOOK 5.1.** `base/git.md` mandates
+  unmerged-branch / orphaned-commit / 360 checks before a tag, but PLAYBOOK
+  5.1 jumped straight to `npm run release`. Added a Pre-release checks
+  subsection (incl. the external link check and the 360).
+- **360 storage = dated reports under `docs/audits/`, not `docs/360-audit.md`.**
+  The 360.md template mandates a single history file; I created one, then
+  caught (via dev-journal line ~2329) that a past session had deliberately
+  split that into `docs/audits/` dated files. Reverted my file, wrote the
+  verbose dated report, documented the deviation in CLAUDE.md §5.3, flagged
+  upstream (solid-ai-templates#337). Maintainer-driven: reports must explain
+  _how_ each score was reached, not just list grades.
+- **Hero-copy overstatement accepted for beta** (#912): beta badge +
+  transparent "limited coverage" messaging make it acceptable to tag; soften
+  before 1.0.
+
 #### Next
 
-- Release: v0.7.0 still un-tagged — `package.json` at 0.6.0; the #779/#896/#902 data-quality arc is now complete, so this is a natural tag point. Decide whether to tag now (follow PLAYBOOK 5.1 — bump `package.json` first).
-- Spot-check other brands for comma-formatted weights / rounded data now that all `extract_physical` brands are live (the shared weight-parsing pattern lives per-brand; brandkit lenses.py `_parse_number` already handles commas, but per-brand `extract_physical` regexes were written independently).
-- Backlog carried over: #894 (Python toolchain spike), #884 (specs-log backfill), pagefetch `download_bytes` escalation for Venus images, pagefetch→submodule extraction.
+- v0.7.0 shipped. Next release tag is a natural point after the #912–#915
+  polish and/or the next data/feature arc.
+- For future tags: `gh release create` is a separate step from the git tag —
+  PLAYBOOK 5.1 (with-manifest path) documents the tag but not the Release;
+  consider adding the `gh release create ... --generate-notes` step to 5.1.
+- Spot-check other brands for comma-formatted weights / rounded data now that
+  all `extract_physical` brands are live (per-brand `extract_physical` regexes
+  were written independently; brandkit lenses.py `_parse_number` already
+  handles commas).
+- Backlog carried over: #894 (Python toolchain spike), #884 (specs-log
+  backfill), pagefetch `download_bytes` escalation for Venus images,
+  pagefetch→submodule extraction.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -3259,9 +3259,11 @@ GitHub Release with auto-generated notes; deploy green).
 
 - v0.7.0 shipped. Next release tag is a natural point after the #912–#915
   polish and/or the next data/feature arc.
-- For future tags: `gh release create` is a separate step from the git tag —
-  PLAYBOOK 5.1 (with-manifest path) documents the tag but not the Release;
-  consider adding the `gh release create ... --generate-notes` step to 5.1.
+- PLAYBOOK 5.1 now documents the full post-merge sequence (tag → verify
+  manifest==tag → `gh release create --generate-notes` → cleanup); the git
+  tag and the GitHub Release are called out as separate artifacts. Flagged
+  upstream as solid-ai-templates#338 (with-manifest path should include
+  `gh release create`).
 - Spot-check other brands for comma-formatted weights / rounded data now that
   all `extract_physical` brands are live (per-brand `extract_physical` regexes
   were written independently; brandkit lenses.py `_parse_number` already


### PR DESCRIPTION
End-of-session documentation for the release-gate + v0.7.0 portion of session 92.

## Changes
- **docs/dev-journal.md** — extends the Session 92 entry with the release-gate + v0.7.0 sub-section (external link check, 360 results overall B / zero critical, gate fixes, non-blockers #912–#915), Key decisions (pre-release gate wired into PLAYBOOK 5.1; 360 stored as dated reports under docs/audits/; hero-copy accepted for beta), and updated Next (v0.7.0 shipped; `gh release create` is separate from the git tag).
- **docs/PLAYBOOK.md §3.1** — adds a manual/scheduled checks sub-table documenting `npm run check:external-links` (weekly cron + pre-release check).

## Context
v0.7.0 was tagged and released this session (tag `v0.7.0`, GitHub Release published, deploy green). Upstream conventions flagged: solid-ai-templates #335 (verify tool before bulk data change), #337 (360 dated-reports), #338 (gh release create in with-manifest path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)