### PR TITLE
docs: add memory-pointer refresh to wrap-up checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,13 +335,14 @@ execution prevents missed steps.
 [ ] 2. Close completed issues (verify auto-close worked)
 [ ] 3. Update epic checklists if relevant
 [ ] 4. Dev journal entry (### heading, --- separator, PRs, issues, key changes, key decisions with ADR refs)
-[ ] 5. ADRs — record any architectural decisions in docs/decisions/. Check: were any new directories created or content moved between documents? Each one needs an ADR.
-[ ] 6. CLAUDE.md — first list every new file, directory, and data field created this session. Then list each new convention/rule. Evaluate each item individually: does it belong in CLAUDE.md? Name the section. Do not batch-dismiss.
-[ ] 7. README.md — for each new command, dependency, or structural change, is it reflected? Name the section.
-[ ] 8. ONBOARDING.md — for each new tool, prerequisite, or setup step, is it documented? Name the section.
-[ ] 9. PLAYBOOK.md — first list every new command and script introduced this session. Then check: is each one documented? Name the section. Do not batch-dismiss.
-[ ] 10. Submodules — check if upstream needs update
-[ ] 11. Flag conventions for solid-ai-templates upstream — list each new convention/decision by name and evaluate individually. No blanket "nothing reusable." For each: state project-specific or reusable; if reusable, name the upstream template file and create an issue
-[ ] 12. Review sources — list every new external link used this session for tech specs, optical specs, or lab/field reviews. For each: is it already in `src/data/reviews.ts` or `docs/bookmarks.md`? If not, bookmark it and evaluate whether it should be added as a review source.
-[ ] 13. Summarize what was done and what's next
+[ ] 5. Memory pointer — rewrite the `session_next_theme` memory file (and its MEMORY.md index line) to the current state: session number, what shipped, and the concrete next priority. This is the agent's only cross-session "where we left off" note and is NOT synced from git — if skipped it silently goes stale.
+[ ] 6. ADRs — record any architectural decisions in docs/decisions/. Check: were any new directories created or content moved between documents? Each one needs an ADR.
+[ ] 7. CLAUDE.md — first list every new file, directory, and data field created this session. Then list each new convention/rule. Evaluate each item individually: does it belong in CLAUDE.md? Name the section. Do not batch-dismiss.
+[ ] 8. README.md — for each new command, dependency, or structural change, is it reflected? Name the section.
+[ ] 9. ONBOARDING.md — for each new tool, prerequisite, or setup step, is it documented? Name the section.
+[ ] 10. PLAYBOOK.md — first list every new command and script introduced this session. Then check: is each one documented? Name the section. Do not batch-dismiss.
+[ ] 11. Submodules — check if upstream needs update
+[ ] 12. Flag conventions for solid-ai-templates upstream — list each new convention/decision by name and evaluate individually. No blanket "nothing reusable." For each: state project-specific or reusable; if reusable, name the upstream template file and create an issue
+[ ] 13. Review sources — list every new external link used this session for tech specs, optical specs, or lab/field reviews. For each: is it already in `src/data/reviews.ts` or `docs/bookmarks.md`? If not, bookmark it and evaluate whether it should be added as a review source.
+[ ] 14. Summarize what was done and what's next
 ```

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -3444,3 +3444,45 @@ tasks), solid-ai-templates#342 (upstream — ASCII diagrams in ADRs).
   downstream can be tuned without it. Then #934 (profiles), #935 (pipeline).
 - Backlog: #930 (Samyang dead Image: links), 34 optical-specs folders with no
   chart image (need sourcing under #790).
+
+---
+
+### Session 95 — Memory Pointer Fix and Backlog Triage Decision
+
+Theme started as a status check; turned into two pieces of process work. No
+code, no data changes. One PR.
+
+PRs: #941 (open — wrap-up checklist memory-pointer step). Issues: none
+created or closed.
+
+#### Key changes
+
+- **Stale memory pointer.** The `session_next_theme` agent-memory file had
+  drifted from session 88 to 94 — six sessions stale. Root cause: it lives
+  outside the repo (`~/.claude/.../memory/`) and is not synced from git, and
+  no wrap-up step required refreshing it, so it silently froze while the
+  dev journal stayed current. Rewrote it to current state (v0.7.0 shipped,
+  MTF digitizer ADR-038 in progress, next = epic #932/#933) and fixed its
+  MEMORY.md index line.
+- **#941 — wrap-up checklist gains a memory step.** Added step 5 (memory
+  pointer refresh) to CLAUDE.md 6.3, next to the dev-journal step, with text
+  naming the failure mode (not git-synced -> goes stale). Renumbered 6-14.
+
+#### Key decisions
+
+- **Backlog triage: deferred, but the model is settled.** Discussed grooming
+  the 203-open backlog (147 are P3/P4). Rejected a multi-stage funnel as
+  YAGNI — the pile is self-generated deferred work, not unvetted intake, so
+  the need is one honest "parked" boundary, not an intake pipeline. Agreed
+  destination: a new **`Funnel` milestone holding parked issues, kept open**
+  (live list = `is:open -milestone:Funnel`), selected via an approved
+  shortlist. User deferred execution to a later session — nothing was
+  created or moved. Candidate clusters identified for next time: premature
+  per-brand MTF digitization (#791-814, blocked on #932/#933), add-missing-
+  lenses epic #820, score-all epic #655, dormant wiki/growth/spike groups.
+
+#### Next
+
+- Backlog triage execution when ready (decisions above are locked).
+- MTF digitizer epic #932 unchanged: start #933 (reference set), then
+  #934, #935.


### PR DESCRIPTION
## What

Adds a new **step 5 — Memory pointer** to the end-of-session wrap-up checklist in `CLAUDE.md` §6.3, placed next to the dev-journal step. Renumbers the remaining items (6–14).

## Why

The `session_next_theme` memory file is the agent's only cross-session "where we left off" note, but unlike the dev journal it is **not** part of the repo and **not** synced from git. With no checklist step requiring a refresh, it silently drifted from session 88 to session 94 — six sessions stale — while every other wrap-up doc (journal, CLAUDE.md, PLAYBOOK) stayed current.

Making the refresh an explicit, enumerated step (and naming the failure mode in the step text) closes the gap.

## Acceptance criteria

- [x] New step 5 added next to the dev-journal step
- [x] Remaining checklist items renumbered 6–14
- [x] Step text names why it matters (not git-synced → goes stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)