### PR TITLE
docs: require --cache-dir for bare pagefetch CLI fetches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ npm run validate     # lint + format + check + test + build — full CI suite
 ### 1.4 Web fetching
 
 - Use `py -m pagefetch <url>` (run from `tools/`) for all web page fetching — never WebFetch or Fetch tools
+- For bare `py -m pagefetch` fetches in this project, ALWAYS pass `--cache-dir .cache/fetch` (resolved from repo root) so the fetch shares the one project cache the brand tools use — never the package's CWD-relative default (which would spawn `tools/.cache/pagefetch`). Brand tools handle this automatically; only the bare CLI needs the flag.
 - WebFetch/Fetch truncates large pages through a small model, silently losing data
 - `pagefetch` auto-escalates: urllib (~1s) → Playwright (~5-9s) → Nodriver (~6-8s) → SeleniumBase UC (~18-24s)
 - Flags: `--html` (raw HTML), `--js` (force Playwright), `--nodriver` (force headed Chrome), `--uc` (force UC), `--batch urls.txt` (persistent browser session), `--no-cache` (bypass cache), `--clean-cache` (sweep bot/404 junk from the cache; add `--dry-run` to preview)

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -190,25 +190,23 @@ genres (once genre formulas are implemented).
 **Fetch a web page (four-tier auto-escalation):**
 
 Run from the `tools/` directory so `python -m pagefetch` resolves the package.
-Set `PAGEFETCH_CACHE_DIR` so the bare CLI shares the one project cache
-(`.cache/fetch`) the brand tools use — otherwise the CLI's default creates a
-separate `tools/.cache/pagefetch`. The brand tools set this automatically (on
-`import brandkit`); for the bare CLI, export it:
+For bare CLI fetches, pass `--cache-dir ../.cache/fetch` so the fetch shares the
+one project cache the brand tools use — otherwise the CLI's default creates a
+separate `tools/.cache/pagefetch`. (Brand tools set the cache dir automatically;
+only the bare CLI needs the flag. `PAGEFETCH_CACHE_DIR` also works if you prefer
+an env var, but the flag is simpler for one-off fetches.)
 
 ```bash
-export PAGEFETCH_CACHE_DIR="$(git rev-parse --show-toplevel)/.cache/fetch"
-
+py -m pagefetch <url> --cache-dir ../.cache/fetch   # share the project cache
 py -m pagefetch <url>              # auto mode: urllib → Playwright → Nodriver → UC
 py -m pagefetch <url> --html       # raw HTML output
 py -m pagefetch <url> --js         # force Playwright (JS-rendered pages)
 py -m pagefetch <url> --nodriver   # force Nodriver (headed Chrome, bot bypass)
 py -m pagefetch <url> --uc         # force SeleniumBase UC (headless fallback)
 py -m pagefetch <url> --no-cache   # bypass cache, fetch fresh
-py -m pagefetch <url> --cache-dir DIR   # use a specific cache dir (overrides the env var)
 py -m pagefetch --batch urls.txt --nodriver --output-dir out/  # batch mode
-py -m pagefetch --clean-cache      # purge bot/404 junk entries from the cache
-py -m pagefetch --clean-cache --dry-run   # list junk entries, delete nothing
-py -m pagefetch --clean-cache --cache-dir DIR   # sweep a specific cache dir
+py -m pagefetch --clean-cache --cache-dir ../.cache/fetch          # purge bot/404 junk
+py -m pagefetch --clean-cache --dry-run --cache-dir ../.cache/fetch   # preview only
 ```
 
 (On Windows PowerShell: `$env:PAGEFETCH_CACHE_DIR = "$(git rev-parse --show-toplevel)/.cache/fetch"`.)


### PR DESCRIPTION
Guarantees bare-CLI fetches land in the project cache (`ROOT/.cache/fetch`)
rather than the package's CWD-relative default — **without adding any code**.

## What

- **CLAUDE.md rule:** always pass `--cache-dir` on bare `py -m pagefetch`
  fetches in this project, so the fetch shares the one project cache. Since
  bare fetches in this repo are agent-run during research, a CLAUDE.md
  instruction is the right enforcement point.
- **PLAYBOOK 2.7:** examples now lead with `--cache-dir ../.cache/fetch`
  (resolves to the repo cache when run from `tools/`, verified). Replaces the
  per-shell `PAGEFETCH_CACHE_DIR` export guidance, which was fiddlier; the env
  var still works but the flag is simpler for one-off fetches.

## Why

`--cache-dir` already exists (#927). The remaining gap was that the bare CLI
only landed in the project cache if you remembered to export the env var.
Rather than add a wrapper file or a machine-env script, this makes "use the
flag" a documented rule — no new code, no new dependency, no per-shell setup.
Brand tools are unaffected (they set the cache dir automatically).

Docs-only (CLAUDE.md + PLAYBOOK). No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)