### PR TITLE
feat: pagefetch cache cleanup — auto-delete on read + --clean-cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 - Use `py -m pagefetch <url>` (run from `tools/`) for all web page fetching — never WebFetch or Fetch tools
 - WebFetch/Fetch truncates large pages through a small model, silently losing data
 - `pagefetch` auto-escalates: urllib (~1s) → Playwright (~5-9s) → Nodriver (~6-8s) → SeleniumBase UC (~18-24s)
-- Flags: `--html` (raw HTML), `--js` (force Playwright), `--nodriver` (force headed Chrome), `--uc` (force UC), `--batch urls.txt` (persistent browser session), `--no-cache` (bypass cache)
+- Flags: `--html` (raw HTML), `--js` (force Playwright), `--nodriver` (force headed Chrome), `--uc` (force UC), `--batch urls.txt` (persistent browser session), `--no-cache` (bypass cache), `--clean-cache` (sweep bot/404 junk from the cache; add `--dry-run` to preview)
 - For bot-protected sites, auto mode skips Playwright and goes straight to Nodriver (headed Chrome, no driver binary)
 - Use DuckDuckGo HTML search (`html.duckduckgo.com/html/?q=...`) when Google/Bing block with CAPTCHAs — works with urllib (~1s)
 - This applies to both the main agent and all subagents — when spawning research agents, instruct them to use `py -m pagefetch`, not WebFetch

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -199,10 +199,15 @@ py -m pagefetch <url> --nodriver   # force Nodriver (headed Chrome, bot bypass)
 py -m pagefetch <url> --uc         # force SeleniumBase UC (headless fallback)
 py -m pagefetch <url> --no-cache   # bypass cache, fetch fresh
 py -m pagefetch --batch urls.txt --nodriver --output-dir out/  # batch mode
+py -m pagefetch --clean-cache      # purge bot/404 junk entries from the cache
+py -m pagefetch --clean-cache --dry-run   # list junk entries, delete nothing
 ```
 
 Responses are cached in `.cache/fetch/` (me-fuji points the cache there).
-See `tools/pagefetch/README.md` for the architecture and library API.
+Bot-blocked and 404/gone responses are never cached and self-heal on read;
+`--clean-cache` sweeps any junk that accumulated (ADR-037 — content-based
+validity, no TTL). See `tools/pagefetch/README.md` for the architecture and
+library API.
 
 **Run the Python tool tests:**
 

--- a/tools/pagefetch/README.md
+++ b/tools/pagefetch/README.md
@@ -36,6 +36,8 @@ py -m pagefetch <url> --nodriver   # force Nodriver (headed)
 py -m pagefetch <url> --uc         # force SeleniumBase UC
 py -m pagefetch <url> --wait 5000  # extra post-load wait (ms)
 py -m pagefetch <url> --no-cache   # bypass cache
+py -m pagefetch --clean-cache      # purge bot/404 junk from the cache
+py -m pagefetch --clean-cache --dry-run   # list junk, delete nothing
 
 py -m pagefetch --batch urls.txt              # batch from file
 py -m pagefetch --batch -                      # batch from stdin
@@ -142,9 +144,16 @@ changing it would invalidate existing caches.
 Only real content is cached: bot-blocked, 404/gone, and implausibly short
 responses are kept out of the cache (see Bot detection). On read, a cached
 body that is recognizably a bot/throttle page **or a 404/gone error page**
-is ignored and re-fetched — so a cache poisoned before this guard existed,
-or one whose product was discontinued after caching, self-heals on the next
-fetch rather than re-serving junk until `--no-cache`.
+is ignored, **deleted**, and re-fetched — so a cache poisoned before this
+guard existed, or one whose product was discontinued after caching,
+self-heals on the next fetch rather than re-serving junk (and the dead file
+does not linger).
+
+To purge accumulated junk in bulk, `py -m pagefetch --clean-cache` sweeps
+the cache and removes every bot-blocked / 404 entry, keeping real content;
+`--dry-run` lists what it would remove without deleting. The "junk"
+definition (`is_cacheable_junk`) is shared by the read-time scrub and the
+sweep, so they never drift.
 
 The cache has **no TTL** — validity is decided by content, not age. Specs
 rarely change; discontinuation surfaces as a 404 (handled above); price
@@ -206,6 +215,9 @@ require headed Chrome and are validated manually.
   404/410/soft-404 page is terminal (not cached, no escalation); cached
   error bodies self-heal on read (handles products discontinued after
   caching). No TTL — validity is content-based, not time-based.
+- **v9** — cache cleanup: junk entries are deleted (not just ignored) when
+  scrubbed on read, so dead files do not linger; `--clean-cache` (with
+  `--dry-run`) sweeps the cache of bot/404 entries on demand.
 
 ### Sites tested
 

--- a/tools/pagefetch/__init__.py
+++ b/tools/pagefetch/__init__.py
@@ -17,13 +17,14 @@ This package has no dependency on any consuming project — it is built to
 be extracted into a standalone repository / git submodule.
 """
 
-from .cache import FileCache
+from .cache import CleanReport, FileCache
 from .detection import (
     BOT_DETECTION_PATTERNS,
     ERROR_PAGE_PATTERNS,
     MIN_REAL_CONTENT_BYTES,
     html_to_text,
     is_bot_blocked,
+    is_cacheable_junk,
     is_error_page,
     looks_like_real_content,
 )
@@ -42,12 +43,14 @@ __all__ = [
     "NetworkFetcher",
     "FakeFetcher",
     "FileCache",
+    "CleanReport",
     "FetchOptions",
     "FetchResult",
     "ContentMode",
     "Transport",
     "is_bot_blocked",
     "is_error_page",
+    "is_cacheable_junk",
     "looks_like_real_content",
     "html_to_text",
     "BOT_DETECTION_PATTERNS",

--- a/tools/pagefetch/__main__.py
+++ b/tools/pagefetch/__main__.py
@@ -17,16 +17,28 @@ Usage:
     py -m pagefetch --batch urls.txt --output-dir out/  # save to files
     py -m pagefetch url1 url2 url3                 # batch from args
     echo url | py -m pagefetch --batch -           # batch from stdin
+
+    py -m pagefetch --clean-cache                  # purge junk cache entries
+    py -m pagefetch --clean-cache --dry-run        # list junk, delete nothing
 """
 
 import sys
 from pathlib import Path
 
+from .detection import is_bot_blocked, is_error_page
 from .network import NetworkFetcher
 from .source import ContentMode, FetchOptions, Transport
 
 _VALUE_FLAGS = {"--wait", "--batch", "--output-dir"}
-_BARE_FLAGS = {"--html", "--no-cache", "--js", "--nodriver", "--uc"}
+_BARE_FLAGS = {
+    "--html",
+    "--no-cache",
+    "--js",
+    "--nodriver",
+    "--uc",
+    "--clean-cache",
+    "--dry-run",
+}
 
 
 def _parse_transport(argv: list[str]) -> Transport:
@@ -77,11 +89,41 @@ def _collect_urls(argv: list[str], batch_file: str | None) -> list[str]:
     return urls
 
 
+def _classify_junk(body: str) -> str | None:
+    """Reason a cached body is junk, or None to keep it. Order matters only
+    for the label — a page that is both is reported as bot-blocked."""
+    if is_bot_blocked(body):
+        return "bot-blocked"
+    if is_error_page(body):
+        return "404/error"
+    return None
+
+
+def _clean_cache(dry_run: bool) -> None:
+    """Sweep the cache of bot-blocked / 404 entries, printing a summary."""
+    from .cache import FileCache
+
+    report = FileCache().clean(_classify_junk, dry_run=dry_run)
+    verb = "would remove" if dry_run else "removed"
+    if report.removed:
+        print(f"{verb} {len(report.removed)} junk entries:", file=sys.stderr)
+        for path, reason in report.removed:
+            print(f"    {path.name}  ({reason})", file=sys.stderr)
+    print(
+        f"{verb} {len(report.removed)} junk entries, kept {report.kept}",
+        file=sys.stderr,
+    )
+
+
 def main() -> None:
     argv = sys.argv
     if len(argv) < 2:
         print(__doc__)
         sys.exit(1)
+
+    if "--clean-cache" in argv:
+        _clean_cache(dry_run="--dry-run" in argv)
+        return
 
     mode = ContentMode.HTML if "--html" in argv else ContentMode.TEXT
     transport = _parse_transport(argv)

--- a/tools/pagefetch/cache.py
+++ b/tools/pagefetch/cache.py
@@ -12,9 +12,21 @@ cached file.
 """
 
 import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from .source import ContentMode
+
+
+@dataclass
+class CleanReport:
+    """Outcome of a cache sweep. `removed` pairs each purged file with the
+    reason it was junk; `dry_run` means nothing was actually deleted."""
+
+    removed: list[tuple[Path, str]] = field(default_factory=list)
+    kept: int = 0
+    dry_run: bool = False
 
 
 class FileCache:
@@ -44,3 +56,48 @@ class FileCache:
     def write(self, url: str, mode: ContentMode, content: str) -> None:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.key(url, mode).write_text(content, encoding="utf-8")
+
+    def delete(self, url: str, mode: ContentMode) -> bool:
+        """Remove one cached entry. Returns True if a file was removed.
+        Idempotent — a missing entry is not an error."""
+        path = self.key(url, mode)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def entries(self) -> list[Path]:
+        """All cached page bodies (.txt / .html). Screenshots (.png) are not
+        page content and are excluded."""
+        if not self.cache_dir.exists():
+            return []
+        return sorted(
+            p
+            for p in self.cache_dir.iterdir()
+            if p.is_file() and p.suffix in (".txt", ".html")
+        )
+
+    def clean(
+        self, classify: Callable[[str], str | None], dry_run: bool = False
+    ) -> CleanReport:
+        """Sweep the cache, removing entries whose body is junk.
+
+        `classify(body)` returns a short reason string when the body is junk
+        (e.g. "404/error", "bot-blocked") or None to keep it. Real content is
+        kept. With `dry_run=True` nothing is deleted — the report lists what
+        would be removed.
+        """
+        report = CleanReport(dry_run=dry_run)
+        for path in self.entries():
+            try:
+                body = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            reason = classify(body)
+            if reason is None:
+                report.kept += 1
+                continue
+            report.removed.append((path, reason))
+            if not dry_run:
+                path.unlink()
+        return report

--- a/tools/pagefetch/detection.py
+++ b/tools/pagefetch/detection.py
@@ -105,6 +105,17 @@ def is_error_page(html: str) -> bool:
     return False
 
 
+def is_cacheable_junk(html: str) -> bool:
+    """Return True if a body should never be served from cache.
+
+    A bot/throttle page or a 404/gone error page is junk: it must not be
+    re-served, and it can be swept from the cache. This is the single
+    definition of "junk" shared by the read-time scrub and the cleanup
+    sweep — keep them in lock-step here, not duplicated at the call sites.
+    """
+    return is_bot_blocked(html) or is_error_page(html)
+
+
 def html_to_text(html: str) -> str:
     """Strip script/style/tags and collapse whitespace to plain text."""
     text = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)

--- a/tools/pagefetch/network.py
+++ b/tools/pagefetch/network.py
@@ -24,6 +24,7 @@ from .chrome import ChromeReaper
 from .detection import (
     html_to_text,
     is_bot_blocked,
+    is_cacheable_junk,
     is_error_page,
     looks_like_real_content,
 )
@@ -412,14 +413,18 @@ class NetworkFetcher(PageSource):
 
         if opts.use_cache:
             cached = self._cache.read(url, mode)
-            # Defend against a poisoned cache: a cached body that is
-            # recognizably a bot/throttle page OR a 404/gone error page is
-            # ignored and re-fetched, so a cache written before these guards
-            # (or before a product was discontinued) self-heals. Only the
-            # pattern checks apply here, not the size threshold — cached
-            # TEXT-mode content of a real page can legitimately be short.
-            if cached is not None and not is_bot_blocked(cached) and not is_error_page(cached):
-                return cached, "cache"
+            if cached is not None:
+                # Defend against a poisoned cache: a cached body that is a
+                # bot/throttle page OR a 404/gone error page is ignored,
+                # deleted, and re-fetched — so a cache written before these
+                # guards (or before a product was discontinued) self-heals
+                # and the dead file does not linger. Only the pattern checks
+                # apply here, not the size threshold — cached TEXT-mode
+                # content of a real page can legitimately be short.
+                if is_cacheable_junk(cached):
+                    self._cache.delete(url, mode)
+                else:
+                    return cached, "cache"
 
         content, tier = self._escalate(url, opts, sb_session)
 

--- a/tools/pagefetch/tests/test_cache.py
+++ b/tools/pagefetch/tests/test_cache.py
@@ -49,3 +49,54 @@ def test_modes_do_not_collide(cache: FileCache):
 def test_default_cache_dir_is_portable():
     # Must not be tied to any project layout — CWD-relative default.
     assert FileCache().cache_dir.name == "pagefetch"
+
+
+# --- delete / entries / clean ----------------------------------------
+
+
+def test_delete_removes_entry_and_is_idempotent(cache: FileCache):
+    url = "https://example.com"
+    cache.write(url, ContentMode.HTML, "<html>hi</html>")
+    assert cache.delete(url, ContentMode.HTML) is True
+    assert cache.read(url, ContentMode.HTML) is None
+    # Second delete is a no-op, not an error.
+    assert cache.delete(url, ContentMode.HTML) is False
+
+
+def test_entries_lists_bodies_excluding_screenshots(cache: FileCache):
+    cache.write("https://a.test", ContentMode.HTML, "a")
+    cache.write("https://b.test", ContentMode.TEXT, "b")
+    # A .png screenshot must not be treated as a page body.
+    cache.cache_dir.mkdir(parents=True, exist_ok=True)
+    cache.screenshot_path("https://a.test").write_bytes(b"\x89PNG")
+    suffixes = sorted(p.suffix for p in cache.entries())
+    assert suffixes == [".html", ".txt"]
+
+
+def test_entries_empty_when_no_cache_dir(tmp_path):
+    assert FileCache(cache_dir=tmp_path / "missing").entries() == []
+
+
+def test_clean_removes_only_junk_and_reports(cache: FileCache):
+    cache.write("https://good.test", ContentMode.HTML, "real lens specs")
+    cache.write("https://bad.test", ContentMode.HTML, "junk page")
+
+    def classify(body: str) -> str | None:
+        return "junk" if "junk" in body else None
+
+    report = cache.clean(classify)
+    assert report.kept == 1
+    assert len(report.removed) == 1
+    assert report.removed[0][1] == "junk"
+    assert cache.read("https://good.test", ContentMode.HTML) == "real lens specs"
+    assert cache.read("https://bad.test", ContentMode.HTML) is None
+
+
+def test_clean_dry_run_deletes_nothing(cache: FileCache):
+    cache.write("https://bad.test", ContentMode.HTML, "junk page")
+
+    report = cache.clean(lambda body: "junk" if "junk" in body else None, dry_run=True)
+    assert report.dry_run is True
+    assert len(report.removed) == 1
+    # File still present — dry run only reports.
+    assert cache.read("https://bad.test", ContentMode.HTML) == "junk page"

--- a/tools/pagefetch/tests/test_cli_clean.py
+++ b/tools/pagefetch/tests/test_cli_clean.py
@@ -1,0 +1,54 @@
+"""CLI --clean-cache tests.
+
+Drive `main()` with `--clean-cache` against a temp cache. `_clean_cache`
+uses the default CWD-relative FileCache, so the test chdirs into tmp_path
+and seeds `.cache/pagefetch` there.
+"""
+
+import os
+
+from pagefetch import ContentMode, FileCache
+from pagefetch.__main__ import _classify_junk, main
+
+
+def _seed_default_cache(tmp_path):
+    """Write one good + two junk entries into the CWD-default cache dir."""
+    cache = FileCache(cache_dir=tmp_path / ".cache" / "pagefetch")
+    cache.write("https://good.test", ContentMode.HTML, "real lens specs here")
+    cache.write("https://gone.test", ContentMode.HTML, "<title>404 Not Found</title>")
+    cache.write("https://blocked.test", ContentMode.TEXT, "Too Many Requests")
+    return cache
+
+
+def test_classify_junk_labels():
+    assert _classify_junk("real content") is None
+    assert _classify_junk("Too Many Requests") == "bot-blocked"
+    assert _classify_junk("<title>404 Not Found</title>") == "404/error"
+
+
+def test_clean_cache_removes_only_junk(tmp_path, monkeypatch):
+    cache = _seed_default_cache(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["pagefetch", "--clean-cache"])
+
+    main()
+
+    assert cache.read("https://good.test", ContentMode.HTML) == "real lens specs here"
+    assert cache.read("https://gone.test", ContentMode.HTML) is None
+    assert cache.read("https://blocked.test", ContentMode.TEXT) is None
+
+
+def test_clean_cache_dry_run_keeps_everything(tmp_path, monkeypatch, capsys):
+    cache = _seed_default_cache(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["pagefetch", "--clean-cache", "--dry-run"])
+
+    main()
+
+    # Nothing deleted.
+    assert cache.read("https://gone.test", ContentMode.HTML) is not None
+    assert cache.read("https://blocked.test", ContentMode.TEXT) is not None
+    # Reports what it would do.
+    err = capsys.readouterr().err
+    assert "would remove 2 junk entries" in err
+    assert "kept 1" in err

--- a/tools/pagefetch/tests/test_detection.py
+++ b/tools/pagefetch/tests/test_detection.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from pagefetch import is_bot_blocked, is_error_page, looks_like_real_content
+from pagefetch import (
+    is_bot_blocked,
+    is_cacheable_junk,
+    is_error_page,
+    looks_like_real_content,
+)
 from pagefetch.detection import (
     BOT_DETECTION_PATTERNS,
     ERROR_PAGE_PATTERNS,
@@ -134,3 +139,18 @@ def test_error_page_even_when_large_is_not_real_content():
     assert len(soft_404) >= MIN_REAL_CONTENT_BYTES
     assert is_error_page(soft_404) is True
     assert looks_like_real_content(soft_404) is False
+
+
+# --- is_cacheable_junk -----------------------------------------------
+
+
+def test_real_page_is_not_cacheable_junk():
+    assert is_cacheable_junk(BIG_REAL_PAGE) is False
+
+
+def test_bot_page_is_cacheable_junk():
+    assert is_cacheable_junk("<body>Too Many Requests</body>") is True
+
+
+def test_error_page_is_cacheable_junk():
+    assert is_cacheable_junk("<title>404 Not Found</title>") is True

--- a/tools/pagefetch/tests/test_network_escalation.py
+++ b/tools/pagefetch/tests/test_network_escalation.py
@@ -179,3 +179,13 @@ def test_cached_error_page_self_heals(fetcher, monkeypatch, cache):
     result = fetcher.fetch("https://x.test", FetchOptions(use_cache=True))
     assert calls == ["urllib"]
     assert result.content == "back online"
+
+
+def test_scrubbed_junk_cache_file_is_deleted(fetcher, monkeypatch, cache):
+    # On read, a junk cache entry is not just ignored — the dead file is
+    # removed so it does not linger. Here the re-fetch also fails (404),
+    # so nothing is re-written and the entry stays gone.
+    cache.write("https://x.test", ContentMode.TEXT, "Too Many Requests")
+    _stub_tiers(fetcher, monkeypatch, urllib_result=_ERROR_PAGE)
+    fetcher.fetch("https://x.test", FetchOptions(use_cache=True))
+    assert cache.read("https://x.test", ContentMode.TEXT) is None


### PR DESCRIPTION
Handles the "dead 404 cache entry lingers" problem and adds an on-demand
cache cleanup command.

> **Stacked on #920** (base branch = `fix/pagefetch-cache-non200-404`).
> Reuses the `is_error_page` / read-scrub logic that #920 introduces. Merge
> #920 first; this PR's base auto-retargets to `main` once #920 lands.

## The problem

Traced from a question about persistent 404s: when the read-time scrub
(from #919/#920) ignored a bot/404 cache entry, the dead file was **left on
disk** — re-read and re-scrubbed on every fetch, never cleaned. No way to
bulk-purge accumulated junk either.

## Fix

**Passive (on read):** when the scrub ignores a junk entry, it now
`delete()`s the file. Self-maintaining; the dead file no longer lingers.

**Active (CLI):** `py -m pagefetch --clean-cache` sweeps the cache and
removes every bot-blocked / 404 entry, keeping real content. `--dry-run`
lists what it would remove without deleting:

```
py -m pagefetch --clean-cache --dry-run
  would remove 2 junk entries:
    094a25f7c032f0ec.html  (404/error)
    2d99d1546644b520.txt   (bot-blocked)
  would remove 2 junk entries, kept 1
```

## Design

- `detection.is_cacheable_junk(html)` — the **single** definition of junk
  (bot-blocked OR 404/error), shared by the read-scrub and the sweep so
  they can't drift.
- `FileCache.delete / entries / clean(classify, dry_run)` + `CleanReport` —
  filesystem ops stay in `cache.py` (no detection dependency); the sweep
  takes a *classifier* so the CLI can label each removal. `entries()`
  excludes `.png` screenshots (not page bodies).
- CLI `--clean-cache [--dry-run]`, prints a removed/kept summary to stderr.

## Tests

+12: delete idempotency, `entries` excludes screenshots, `clean`
keeps-good/removes-junk/dry-run, `is_cacheable_junk`, scrub-deletes-file on
read, and CLI clean + dry-run (new `test_cli_clean.py`). `pagefetch` suite
**83 passed**; full `tools` suite **255 passed**. Verified end-to-end
against a real temp cache. README (v9), PLAYBOOK, CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)