### PR TITLE
fix(pagefetch): tighten Cloudflare bot pattern to fix DPReview false positive

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "Wuseria CodeQL config"
+
+# Captured third-party HTML used as offline parser test fixtures is not our
+# code. CodeQL otherwise reports false-positive alerts on minified JS embedded
+# in the saved pages (e.g. js/useless-regexp-character-escape on DPReview's
+# analytics blob — see PR #945, issue #870).
+paths-ignore:
+  - "tools/**/tests/fixtures/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
+          config-file: ./.github/codeql-config.yml
 
       - uses: github/codeql-action/analyze@v4

--- a/tools/pagefetch/detection.py
+++ b/tools/pagefetch/detection.py
@@ -13,7 +13,11 @@ import re
 BOT_DETECTION_PATTERNS = [
     r"<title>403\b",
     r"<title>Access Denied",
-    r"Checking your browser",
+    # Cloudflare interstitial. Anchored to the canonical CF phrasing
+    # ("Checking your browser before accessing …") so the substring does not
+    # false-match on ad-blocker help text like "checking your browser
+    # extensions and settings" embedded in real content pages (#870).
+    r"Checking your browser\b[^.]{0,40}\bbefore\b",
     r"Checking the site connection security",
     r"Enable JavaScript and cookies to continue",
     r"Attention Required.*Cloudflare",

--- a/tools/pagefetch/tests/fixtures/dpreview_specifications.html
+++ b/tools/pagefetch/tests/fixtures/dpreview_specifications.html
@@ -1,0 +1,1576 @@
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+        <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GBDVGN57Q7"></script>
+    <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() { dataLayer.push(arguments); }
+            gtag('js', new Date());
+            gtag('config', 'G-GBDVGN57Q7', {
+                'logged_in': 'No',
+                'light_theme': 'Yes'
+            });
+    </script>
+    <!-- Google Tag Manager -->
+    <script>
+            (function (w, d, s, l, i) {
+                w[l] = w[l] || []; w[l].push({
+                    'gtm.start':
+                        new Date().getTime(), event: 'gtm.js'
+                }); var f = d.getElementsByTagName(s)[0],
+                    j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+            })(window, document, 'script', 'dataLayer', 'GTM-WQWG8FL');
+    </script>
+    <!-- End Google Tag Manager -->
+
+        <script src="https://experiments.parsely.com/vip-experiments.js?apiKey=dpreview.com"></script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <title>Nikon Z6III Specs: DPReview | Photography News, Gear Reviews &amp; Community</title>
+
+        <meta name="description" content="Expert news, reviews and videos of the latest digital cameras, lenses, accessories, and phones. Get answers to your questions in our photography forums.">
+
+        <link rel="alternate" media="only screen and (max-width: 640px)" href="https://m.dpreview.com/products/nikon/slrs/nikon_z6iii/specification">
+
+    <link rel="stylesheet" type="text/css" href="https://2.img-dpreview.com/resources/styles/fonts/OpenSans.min.css?v=5794">
+    <link rel="stylesheet" type="text/css" href="https://2.img-dpreview.com/resources/styles/fonts/MaterialIcons.min.css?v=5794">
+
+    
+    <style type="text/css">
+        html, body { background-color: #f1f1f1; }
+    </style>
+
+    <link rel="stylesheet" type="text/css" href="https://1.img-dpreview.com/resources/styles/Common.min.css?v=5794">
+    <link rel="stylesheet" type="text/css" href="https://4.img-dpreview.com/resources/styles/Sidebar.min.css?v=5794">
+
+    <!--[if lt IE 9]><script type="text/javascript" language="javascript" src="https://1.img-dpreview.com/resources/scripts/libraries/jquery-1.12.4.min.js?v=5794"></script><![endif]--><!--[if gte IE 9]><!--><script type="text/javascript" language="javascript" src="https://2.img-dpreview.com/resources/scripts/libraries/jquery.min.js?v=5794"></script><!--<![endif]-->
+    <script type="text/javascript" language="javascript" src="https://1.img-dpreview.com/resources/scripts/libraries/jquery-ui.min.js?v=5794"></script><script type="text/javascript" language="javascript" src="https://1.img-dpreview.com/resources/scripts/libraries/jquery-ui.touch-punch.min.js?v=5794"></script>
+    <link rel="stylesheet" type="text/css" href="https://3.img-dpreview.com/resources/scripts/libraries/material-components-web/material-components-web.min.css?v=5794">
+
+    <script type="text/javascript">var GlobalSettings = {"isLive":true,"readOnlyMode":false,"mainHostName":"www.dpreview.com","enableProtocolRequire":true,"assetsHostName":["1.img-dpreview.com","2.img-dpreview.com","3.img-dpreview.com","4.img-dpreview.com"],"assetsVersion":5794,"location":"US","mobile":false,"loginUrl":"https://signin.dpreview.com/login","registerUrl":"https://signin.dpreview.com/signup","loginClientID":"3lr6v0p5ij9ijctbt4io7o7od5","isSanctioned":false,"surveyEnabled":false,"impressionTrackingEnabled":false,"cookieDomain":".dpreview.com","loginUnavailableUrl":"https://www.dpreview.com/login-unavailable"}; document.domain = "dpreview.com";</script>
+
+<script type="text/javascript" language="javascript" src="https://4.img-dpreview.com/resources/scripts/min/Common.js?v=5794"></script>
+
+    
+    <script type="text/javascript">
+        (function(c, l, a, r, i, t, y)
+        {
+            c[a] = c[a] || function() { (c[a].q = c[a].q || []).push(arguments) };
+            t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+        })(window, document, "clarity", "script", "jf8hmki39d");
+    </script>
+    <meta name="p:domain_verify" content="2837f90df83a46e8fb45fb264912b6fc" />
+<script type="text/javascript">!(function (o, _name) { o[_name] = o[_name] || function $() { ($.q = $.q || []).push(arguments) }, o[_name].v = o[_name].v || 2; !(function (o, t, e, n, c, a) { function f(n, c) { (n = (function (t, e) { try { if (e = (t = o.localStorage).getItem("_aQS02NDQwNEFCMTg2NjA3RUM0NkE5NUVDOUQtMg")) return JSON.parse(e).lgk || []; if ((t.getItem(decodeURI(decodeURI('%76%25%334%61c1%25%365%69Z%72%2530'))) || "").split(",")[4] > 0) return [[_name + "-engaged", "true"]] } catch (n) { } })()) && typeof n.forEach === e && (c = o[t].pubads()) && n.forEach((function (o) { o && o[0] && c.setTargeting(o[0], o[1] || "") })) } try { (a = o[t] = o[t] || {}).cmd = a.cmd || [], typeof a.pubads === e ? f() : typeof a.cmd.unshift === e ? a.cmd.unshift(f) : a.cmd.push(f) } catch (i) { } })(window, "googletag", "function");; })(window, decodeURI(decodeURI('a%64%25%36d%69%25%37%32%2561l'))); !(function (n, o, e, t, c, i, a, r, u, f, d, s, m, $, h, l, p, v, R, _, E) { function S(e, i) { navigator.onLine && p && (p = !1, (i = (function (n, o, e) { if (!m) return !1; for (o = (n = m.getEntriesByType("resource")).length; e = n[--o];)if (!e.deliveryType && e.transferSize > 300 && e.fetchStart > $) return !0; return !1 })()) || (E = 8), !v && l && (E = 16), !v && !i || (function (e, i, a) { if (!/bot|spider|headlesschrome|java\//i.test(navigator.userAgent || "") && (new (function () { e = (function h(e, t, r, n) { if (!e || (function e(r, n, i, o) { for (o = 0; r && o < r.length; o += 2)o > 0 && (r[o + 1] || []).unshift(i), i = (n = t[r[o]]) && n(e, r[o + 1] || []); return i })(e)) return r.apply(this, n || []) }([0, [[[1, [[[2, [[4, ["admbenefits"], 3, [""]]]]]]], [2, [[4, ["auth"], 3, [""]]]]]]], [function c(e, t) { for (var r = t[0] && t[0].length > 0, n = 0; r && n < t[0].length; n++)r = e(t[0][n]); return r }, function c(e, t) { for (var r = t[0] && t[0].length > 0, n = 0; r && n < t[0].length; n++)r = e(t[0][n]); return r }, function a(e, t) { return !e(t[0]) }, function u(e, t, r, n) { return r = t[0] || "", (n = t[1] || "") ? -1 !== r.indexOf(n) : !!r }, function f(e, t, r) { return (r = (document.cookie || "").match(new RegExp("(^|;\\s*)" + t[0] + "\\s*=\\s*([^;]+)"))) ? r[2] : void 0 }], function (d, c, e, f, i, m, y) { e = d.createElement("div"); e.innerHTML = "<div class=\"DCDOr\"><div class=\"eRIqgq a__s1p0xe8r-0\"><div class=\"ezkXGa a__s1p0xe8r-0\"><div class=\"eUoqVy\"><h3 class=\"kMGqeO\">Your Support Helps DPReview Thrive<\/h3><div class=\"eFEjHN\">We noticed you’re using a tool like an ad blocker or privacy extension. While it’s not disrupting how our site works for you, it does impact our ability to generate the revenue we rely on to bring you in-depth reviews, engaging content, and a vibrant community.\n\n<br><br><b>\nHow You Can Help:\n<\/b>\n\n<br>\n1. <b>Consider adding DPReview to your allowlist <\/b> to support our writers and the site’s continued operation. \n<br>\n2. <b>Prefer an ad-free experience? <\/b>Let us know—your feedback helps us explore options that work for everyone.\n\n<br><br><b>\nFAQs\n<\/b><br><br><b>I'm not using an ablocker. Why am I seeing this message?<\/b> <br> Other tools like VPNs, privacy extensions, or malware blockers can sometimes cause similar effects. This message appears to ask for your support in keeping our site sustainable.  <br> \n\n<\/b><br> <b>I'm happy to support DPReview but still seeing the message. What can I do?<\/b> <br>\n\nIt’s possible that more than one tool is active (e.g., multiple blockers or privacy settings). We recommend checking your browser extensions and settings.\n<br><br>\nWe value your time here and understand the importance of tools that protect your browsing experience. If you’d like to learn more about how ad revenue supports our work, feel free to reach out or explore our FAQs. Thank you for helping keep DPReview’s content accessible and thriving.<\/div><button data-azi-0 data-adm-url=\"https://my.%67%65%74admira%6c.com/instructions\" class=\"bxafsa a__s1p0xe8r-1\">Disable my adblocker<\/button><button data-azi-2 class=\"bJEbUM a__s1p0xe8r-1\">Continue without disabling<\/button><\/div><div class=\"jozuUb\"><img src=\"https://www.dpreview.com/files/p/articles/5901145460/DPR-logo-large-no-tagline.png\" class=\"hgqALM\"><\/img><\/div><\/div><\/div><div class=\"bxeFSq\"><span class=\"bRORkN\"><a href=\"https://%67%65tadm%69%72a%6c.typeform.com/to/s8M2nY5H\" target=\"_blank\" class=\"PiHDv\">Contact support<\/a><\/span><span class=\"bRORkN\">|<\/span><span class=\"bRORkN\"><a href=\"https://%67%65%74%61dmi%72%61%6c.com/pb/\" target=\"_blank\" class=\"PiHDv\">We're using <img src=\"https://pubgifs.com/412d3634343034414231383636303745433436413935454339442d32_logo.svg\" class=\"ggJJaU\"><\/img><\/a><\/span><\/div><\/div>"; function onClose() { e.remove() } f = ["click", function (e) { var t = e.currentTarget.getAttribute("data-adm-url"), r = e.currentTarget.parentElement, n = document.createElement("iframe"); n.src = t, n.style = "margin: 36px 0;outline: 0;border: 0;width: 100%;height: 400px;", r.replaceWith(n); var i = function (e) { var t = e.data, o = t.goBack, c = t.blockerDisabled; o ? (n.replaceWith(r), window.removeEventListener("message", i)) : c && window.location.reload() }; window.addEventListener("message", i) }, "click", onClose]; for (i = 0; i < f.length; i += 2) { (m = e.querySelector('[data-azi-' + i + ']')) && m.addEventListener(f[i], f[i + 1]) } y = d.createElement("style"); y[c](d.createTextNode(".DCDOr{all:initial;position:fixed;top:0;right:0;bottom:0;left:0;font-family:Arial;overflow:auto;background-color:rgba(255,255,255,1);z-index:2147483647;}.DCDOr .a__s1p0xe8r-0{width:100%;height:100%;margin:0 auto;}.DCDOr .a__s1p0xe8r-1{cursor:pointer;border:none;font-weight:700;}.eRIqgq{max-width:740px;position:relative;}.ezkXGa{box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-align-items:flex-start;-webkit-box-align:flex-start;-ms-flex-align:flex-start;align-items:flex-start;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;}.eUoqVy{display:inline-block;max-width:700px;width:100%;margin-bottom:48px;padding-bottom:48px;border-bottom:1px solid #121e401f;color:rgba(0,0,0,1);}.bxeFSq{position:fixed;bottom:0;height:40px;width:100%;text-align:center;line-height:40px;font-size:13px;color:rgba(0,0,0,1);background-color:rgba(24,33,57,0.05);}.jozuUb{display:block;}.hgqALM{max-width:150px;max-height:150px;}.ggJJaU{height:15px;vertical-align:middle;}.kMGqeO{box-sizing:border-box;text-align:left;margin:0 0 5px;font-size:24px;line-height:28px;font-weight:500;}.eFEjHN{box-sizing:border-box;text-align:left;margin:0 0 15px;font-size:14px;line-height:22px;}.bRORkN{display:inline-block;margin-right:5px;line-height:40px;}.PiHDv{-webkit-text-decoration:none;text-decoration:none;color:rgba(0,0,0,1);}.bxafsa{width:100%;height:33px;background-color:rgba(65,158,217,1);color:rgba(244,244,246,1);border-radius:3px;margin-bottom:24px;}.bJEbUM{background-color:rgba(255,255,255,1);color:rgba(65,158,217,1);}")); d.body[c](y); d.body[c](e); return { "candidates": [{ "batchID": "66cf5cc0476d2dd3cb1b410b", "candidateID": "66cf5cc0476d2dd3cb1b410a", "groups": ["purpose:failsafe"], "payload": { "name": "Failsafe" }, "payloadType": "template", "triggers": [{ "type": "adblockerDisabled" }], "tsUpdated": 1733173096.973 }] } }, [document, "appendChild"])) }), !d++)) { i = o.sessionStorage; try { a = JSON.parse(i[t(t(f))]).slice(-4) } catch (r) { a = [] } a.push([c(), { p: "" + o.location, r: "" + n.referrer, cs: e, t: 1, fc: E }]), i[t(t(f))] = JSON.stringify(a) } })()) } m = o.performance, l = o.fetch, p = !l, (function g(r, u, f, d, R) { function _(n) { R.removeChild(f), e(s), n && !1 === n.isTrusted || u >= 4 ? (setTimeout(S, v !== undefined || p ? 0 : Math.max(4e3 - (c() - h), Math.max(2e3 - ((m && m.now()) - $), 0))), p = !0) : g(u < 2 ? r : i, ++u) } f = n.createElement(a), d = n.getElementsByTagName(a)[0], R = d.parentNode, f.async = 1, f.src = r, 1 == u && l && (h = c(), l((function (e, t, c, i, a, r, u, f) { for (t = (e = n.getElementsByTagName("link")).length, i = (o.origin || "").length || 1; i && (c = e[--t]);)if (a = (c.href || "").substring(0, i), u = 0 === (c.type || "").indexOf("image/"), f = "icon" === c.rel || (c.rel || "").indexOf(" icon") >= 0, (u || f) && ("/" === a[0] || a === o.origin) && (r = c.href, u && f)) return c.href; return r || "/favicon.ico" })(), { mode: "no-cors", credentials: "omit", cache: "no-cache" }).then((function () { v = !0, S() }), (function (n) { v = !1 }))), f.addEventListener && (r === i && (s = setTimeout(_, 3e4)), f.addEventListener("error", _), f.addEventListener("load", (function () { o[t(t('%2561%25%36%34%6d%72%6cL%6f%2561d%2565%25%36%34'))] && e(s) }))), R.insertBefore(f, d) })("https://ubiquitoussea.com/assets/js/b459d7c4fb61d1d2/9b083f10b43bc7b57d90.min.js", 0), $ = m && m.now() })(document, window, clearTimeout, decodeURI, Date.now, "https://succeedscene.com/adverts_siteadvert.js", "script", 0, 0, '%2561%25%366%25%37%33%25%376is%25%369%25%37%34%73');</script>
+    <script>
+        !function() {
+            "use strict";
+            var e = window.location.search.substring(1).split("&");
+            const t = e => e.replace(/\s/g, ""),
+                o = e => new Promise((t => {
+                    if (!("msCrypto" in window) && "https:" === location.protocol && "crypto" in window && "TextEncoder" in window) {
+                        const o = (new TextEncoder).encode(e);
+                        crypto.subtle.digest("SHA-256", o).then((e => {
+                            const o = Array.from(new Uint8Array(e)).map((e => ("00" + e.toString(16)).slice(-2))).join("");
+                            t(o)
+                        }))
+                    } else t("")
+                }));
+            for (var n = 0; n < e.length; n++) {
+                var r = "adt_ei",
+                    i = decodeURIComponent(e[n]);
+                if (0 === i.indexOf(r)) {
+                    var a = i.split(r + "=")[1];
+                    if ((e => {
+                            const t = e.match(/((?=([a-zA-Z0-9._!#$%+^&*()[\]<>-]+))\2@[a-zA-Z0-9._-]+\.[a-zA-Z0-9._-]+)/gi);
+                            return t ? t[0] : ""
+                        })(t(a.toLowerCase()))) {
+                        o(a).then((t => {
+                            t.length && (localStorage.setItem(r, t), localStorage.setItem("adt_emsrc", "url"), e.splice(n, 1), history.replaceState(null, "", "?" + e.join("&")))
+                        }));
+                        break
+                    }
+                }
+            }
+        }();
+    </script>
+
+
+
+
+<link rel="preload" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js" as="script">
+<link rel="dns-prefetch" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js" />
+
+<script type="text/javascript">
+    
+    window.raptivetarget = {
+        id: "",
+        is_testing: "no",
+        is_home: "no",
+        is_sponsored: "no",
+        tags: "",
+        section: ""
+    }
+</script>
+
+<!-- AdThrive Head Tag Manual -->
+<script data-no-optimize="1" data-cfasync="false">
+    (function (w, d)
+    {
+        w.adthrive = w.adthrive || {};
+        w.adthrive.cmd = w.
+            adthrive.cmd || [];
+        w.adthrive.plugin = 'adthrive-ads-manual';
+        w.adthrive.host = 'ads.adthrive.com'; var s = d.createElement('script');
+        s.async = true;
+        s.referrerpolicy = 'no-referrer-when-downgrade';
+        s.src = 'https://' + w.adthrive.host + '/sites/65ea5069fa5c4c7032386304/ads.min.js?referrer=' + w.encodeURIComponent(w.location.href) + '&cb=' + (Math.floor(Math.random() * 100) + 1);
+        var n = d.getElementsByTagName('script')[0];
+        n.parentNode.insertBefore(s, n);
+    })(window, document);
+</script>
+<!-- End of AdThrive Head Tag -->
+<!-- Body Class Targetting -->
+<!-- No videos on 25th anniversary content -->
+<!-- Site-wrap testing -->
+
+        <meta name="apple-mobile-web-app-title" content="Digital Photography Review">
+    <meta name="application-name" content="Digital Photography Review">
+    <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml?v=2">
+    <meta name="theme-color" content="#ffffff">
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/resources/favicons/apple-touch-icon.png?v=2">
+    <link rel="icon" type="image/png" href="/resources/favicons/favicon-32x32.png?v=2" sizes="32x32">
+    <link rel="icon" type="image/png" href="/resources/favicons/favicon-16x16.png?v=2" sizes="16x16">
+    <link rel="manifest" href="/resources/favicons/manifest.json?v=2">
+    <link rel="mask-icon" href="/resources/favicons/safari-pinned-tab.svg?v=2" color="#5bbad5">
+    <link rel="shortcut icon" href="/resources/favicons/favicon.ico?v=2">
+
+    <script type="text/javascript">
+        if (window != top) { top.location = location; }
+    </script>
+
+    <link rel="alternate" type="application/rss+xml" title="News: Digital Photography Review (dpreview.com)" href="https://www.dpreview.com/feeds/news.xml">
+    <link rel="alternate" type="application/rss+xml" title="Reviews: Digital Photography Review (dpreview.com)" href="https://www.dpreview.com/feeds/reviews.xml">
+    <link rel="alternate" type="application/rss+xml" title="Latest cameras: Digital Photography Review (dpreview.com)" href="https://www.dpreview.com/feeds/latest.xml">
+
+
+
+    <link rel="stylesheet" type="text/css" href="https://1.img-dpreview.com/resources/styles/Extended.min.css?v=5794">
+    <link rel="stylesheet" type="text/css" href="https://3.img-dpreview.com/resources/styles/Product.min.css?v=5794">
+
+    <script type="text/javascript" language="javascript" src="https://2.img-dpreview.com/resources/scripts/min/Extended.js?v=5794"></script>
+    <script type="text/javascript" language="javascript" src="https://3.img-dpreview.com/resources/scripts/min/ProductPage.js?v=5794"></script>
+
+    <link rel="stylesheet" type="text/css" href="https://2.img-dpreview.com/resources/styles/ShortList.min.css?v=5794">
+
+<script type="text/javascript" language="javascript" src="https://4.img-dpreview.com/resources/scripts/libraries/persist.min.js?v=5794"></script>
+<script type="text/javascript" language="javascript" src="https://1.img-dpreview.com/resources/scripts/min/ShortList.js?v=5794"></script>
+
+<script type="text/javascript">
+    $(document).ready(function()
+    {
+        ShortList({"productCategories":[{"label":"cameras","id":"cameras"},{"label":"lenses","id":"lenses"},{"label":"mobile phones","id":"mobilephones"},{"label":"instant cameras","id":"instant-cameras"},{"label":"drones","id":"drones"},{"label":"printers","id":"printers"},{"label":"software","id":"software"},{"label":"tablets","id":"tablets"},{"label":"mobile applications","id":"mobileapps"},{"label":"tripods and supports","id":"tripods"},{"label":"gimbals","id":"gimbals"},{"label":"flashes and on-camera lights","id":"flashes-and-on-camera-lights"},{"label":"bags and cases","id":"bags-and-cases"},{"label":"batteries and power","id":"batteries-and-power"},{"label":"camera straps","id":"camera-straps"},{"label":"filters","id":"filters"},{"label":"memory cards and readers","id":"memory-cards-and-readers"},{"label":"storage","id":"storage"},{"label":"lens accessories","id":"lens-accessories"},{"label":"system accessories","id":"system-accessories"},{"label":"cleaning supplies","id":"cleaning-supplies"},{"label":"laptops","id":"laptops"},{"label":"TVs","id":"tvs"}]});
+    });
+</script>
+
+    <meta property="og:url" content="https://www.dpreview.com/products/nikon/slrs/nikon_z6iii">
+<meta property="og:title" content="Nikon Z6III: DPReview | Photography News, Gear Reviews &amp; Community">
+<meta property="og:image" content="https://www.dpreview.com/files/p/E~products/nikon_z6iii/shots/c9fd121242a7492b87620c587390e867.png">
+
+
+    <script type="text/javascript">
+        $(document).ready(function()
+        {
+            ProductSpecsController();
+        });
+    </script>
+
+    <script type="application/ld+json">{"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https://www.dpreview.com/products/","name":"Products"}},{"@type":"ListItem","position":2,"item":{"@id":"https://www.dpreview.com/products/cameras/all","name":"Cameras"}},{"@type":"ListItem","position":3,"item":{"@id":"https://www.dpreview.com/products/nikon/slrs/nikon_z6iii","name":"Nikon Z6III"}}]}</script>
+
+
+    
+
+
+
+<script type="text/javascript">
+    window.DprAmazonSubtag = {"sourceId":null,"sessionId":"58062a93-3907-4400-8ad2-c936ac85fc3e","clickHash":""};
+</script>
+
+    <script type="text/javascript">
+            AntiCSRFTokenManager.setToken("ILl5MPUCXsZaEKsP3St1O3TsM9AKBBV1DOoPnBn5ccM=");
+    </script>
+
+        <script id="mcjs">!function (c, h, i, m, p) { m = c.createElement(h), p = c.getElementsByTagName(h)[0], m.async = 1, m.src = i, p.parentNode.insertBefore(m, p) }(document, "script", "https://chimpstatic.com/mcjs-connected/js/users/6c818d5d6d006adf8eed5cf6b/d64642f930fb0b96d75ab39ca.js");</script>
+
+    
+
+</head>
+
+<body class="light noskimwords noTouch loggedOut">
+
+        <!-- Google Tag Manager (noscript) -->
+        <noscript>
+            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQWG8FL"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+        </noscript>
+        <!-- End Google Tag Manager (noscript) -->
+    
+
+
+
+    <div id="mainBody" class="mainBody">
+        
+        
+
+
+
+
+<div class="centerAdContainer">
+    <div id="adSlot_center_wrapper" class="ad-wrapper center"><div id="adSlot_center" class="ad center center"></div></div>
+</div>
+
+<div class="siteHeaderSocialContainer">
+    <div class="socialAndTheme">
+        <div class="social">
+            <a href="https://www.instagram.com/dpreview" class="instagram">Instagram</a>
+            <a href=https://www.tiktok.com/@dpreviewtv class="tiktok">TikTok</a>
+            <a href="https://www.youtube.com/user/dpreviewcom" class="youtube">YouTube</a>
+            <a href="https://www.twitter.com/dpreview" class="twitter">Twitter</a>
+            <a href="https://www.facebook.com/dpreview" class="facebook">Facebook</a>
+                <a href="https://newsletters.dpreview.com/subscribe" rel="nofollow" class="newsletter">Newsletter</a>
+            <a href="https://www.dpreview.com/feedback?category=content-suggestion&amp;url=https%3a%2f%2fwww.dpreview.com%2fproducts%2fnikon%2fslrs%2fnikon_z6iii%2fspecifications" rel="nofollow" class="tip">Submit a News Tip!</a>
+        </div>
+        <div class="theme" id="themeToggle">
+            Reading mode:
+            <span class="option light">Light</span>
+            <span class="option dark">Dark</span>
+        </div>
+        <script type="text/javascript">
+            document.addEventListener("DOMContentLoaded", function ()
+            {
+                var themeToggle = document.getElementById("themeToggle");
+                if (themeToggle)
+                {
+                    themeToggle.addEventListener("click", function (e)
+                    {
+                        if (e.target.classList.contains("option"))
+                        {
+                            var theme = e.target.textContent.trim();
+                            if (theme && typeof gtag === "function")
+                            {
+                                gtag('event', 'nav_theme_toggle_click ', {
+                                    'theme_selected': theme
+                                });
+                            }
+                        }
+                    });
+                }
+            });
+        </script>
+    </div>
+</div>
+
+<div class="siteHeaderContainer">
+    <div class="siteHeader">
+
+        <div class="logo">
+            <a href="https://www.dpreview.com"></a>
+        </div>
+
+        <div class="userTools">
+
+                <a href="https://signin.dpreview.com/login?client_id=3lr6v0p5ij9ijctbt4io7o7od5&amp;response_type=code&amp;scope=openid+aws.cognito.signin.user.admin&amp;redirect_uri=https%3a%2f%2fwww.dpreview.com%2fpost-login&amp;state=https%253a%252f%252fwww.dpreview.com%252fproducts%252fnikon%252fslrs%252fnikon_z6iii%252fspecifications" rel="nofollow">Login</a> |
+                <a href="https://signin.dpreview.com/signup?client_id=3lr6v0p5ij9ijctbt4io7o7od5&amp;response_type=code&amp;scope=email+openid+aws.cognito.signin.user.admin&amp;redirect_uri=https%3a%2f%2fwww.dpreview.com%2fpost-login&amp;state=https%253a%252f%252fwww.dpreview.com%252fproducts%252fnikon%252fslrs%252fnikon_z6iii%252fspecifications" rel="nofollow">Register</a>
+
+        </div>
+
+        <div class="searchContainer">
+            <div class="mainSiteSearch" id="mainSiteSearch">
+                <form method="get" action="https://www.dpreview.com/search">
+                    <input type="text" name="query" class="searchBox" placeholder="Search dpreview.com" autocomplete="off" spellcheck="true">
+                    <input type="submit" class="submitBtn" value="">
+                </form>
+                <script type="text/javascript">
+                    $(document).ready(function ()
+                    {
+                        MainSiteSearch();
+                    });
+                </script>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<div class="siteNav ">
+    <div class="mainMenu"><a href="https://www.dpreview.com" class="mainItem "><span class="label">News</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="https://www.dpreview.com/articles/9999142289/what-you-missed-in-the-dpreview-community-may-2026">What you missed in the DPReview community: May 2026</a></div><div class="menuItem"><a href="https://www.dpreview.com/news/0966220713/leica-xiaomi-interview-phone-photography-processing">Leica says it had &quot;serious discussions&quot; about how phone photos should look</a></div><div class="menuItem"><a href="https://www.dpreview.com/news/6833997475/leica-metal-gray-paint-new-finish-m11-p-d-lux-8-q3">Leica&#39;s giving some of its most popular cameras a fresh coat of paint</a></div><div class="menuItem"><a href="https://www.dpreview.com/articles/3189599253/a-passion-for-fashion-inside-one-photographer-s-surprisingly-versatile-kit">A passion for fashion: Inside one photographer&#39;s surprisingly versatile kit</a></div><div class="menuItem"><a href="https://www.dpreview.com/news/1539510330/xiaomi-17t-and-17t-pro-announcement">Xiaomi hopes Leica will breathe life into its latest smartphones</a></div><div class="menuItem"><a href="https://www.dpreview.com/news/1165259685/7artisans-135mm-f1p8-af-portrait-lens">Nikon shooters are getting a new $690 portrait monster</a></div><div class="menuItem"><a href="https://www.dpreview.com/news/4797770033/halide-mark-iii-announced">Halide Mark III: Redesigned camera, new looks, and surprise Raw file support</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/threads/what-are-your-favorite-weather-conditions-for-photography.4837268/">What are your favorite weather conditions for photography?</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/panasonic-dc-l10-comapct-camera-four-thirds-review">Panasonic L10 initial review: The compact that&#39;s dividing photographers</a></div><div class="menuItem"><a href="https://www.dpreview.com/samples/3580032357/xiaomi-17t-pro-sample-gallery">Xiaomi 17T Pro sample gallery: First photos from the upcoming phone</a></div><div class="menuItem"><a href="https://www.dpreview.com/samples/4620354788/sony-fe-100-400mm-f4p5-gm-oss-sample-gallery">Reaching far with Sony&#39;s 100-400mm F4.5 zoom lens</a></div><div class="menuItem"><a href="https://www.dpreview.com/articles/8383410380/blast-from-the-past-check-out-these-primordial-digital-cameras">Blast from the past: check out these primordial digital cameras</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/5352056455/panasonic-l10-dpreview-team-discussion">Is this the camera of our dreams?</a></div><div class="menuItem"><a href="https://www.dpreview.com/articles/3334381491/join-our-community-photo-chain-each-shot-inspires-the-next">Join our community photo chain: each shot inspires the next</a></div><div class="menuItem"><a href="https://www.dpreview.com/articles/7501109396/collaboration-might-be-the-creative-push-your-photography-needs">Collaboration might be the creative push your photography needs</a></div><div class="menuItem"><a href="/newsletter">Subscribe to the DPReview newsletter</a></div><div class="menuItem"><a href="/feedback?category=content">Submit a tip</a></div></div></div></div><a href="https://www.dpreview.com/reviews" class="mainItem "><span class="label">Reviews</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/reviews?category=cameras">Camera reviews</a></div><div class="menuItem"><a href="/reviews?category=lenses">Lens reviews</a></div><div class="menuItem"><a href="/reviews?category=mobilephones">Smartphone reviews</a></div><div class="menuItem"><a href="/reviews?category=system-accessories">Accessory reviews</a></div><div class="menuItem"><a href="/reviews?category=printers">Printer reviews</a></div><div class="menuItem"><a href="/reviews?category=software">Software reviews</a></div><div class="menuItem"><a href="/reviews?category=drones">Drone reviews</a></div><div class="menuItem"><a href="/reviews?category=laptops">Laptop reviews</a></div><div class="menuItem"><a href="/reviews?filter=videoonly">Video reviews</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/panasonic-dc-l10-comapct-camera-four-thirds-review">Panasonic Lumix DC-L10 preview</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/sony-a7r-vi-review">Sony a7R VI review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/nikon-zr-in-depth-review-compact-full-frame-video-camera-6k-60">Nikon ZR in-depth review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/ricoh-gr-iv-monochrome-review">Ricoh GR IV Monochrome review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/sony-a7-v-review">Sony a7 V review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/fujifilm-x-t30-iii-in-depth-review">Fujifilm X-T30 III review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/panasonic-lumix-dc-s1rii-review">Panasonic Lumix DC-S1RII review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/usb-4-thunderbolt-5-ssd-owc-sandisk-speeds-roundup">External SSDs for photographers tested</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/canon-eos-r6-iii-in-depth-review">Canon EOS R6 Mark III review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/panasonic-lumix-dc-s1ii-review">Panasonic Lumix DC-S1II review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/leica-q3-monochrom-review">Leica Q3 Monochrom review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/om-system-om-5-mark-ii-in-depth-review">OM System OM-5 II review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/leica-m-ev1">Leica M EV1 preview</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/ricoh-gr-iv-in-depth-review">Ricoh GR IV review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/hasselblad-x2d-ii-100c-in-depth-review">Hasselblad X2D II 100c review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/nikon-z5ii-review">Nikon Z5II review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/sony-dsc-rx1r-iii-review">Sony DSC-RX1R III review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/fujifilm-x-e5-review">Fujifilm X-E5 review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/fujifilm-x-half-retro-compact-camera-review">Fujifilm X half review</a></div><div class="menuItem"><a href="https://www.dpreview.com/reviews/canon-powershot-v1-review">Canon PowerShot V1 review</a></div><div class="menuItem"><a href="/reviews/">See all reviews &amp; previews</a></div><div class="menuItem"><a href="/sample-galleries">Review sample galleries</a></div><div class="menuItem"><a href="/reviews/image-comparison">Studio scene comparison tool</a></div><div class="menuItem"><a href="/reviews/studio-compare">Old studio comparison tool</a></div></div></div></div><a href="https://www.dpreview.com/features" class="mainItem "><span class="label">Articles</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="https://www.dpreview.com/features#photography">Portfolios and Photography News</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#camera-lens-features">Camera and Lens Features</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#accessory-reviews">Accessory Reviews</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#photography-techniques">Technique</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#video">Video</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#technology">Imaging Science and Technology</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#sample-galleries">Sample Galleries</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#interviews">Interviews</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#opinion">Opinion and Editorial</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#mobile">Mobile Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#software-and-printing">Software and Printing</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#show-reports">Show Reports</a></div><div class="menuItem"><a href="https://www.dpreview.com/features#book-reviews">Book Reviews</a></div></div></div></div><a href="https://www.dpreview.com/buying-guides" class="mainItem "><span class="label">Buying Guides</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/buying-guides">All Buying Guides</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-under-1000">Best cameras under $1000</a></div><div class="menuItem"><a href="/reviews/the-best-cameras-under-2000-in-2025">Best cameras under $2000</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-under-3000">Best cameras under $3000</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-high-end-cameras">Best high-end cameras</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-lenses-for-sony-mirrorless">Best lenses for Sony Mirrorless</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-lenses-for-fujifilm-mirrorless-cameras">Best lenses for Fujifilm Mirrorless</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-lenses-for-micro-four-thirds">Best lenses for Micro Four Thirds</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-compact-zoom-cameras">Best compact zoom cameras</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-fixed-prime-lens-cameras">Best fixed prime lens cameras</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-mirrorless-cameras">Best mirrorless cameras</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-instant-camera">Best instant cameras</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-video-cameras-for-photographers">Best video cameras for photographers</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-for-videographers">Best cameras for videographers</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-for-travel">Best cameras for travel</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-for-landscapes">Best cameras for landscapes</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-for-instagram">Best cameras for Instagram</a></div><div class="menuItem"><a href="/reviews/buying-guide-best-cameras-for-vlogging">Best cameras for vlogging</a></div><div class="menuItem"><a href="/articles/1328199596/buying-guide-what-to-know-before-buying-your-first-interchangeable-lens-digital-camera">How to buy your first digital camera</a></div><div class="menuItem"><a href="/articles/9162056837/buying-guide-what-you-need-to-know-before-buying-your-first-lens">How to choose your next lens</a></div><div class="menuItem"><a href="/articles/5481327930/buying-guide-beginners-guide-to-buying-a-camera-for-video">How to buy a camera for video</a></div><div class="menuItem"><a href="/articles/0591932989/buying-guide-a-photographers-guide-to-buying-a-smartphone">How to buy your next smartphone</a></div></div></div></div><a href="https://www.dpreview.com/products/compare/cameras" class="mainItem "><span class="label">Compare</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/products/compare/cameras">Camera Comparison Tool</a></div><div class="menuItem"><a href="/products/compare/side-by-side/nikon_z6iii-vs-canon_eosr6ii-vs-sony_a7iv">Nikon Z6III vs Canon EOS R6 II vs Sony a7 IV</a></div><div class="menuItem"><a href="/products/compare/side-by-side/canon_eosr5ii-vs-nikon_z8">Canon EOS R5 II vs Nikon Z8</a></div><div class="menuItem"><a href="/products/compare/side-by-side/canon_eosr1-vs-nikon_z9-vs-sony_a9iii">Canon EOS R1 vs Nikon Z9 vs Sony a9 III</a></div><div class="menuItem"><a href="/products/compare/side-by-side/sony_zve10ii-vs-fujifilm_xm5">Sony ZV-E10 II vs Fujifilm X-M5</a></div><div class="menuItem"><a href="/products/compare/side-by-side/canon_eosr8-vs-nikon_z5">Canon EOS R8 vs Nikon Z5</a></div><div class="menuItem"><a href="/products/compare/lenses">Lens Comparison Tool</a></div><div class="menuItem"><a href="/products/compare/side-by-side/sigma_24-70_2p8_dg_dn_ii-vs-sony_fe_24-70_2p8_gm_ii">Sony FE 24-70mm F2.8 GM II vs. Sigma 24-70mm F2.8 DG DN II | Art</a></div><div class="menuItem"><a href="/products/compare/side-by-side/fujifilm_xf_23_1p4_r_lm_wr-vs-sigma_23_1p4_dc_dn_c">Sigma 23mm F1.4 DC DN | C vs. Fujifilm XF 23mm F1.4 R LM WR</a></div><div class="menuItem"><a href="/reviews/image-comparison">Image comparison tool</a></div><div class="menuItem"><a href="/products/search/cameras#!">Camera feature search</a></div><div class="menuItem"><a href="/products/search/lenses#criterias=SpecsCoreParams&amp;paramSpecsCoreParamsLensType=&amp;paramSpecsCoreParamsSubcriteria=LensMount%2CLensType%2CAdditionalFeatures&amp;paramSpecsCoreParamsSearchType=Simple">Lens feature search</a></div><div class="menuItem"><a href="/products/timeline?year=2024&amp;brand=&amp;category=cameras">Camera Timeline</a></div><div class="menuItem"><a href="/products/timeline?year=2024&amp;brand=&amp;category=lenses">Lens timeline</a></div><div class="menuItem"><a href="/buying-guides">Buying Guides</a></div></div></div></div><a href="https://www.dpreview.com/sample-galleries" class="mainItem "><span class="label">Sample Images</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/sample-galleries?category=cameras">Camera sample images</a></div><div class="menuItem"><a href="/sample-galleries?category=lenses">Lens sample images</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/4139367840/xiaomi-17t-pro-sample-gallery">Xiaomi 17T Pro sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/6136202118/panasonic-dc-l10-sample-gallery">Panasonic DC-L10 sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/8728974224/sony-fe-100-400mm-f4p5-gm-oss-sample-images-raw">Sony FE 100-400mm F4.5 GM OSS sample images</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/5711210645/sony-a7r-vi-sample-gallery">Sony a7R VI sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/4096662706/viltrox-af-55mm-f1p8-evo-sample-gallery">Viltrox AF 55mm F1.8 Evo sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/1004652535/panasonic-lumix-s-40mm-f2-0-sample-gallery">Panasonic Lumix S 40mm F2.0 sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/2975004153/thypoch-voyager-24-50mm-f2p8-sample-gallery">Thypoch Voyager 24-50mm F2.8 sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/4772005133/viltrox-af-16mm-f1p8-l-sample-gallery">Viltrox AF 16mm F1.8 L sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/5653884153/tamron-35-100mm-f2p8-sample-gallery">Tamron 35-100mm F2.8 Di III VXD sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/8765823470/sigma-15mm-f1-4-dc-contemporary-sample-gallery">Sigma 15mm F1.4 DC Contemporary sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/2323925491/sigma-35mm-f1-4-dg-ii-sample-gallery">Sigma 35mm F1.4 DG II sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/4044106697/ricoh-gr-iv-monochrome-sample-gallery">Ricoh GR IV Monochrome sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/6823669941/google-pixel-10a-sample-gallery">Google Pixel 10a sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/6688472206/viltrox-35mm-f1p2-lab-sample-gallery">Viltrox 35mm F1.2 Lab sample gallery</a></div><div class="menuItem"><a href="https://www.dpreview.com/sample-galleries/7812474336/sony-a7-v-sample-gallery">Sony a7 V sample gallery</a></div><div class="menuItem"><a href="/sample-galleries">Browse all</a></div><div class="menuItem"><a href="/reviews/image-comparison">Studio scene comparison tool</a></div><div class="menuItem"><a href="/reviews/studio-compare">Old studio comparison tool</a></div></div></div></div><a href="https://www.dpreview.com/videos" class="mainItem "><span class="label">Videos</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="https://www.dpreview.com/videos">Browse all videos</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv">DPReview TV</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/gear-overviews">First looks</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/sample-reels">Sample reels</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/advice">Advice</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/features">Features</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/interviews">Interviews</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-live">DPReview Live</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/show-reports">Show reports</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/test-samples">Test samples</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/pix2015">PIX 2015</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13971">Why niche cameras are the future of photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13970">Sony a7 V Review: the do-it-all powerhouse</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/gear-overviews?play=13969">Testing the Sigma 35mm F1.4 on Old Compton Street London #cameras #streetphotography</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13968">Inside Japan’s Photo Culture: DPReview CP+ Trip, Zine Fair Finds &amp; Yodobashi Camera</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13967">The Photography of CP+ 2026</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13966">What&#39;s it like to attend CP+ 2026? Go inside the biggest camera event of the year with DPReview</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13965">DPReview Discussions: Live from CP+</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13961">Buying a Film Camera in Tokyo #cameras #film #japan</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13962">The Little Worlds of CP+</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13963">Going hands on with new lenses at CP+ #cameras #cameraequipment #lenses</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13964">DPR Team Photowalk in Yokohama</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13960">First visit to Yodobashi Camera in Tokyo #cameras #tokyo #travel</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13959">DPReview Discussions: the week of new, strange, and wonderful lenses</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/gear-overviews?play=13958">Shooting with the $9600 Leica lens made for the night</a></div><div class="menuItem"><a href="https://www.dpreview.com/videos/dpreview-tv?play=13957">Breaking Down the Ricoh GR IV Monochrome and Hands on with the Fujifilm Instax Mini Evo Cinema</a></div></div></div></div><a href="https://www.dpreview.com/products/cameras" class="mainItem "><span class="label">Cameras</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/products/cameras">Camera hub</a></div><div class="menuItem"><a href="/reviews?category=cameras">Camera reviews</a></div><div class="menuItem"><a href="/products/search/cameras">Camera feature search</a></div><div class="menuItem"><a href="/products/compare/cameras">Side-by-side camera comparison</a></div><div class="menuItem"><a href="/products/timeline?category=cameras">Camera timeline</a></div><div class="menuItem"><a href="/products/compacts/statistics">Popular compact cameras</a></div><div class="menuItem"><a href="/products/slrs/statistics">Popular interchangeable lens cameras</a></div><div class="menuItem"><a href="/articles/4416254604/camera-scores-ratings-explained">Camera Scores &amp; Ratings</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/agfa">Agfa</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/canon">Canon</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/casio">Casio</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/dji">DJI</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/dxo_labs">DxO Labs</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/fujifilm">Fujifilm</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/gopro">GoPro</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/hasselblad">Hasselblad</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/holga">Holga</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/kodak">Kodak</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/konicaminolta">Konica Minolta</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/leica">Leica</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/lytro">Lytro</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/nikon">Nikon</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/olympus">OM System / Olympus</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/panasonic">Panasonic</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/pentax">Pentax</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/pixii">Pixii</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/ricoh">Ricoh</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/samsung">Samsung</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/sealife">SeaLife</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/sigma">Sigma</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/sony">Sony</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/yi">YI</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/cameras/zeiss">Zeiss</a></div></div></div></div><a href="https://www.dpreview.com/products/lenses" class="mainItem "><span class="label">Lenses</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/products/lenses">Lens hub</a></div><div class="menuItem"><a href="/reviews?category=lenses">Lens reviews</a></div><div class="menuItem"><a href="/products/search/lenses">Lens feature search</a></div><div class="menuItem"><a href="/products/compare/lenses">Side-by-side lens comparison</a></div><div class="menuItem"><a href="/products/timeline?category=lenses">Lens timeline</a></div><div class="menuItem"><a href="/products/lenses/statistics">Popular lenses</a></div><div class="menuItem"><a href="/articles/9162056837/digital-camera-lens-buying-guide">Lens Buying Guide</a></div><div class="menuItem"><a href="/articles/3135549652/lens-reviews-explained">Lens Reviews Explained</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/sevenartisans">7Artisans</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/canon">Canon</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/fujifilm">Fujifilm</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/hartblei">Hartblei</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/hasselblad">Hasselblad</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/holga">Holga</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/irix">Irix</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/kamlan">Kamlan</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/kenko">Kenko</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/konicaminolta">Konica Minolta</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/venus">Laowa/Venus Optics</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/leica">Leica</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/lensbaby">Lensbaby</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/meike">Meike</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/nikon">Nikon</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/nisi">NiSi</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/olympus">OM System / Olympus</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/panasonic">Panasonic</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/pentax">Pentax</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/samsung">Samsung</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/samyang">Samyang/Rokinon</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/schneider">Schneider</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/sigma">Sigma</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/sirui">Sirui</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/sony">Sony</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/tamron">Tamron</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/thypoch">Thypoch</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/tokina">Tokina</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/viltrox">Viltrox</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/voigtlander">Voigtlander</a></div><div class="menuItem"><a href="https://www.dpreview.com/products/lenses/zeiss">Zeiss</a></div></div></div></div><a href="https://www.dpreview.com/forums" class="mainItem newMenu"><span class="label">Forums</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="https://www.dpreview.com/forums/1018">Open Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1000">News &amp; Rumors Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1002">Beginners Questions</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1005">Samples and Galleries</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1044">Challenge Discussions</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/4001">Camera, Lens and System Buying Advice</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/5001">Site Questions and Help</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1010">Canon PowerShot Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1060">Canon EOS M Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1070">Canon EOS R Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1031">Canon Rebel (EOS 100D-4000D) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1019">Canon EOS 7D / 10D - 90D Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1032">Canon EOS-1D / 5D / 6D Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1029">Canon SLR Lens Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1015">Casio Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1012">Fujifilm FinePix Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1020">Fujifilm X System / SLR Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1011">Kodak Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1026">Kodak SLR Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1024">Konica Minolta Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1038">Leica Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1071">L-mount (Panasonic/Sigma/Leica) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1007">Nikon Coolpix Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1058">Nikon 1 System Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1034">Nikon DX SLR (D40-D90, D3000-D7500) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1039">Nikon Pro DX SLR (D500, D300, D200, D100) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1021">Nikon FX SLR (DF, D1-D5, D600-D850) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1068">Nikon Z Mirrorless Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1030">Nikon SLR Lens Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1008">Olympus Compact Camera Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1022">Olympus SLR Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1041">Micro Four Thirds Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1033">Panasonic Compact Camera Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1028">Pentax Compact Camera Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1036">Pentax SLR Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1013">Ricoh Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1001">Samsung Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1027">Sigma Camera Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1009">Sony Cyber-shot Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1037">Sony Alpha SLR/SLT A-mount Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1042">Sony Alpha / NEX E-mount (APS-C) Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1064">Sony Alpha Full Frame E-mount Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1069">Sony Mirrorless Lens Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1500">VR / Action Cameras</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1023">Accessories Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1043">Third Party Lens Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1065">Adapted Lens Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1067">Medium Format Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1072">Film Photography Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1004">PC Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1017">Mac Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1003">Printers and Printing</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1006">Retouching</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1014">Pro Digital Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1025">Studio and Lighting Technique</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1045">Digital Video Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1047">Landscape and Travel Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1048">Portrait and People Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1049">Black and White Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1050">3D and Stereo Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1051">Nature and Wildlife Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1052">Documentary and Street Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1053">Sport and Action Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1054">Macro and Still Life Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1059">Astrophotography Talk Forum</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1055">General Photo Techniques</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1062">DIY and Photo Experiments</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1063">Underwater Photography</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1066">Drone Photography Talk Forum</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1061">Photographic Science and Technology</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1056">For Sale and Wanted</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/1046">Mobile Photography Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/2004">Android Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/2007">iOS Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/2010">Windows Phone Talk</a></div><div class="menuItem"><a href="https://www.dpreview.com/forums/2018">Other Mobile OS Talk</a></div><div class="menuItem"><a href="/search/forums">Search forums</a></div><div class="menuItem"><a href="/community-guidelines">Forum rules &amp; Community guidelines</a></div><div class="menuItem"><a href="/members/me/forums/threads">My threads</a></div></div></div></div><a href="https://www.dpreview.com/galleries" class="mainItem "><span class="label">Galleries</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/galleries">My gallery</a></div><div class="menuItem"><a href="/galleries/upload">Upload to my gallery</a></div><div class="menuItem"><a href="/galleries/tags">Gallery tags</a></div></div></div></div><a href="https://www.dpreview.com/challenges" class="mainItem "><span class="label">Challenges</span></a><div class="dropDownMenuContainer"><div class="dropDownMenu"><span class="dropdownMenuArrow"><span class="inner1"></span><span class="inner2"></span></span><div class="dropdownMenuContent"><div class="menuItem"><a href="/challenges">Challenges</a></div><div class="menuItem"><a href="/challenges/ChallengesAnnounced.aspx">Announced challenges</a></div><div class="menuItem"><a href="/challenges/ChallengesSubmission.aspx">Challenges open for submission</a></div><div class="menuItem"><a href="/challenges/ChallengesVoting.aspx">Challenges open for voting</a></div><div class="menuItem"><a href="/challenges/ChallengesFinished.aspx">Finished challenges</a></div></div></div></div></div>
+</div>
+
+
+
+
+<style>
+    div.siteAnnouncementContainer {
+        background-color: black;
+        padding: 6px;
+        max-width: 928px;
+        width: fit-content;
+        margin: auto;
+        box-shadow: 0 0 25px black;
+        border: 1px solid #444;
+        display: none;
+    }
+
+    div.siteAnnouncement {
+        background-color: #222;
+        max-width: 908px;
+        width: fit-content;
+        margin: auto;
+        font-family: Open Sans,Helvetica,Arial,sans-serif;
+        font-size: 12px;
+        padding: 2px 2px 2px 5px;
+        border: 1px solid #4bd;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        align-content: center;
+    }
+
+        div.siteAnnouncement .title {
+            display: inline;
+            color: #fc0;
+            font-size: 11px;
+            text-transform: uppercase;
+            margin-bottom: 3px;
+        }
+
+        div.siteAnnouncement .subtitle {
+            display: inline;
+            font-family: DIN,Helvetica,Arial,sans-serif;
+            font-size: 19px;
+            color: white;
+            font-weight: bold;
+            line-height: 1.1;
+        }
+
+        div.siteAnnouncement .content {
+            color: #ccc;
+        }
+        /*
+            div.siteAnnouncement .content a {
+                font-weight: bold;
+            }*/
+
+        div.siteAnnouncement a {
+            height: 47px;
+        }
+
+    div.siteAnnouncementImage {
+        padding: 0px 0px 0px 6px;
+        width: fit-content;
+        margin: auto;
+    }
+
+    body.light div.siteAnnouncement {
+        background-color: #eee;
+        border: 1px solid #4bd;
+    }
+
+        body.light div.siteAnnouncement .title {
+            color: #18b;
+            text-transform: uppercase;
+        }
+
+        body.light div.siteAnnouncement .subtitle {
+            font-family: DIN,Helvetica,Arial,sans-serif;
+            font-size: 19px;
+            color: #333;
+            font-weight: bold;
+            line-height: 1.1;
+        }
+
+        body.light div.siteAnnouncement .content {
+            color: #333
+        }
+
+    body.light div.siteAnnouncement2 {
+        background-color: #eee;
+        border: 1px solid #4bd;
+    }
+    }
+</style>
+<style>
+    div.siteAnnouncementContainer2 {
+        position: relative;
+        background-color: black;
+        padding: 6px;
+        max-width: 928px;
+        width: fit-content;
+        margin: auto;
+        box-shadow: 0 0 25px black;
+        border: 1px solid #444;
+        z-index: 2;
+    }
+
+    div.siteAnnouncement2 {
+        background-color: #222;
+        max-width: 950px;
+        width: fit-content;
+        margin: auto;
+        font-family: Open Sans,Helvetica,Arial,sans-serif;
+        font-size: 12px;
+        padding: 2px 2px 2px 5px;
+        border: 2px solid #269;
+        justify-content: center;
+        align-items: center;
+        align-content: center;
+        text-align: center;
+    }
+
+        div.siteAnnouncement2 .title {
+            display: inline;
+            color: #fc0;
+            font-size: 11px;
+            text-transform: uppercase;
+            margin-bottom: 3px;
+        }
+
+        div.siteAnnouncement2 .subtitle {
+            display: inline;
+            font-family: DIN,Helvetica,Arial,sans-serif;
+            font-size: 19px;
+            color: white;
+            font-weight: bold;
+            line-height: 1.1;
+        }
+
+        div.siteAnnouncement2 .content {
+            font-family: Open Sans,Helvetica,Arial,sans-serif;
+            font-size: 14px;
+            font-weight: 700;
+            line-height: 1.5;
+            color: #ccc;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: no-wrap;
+        }
+
+            div.siteAnnouncement2 .content span {
+                width: 100%;
+                white-space: nowrap;
+            }
+
+            div.siteAnnouncement2 .content a {
+                color: #269;
+            }
+
+    body.light div.siteAnnouncementContainer2 {
+        background-color: white;
+        box-shadow: 0 0 25px #cccccc;
+        border-color: #ddd;
+    }
+
+    body.light div.siteAnnouncement2 {
+        background-color: #eee;
+        border: 2px solid #269;
+    }
+
+        body.light div.siteAnnouncement2 .title {
+            color: #18b;
+            text-transform: uppercase;
+        }
+
+        body.light div.siteAnnouncement2 .subtitle {
+            font-family: DIN,Helvetica,Arial,sans-serif;
+            font-size: 19px;
+            color: #333;
+            font-weight: bold;
+            line-height: 1.1;
+        }
+
+        body.light div.siteAnnouncement2 .content {
+            color: #333
+        }
+
+
+    @media (max-width: 768px) {
+        div.siteAnnouncement2 .content {
+            font-size: 11px;
+            font-weight: 700;
+            flex-wrap: wrap;
+        }
+		
+		div.siteAnnouncement2 .content span {
+                width: 100%;
+                white-space: wrap;
+            }
+    }
+</style>
+<!--
+<div class="siteAnnouncementContainer2">
+    <div class="siteAnnouncement2"><div class="content"><span class="line">Server maintenance starts Wed, Dec 17 at 1am PST<BR>The main site will be down for one hour with forums remaining online.</div></div>
+</div>
+-->
+
+
+
+<script type="text/javascript" src="https://4.img-dpreview.com/nav/E15C053D702F31FF0244280CFC5F85ED/mainmenu-s.js"></script>
+
+        <div class="mainContentSidebarAndFooter">
+            
+
+            <div class="mainContentAndSidebar">
+                <div id="mainContent" class="mainContent">
+                    
+
+
+
+
+
+
+<div class="headerContainer">
+    
+<div class="breadcrumbs"><a class="item" href="https://www.dpreview.com/products/">Brand index</a><span class="separator"></span><a class="item" href="https://www.dpreview.com/products/nikon">Nikon</a><span class="separator"></span><a class="item" href="https://www.dpreview.com/products/slrs/nikon">Nikon Interchangeable Lens Cameras</a><span class="separator"></span><span class="item"></span></div>
+<h1>Nikon Z6III Specs</h1>
+
+<div class="shortSpecs">
+    <span class="greyLabel">Announced</span> Jun 17, 2024
+ &bull;     <div class="singleline shortProductSpecs">25 <span class="unitsSuffix">megapixels</span> | 3.1<span class="unitsSuffix">&#8243;</span> screen | Full frame sensor</div>
+</div>
+
+<div class="navigation">
+    
+<div class="tabNavigation">
+
+    <div class="tabs" id="productPageTabs"><ul class="tabs"><li class="leftmost maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/overview"><span class="middle"><span class="left"><span class="right"><span class="text">Home</span></span></span></span></a></li><li class="selected maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/specifications"><span class="middle"><span class="left"><span class="right"><span class="text">Specs</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/review"><span class="middle"><span class="left"><span class="right"><span class="text">Review</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/sample-photos"><span class="middle"><span class="left"><span class="right"><span class="text">Samples</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/videos"><span class="middle"><span class="left"><span class="right"><span class="text">Videos</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/user-reviews"><span class="middle"><span class="left"><span class="right"><span class="text">User reviews (6)</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/questions-and-answers"><span class="middle"><span class="left"><span class="right"><span class="text">Q&amp;As (14)</span></span></span></span></a></li><li class="maintab"><a class="maintab" href="/products/nikon/slrs/nikon_z6iii/buy"><span class="middle"><span class="left"><span class="right"><span class="text">Buy</span></span></span></span></a></li></ul></div><script type="text/javascript">Tabs({"mainElementId":"productPageTabs","tabContentElementId":"tabContent"});</script>
+
+</div>
+</div>
+</div>
+
+<div class="specificationsPage">
+    <table cellpadding="0" cellspacing="0" class="specsTable compact" style="margin-bottom: 15px;">
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Price</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    MSRP
+                                </th>
+                                <td class="value">
+                                    $2500
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Body type</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Body type
+                                </th>
+                                <td class="value">
+                                    SLR-style mirrorless
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Sensor</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Max resolution
+                                </th>
+                                <td class="value">
+                                    6048 x 4032
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Image ratio w:h
+                                </th>
+                                <td class="value">
+                                    1:1, 3:2, 16:9
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Effective pixels
+                                </th>
+                                <td class="value">
+                                    25 <span class="unitsSuffix">megapixels</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Sensor photo detectors
+                                </th>
+                                <td class="value">
+                                    27 <span class="unitsSuffix">megapixels</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Sensor size
+                                </th>
+                                <td class="value">
+                                    Full frame (35.9 x 23.9 mm)
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Sensor type
+                                </th>
+                                <td class="value">
+                                    BSI-CMOS
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Processor
+                                </th>
+                                <td class="value">
+                                    Expeed 7
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Image</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    ISO
+                                </th>
+                                <td class="value">
+                                    100-64000
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Boosted ISO (minimum)
+                                </th>
+                                <td class="value">
+                                    50
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Boosted ISO (maximum)
+                                </th>
+                                <td class="value">
+                                    204800
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    White balance presets
+                                </th>
+                                <td class="value">
+                                    7
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Custom white balance
+                                </th>
+                                <td class="value">
+                                    Yes <span class="boolNote">(Six slots)</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Image stabilization
+                                </th>
+                                <td class="value">
+                                    Sensor-shift
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Image stabilization notes
+                                </th>
+                                <td class="value">
+                                    Includes focus-point centered correction
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    CIPA image stabilization rating
+                                </th>
+                                <td class="value">
+                                    8 <span class="unitsSuffix">stop(s)</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Uncompressed format
+                                </th>
+                                <td class="value">
+                                    RAW
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    JPEG quality levels
+                                </th>
+                                <td class="value">
+                                    Fine, Normal, Basic
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Optics &amp; Focus</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Autofocus
+                                </th>
+                                <td class="value">
+                                    <ul>
+	<li>Contrast Detect (sensor)</li><li>Phase Detect</li><li>Multi-area</li><li>Center</li><li>Selective single-point</li><li>Tracking</li><li>Single</li><li>Continuous</li><li>Touch</li><li>Face Detection</li><li>Live View</li>
+</ul>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Manual focus
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Number of focus points
+                                </th>
+                                <td class="value">
+                                    273
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Lens mount
+                                </th>
+                                <td class="value">
+                                    Nikon Z
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Focal length multiplier
+                                </th>
+                                <td class="value">
+                                    1<span class="unitsSuffix">&#215;</span>
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Screen / viewfinder</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Articulated LCD
+                                </th>
+                                <td class="value">
+                                    Fully articulated
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Screen size
+                                </th>
+                                <td class="value">
+                                    3.1<span class="unitsSuffix">&#8243;</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Screen dots
+                                </th>
+                                <td class="value">
+                                    2,100,000
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Touch screen
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Live view
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Viewfinder type
+                                </th>
+                                <td class="value">
+                                    Electronic
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Viewfinder coverage
+                                </th>
+                                <td class="value">
+                                    100<span class="unitsSuffix">%</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Viewfinder magnification
+                                </th>
+                                <td class="value">
+                                    0.8<span class="unitsSuffix">&#215;</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Viewfinder resolution
+                                </th>
+                                <td class="value">
+                                    5,760,000
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Photography features</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Minimum shutter speed
+                                </th>
+                                <td class="value">
+                                    900 <span class="unitsSuffix">sec</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Maximum shutter speed
+                                </th>
+                                <td class="value">
+                                    1/8000 <span class="unitsSuffix">sec</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Maximum shutter speed (electronic)
+                                </th>
+                                <td class="value">
+                                    1/16000 <span class="unitsSuffix">sec</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Aperture priority
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Shutter priority
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Manual exposure mode
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Subject / scene modes
+                                </th>
+                                <td class="value">
+                                    No
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Built-in flash
+                                </th>
+                                <td class="value">
+                                    No
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    External flash
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Flash modes
+                                </th>
+                                <td class="value">
+                                    Front-curtain sync, Rear-curtain sync, Red-eye reduction, Red-eye reduction with slow sync, Slow sync
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Continuous drive
+                                </th>
+                                <td class="value">
+                                    20.0 <span class="unitsSuffix">fps</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Self-timer
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Metering modes
+                                </th>
+                                <td class="value">
+                                    <ul>
+	<li>Multi</li><li>Center-weighted</li><li>Highlight-weighted</li><li>Average</li><li>Spot</li><li>Spot AF-area</li><li>Partial</li>
+</ul>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Exposure compensation
+                                </th>
+                                <td class="value">
+                                    &plusmn;5 (at 1/3 EV, 1/2 EV steps)
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    AE Bracketing
+                                </th>
+                                <td class="value">
+                                    &plusmn;1.3 (3, 5, 7 frames at 1/3 EV steps)
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    WB Bracketing
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Videography features</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Format
+                                </th>
+                                <td class="value">
+                                    H.264, H.265
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Microphone
+                                </th>
+                                <td class="value">
+                                    Stereo
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Speaker
+                                </th>
+                                <td class="value">
+                                    Mono
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Storage</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Storage types
+                                </th>
+                                <td class="value">
+                                    One CFexpress Type B, One UHS-II SD
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Connectivity</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    USB
+                                </th>
+                                <td class="value">
+                                    
+                            USB 3.2 Gen 1 <small>(5 GBit/sec)</small>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    USB charging
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    HDMI
+                                </th>
+                                <td class="value">
+                                    Yes <span class="boolNote">(Full-size)</span>
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Microphone port
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Headphone port
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Wireless
+                                </th>
+                                <td class="value">
+                                    Built-In
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Wireless notes
+                                </th>
+                                <td class="value">
+                                    802.11b/g/n/a/ac + Bluetooth 5
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Remote control
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Physical</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Environmentally sealed
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Battery
+                                </th>
+                                <td class="value">
+                                    Battery Pack
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Battery description
+                                </th>
+                                <td class="value">
+                                    EN-EL15c
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Battery Life (CIPA)
+                                </th>
+                                <td class="value">
+                                    380
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Weight (inc. batteries)
+                                </th>
+                                <td class="value">
+                                    760 <span class="unitsSuffix">g</span> (1.68 <span class="unitsSuffix">lb</span> / 26.81 <span class="unitsSuffix">oz</span>)
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Dimensions
+                                </th>
+                                <td class="value">
+                                    139 x 102 x 74 <span class="unitsSuffix">mm</span> (5.47 x 4.02 x 2.91<span class="unitsSuffix">&#8243;</span>)
+                                </td>
+                                
+                            </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th colspan="3" class="large groupLabel">Other features</th>
+                </tr>
+            </thead>
+            <tbody>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Orientation sensor
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    Timelapse recording
+                                </th>
+                                <td class="value">
+                                    Yes
+                                </td>
+                                
+                            </tr>
+                            <tr>
+                                <th scope="row" class="label">
+                                    GPS
+                                </th>
+                                <td class="value">
+                                    None
+                                </td>
+                                
+                            </tr>
+            </tbody>
+    </table>
+    <p id="specErrorLink" class="linkish">Have you spotted an error? Report it...</p>
+    <div id="specErrorContainer" class="roundedBox">
+        <div>Please use the form below to report the error.</div>
+
+        <form id="specErrorForm" class="specError" method="post" action="/products/create-spec-error-report">
+            <div class="section">
+                <div class="sectionHeader"><div class="sectionHeaderText">Erroneous field</div><div class="greyLine"></div></div>
+                <select name="field">
+                    <option value="missing-column">Missing specification</option>
+                            <optgroup label="Price">
+                                            <option value="MSRP">MSRP</option>
+                            </optgroup>
+                            <optgroup label="Body type">
+                                            <option value="BodyType">Body type</option>
+                            </optgroup>
+                            <optgroup label="Sensor">
+                                            <option value="MaxResolution">Max resolution</option>
+                                            <option value="AspectRatioNew">Image ratio w:h</option>
+                                            <option value="EffectivePixels">Effective pixels</option>
+                                            <option value="SensorPhotoDetectors">Sensor photo detectors</option>
+                                            <option value="SensorSize">Sensor size</option>
+                                            <option value="SensorType">Sensor type</option>
+                                            <option value="Processor">Processor</option>
+                                            <option value="ColorFilterArray">Color filter array</option>
+                            </optgroup>
+                            <optgroup label="Image">
+                                            <option value="ISORating">ISO</option>
+                                            <option value="BoostedISOMinimum">Boosted ISO (minimum)</option>
+                                            <option value="BoostedISOMaximum">Boosted ISO (maximum)</option>
+                                            <option value="WhiteBalanceOverridePresets">White balance presets</option>
+                                            <option value="WhiteBalanceOverrideCustom">Custom white balance</option>
+                                            <option value="ImageStabilizationNew">Image stabilization</option>
+                                            <option value="ImageStabilizationNotes">Image stabilization notes</option>
+                                            <option value="CIPAImageStabilization">CIPA image stabilization rating</option>
+                                            <option value="UncompressedFormatNew">Uncompressed format</option>
+                                            <option value="QualityLevels">JPEG quality levels</option>
+                                            <option value="FileFormatStill">File format</option>
+                                            <option value="ImageParameters">Image parameters</option>
+                            </optgroup>
+                            <optgroup label="Optics &amp; Focus">
+                                            <option value="AutoFocus">Autofocus</option>
+                                            <option value="ManualFocus">Manual focus</option>
+                                            <option value="AutoFocusPoints">Number of focus points</option>
+                                            <option value="LensMount">Lens mount</option>
+                                            <option value="FocalLengthMultiplier">Focal length multiplier</option>
+                            </optgroup>
+                            <optgroup label="Screen / viewfinder">
+                                            <option value="LCDNew">Articulated LCD</option>
+                                            <option value="LCDSize">Screen size</option>
+                                            <option value="LCDDots">Screen dots</option>
+                                            <option value="TouchScreen">Touch screen</option>
+                                            <option value="LiveView">Live view</option>
+                                            <option value="ViewfinderType">Viewfinder type</option>
+                                            <option value="ViewfinderCoverage">Viewfinder coverage</option>
+                                            <option value="ViewfinderMagnification">Viewfinder magnification</option>
+                                            <option value="ElectronicViewfinderResolution">Viewfinder resolution</option>
+                            </optgroup>
+                            <optgroup label="Photography features">
+                                            <option value="MinShutter">Minimum shutter speed</option>
+                                            <option value="MaxShutter">Maximum shutter speed</option>
+                                            <option value="MaxShutterElectronic">Maximum shutter speed (electronic)</option>
+                                            <option value="AperturePriority">Aperture priority</option>
+                                            <option value="ShutterPriority">Shutter priority</option>
+                                            <option value="ManualExposure">Manual exposure mode</option>
+                                            <option value="SceneModes">Subject / scene modes</option>
+                                            <option value="ExposureModes">Exposure modes</option>
+                                            <option value="BuiltInFlash">Built-in flash</option>
+                                            <option value="ExternalFlash">External flash</option>
+                                            <option value="FlashModes">Flash modes</option>
+                                            <option value="FlashXSyncSpeed">Flash X sync speed</option>
+                                            <option value="DriveModes">Drive modes</option>
+                                            <option value="ContinuousDriveFPS">Continuous drive</option>
+                                            <option value="SelfTimer">Self-timer</option>
+                                            <option value="MeteringModesNew">Metering modes</option>
+                                            <option value="ExposureCompensation">Exposure compensation</option>
+                                            <option value="ExposureBracketing">AE Bracketing</option>
+                                            <option value="WhiteBalanceBracketing">WB Bracketing</option>
+                            </optgroup>
+                            <optgroup label="Videography features">
+                                            <option value="VideoFormat">Format</option>
+                                            <option value="Microphone">Microphone</option>
+                                            <option value="Speaker">Speaker</option>
+                            </optgroup>
+                            <optgroup label="Storage">
+                                            <option value="StorageTypes">Storage types</option>
+                            </optgroup>
+                            <optgroup label="Connectivity">
+                                            <option value="USB">USB</option>
+                                            <option value="USBCharging">USB charging</option>
+                                            <option value="HDMI">HDMI</option>
+                                            <option value="MicrophonePort">Microphone port</option>
+                                            <option value="HeadphonePort">Headphone port</option>
+                                            <option value="Wireless">Wireless</option>
+                                            <option value="WirelessNotes">Wireless notes</option>
+                                            <option value="RemoteControl">Remote control</option>
+                            </optgroup>
+                            <optgroup label="Physical">
+                                            <option value="EnvironmentallySealed">Environmentally sealed</option>
+                                            <option value="BatteryNew">Battery</option>
+                                            <option value="BatteryNotes">Battery description</option>
+                                            <option value="BatteryLife">Battery Life (CIPA)</option>
+                                            <option value="Weight">Weight (inc. batteries)</option>
+                                            <option value="Dimensions">Dimensions</option>
+                            </optgroup>
+                            <optgroup label="Other features">
+                                            <option value="OrientationSensor">Orientation sensor</option>
+                                            <option value="TimelapseRecording">Timelapse recording</option>
+                                            <option value="GPS">GPS</option>
+                            </optgroup>
+                </select>
+            </div>
+                            
+            <div class="section">
+                <div class="sectionHeader"><div class="sectionHeaderText">Comment</div><div class="greyLine"></div></div>
+                <div><textarea name="comment" rows="4" style="width: 570px"></textarea></div>
+            </div>
+
+            
+
+            <div class="section">
+                <input type="hidden" name="dprCode" value="nikon_z6iii">
+                <input type="submit" value="Send report">
+            </div>
+        </form>
+    </div>
+</div>
+                </div>
+                    <div class="sidebar">
+                        
+
+
+
+<div id="adSlot_top_wrapper" class="ad-wrapper top"><div id="adSlot_top" class="ad top ad300x250"></div></div>
+
+
+
+
+
+<div class="widget latestReviewsWidgetV2"><div class="widgetTitle">Latest reviews</div><div class="widgetContent"><div class="reviews" id="latestReviewsSidebarWidget"><div class="review" data-impressionable="SidebarWidgetLatestReviews"><table cellspacing="0" cellpadding="0" border="0" class="review"><tbody><tr><td class="image"><a href="https://www.dpreview.com/reviews/panasonic-dc-l10-comapct-camera-four-thirds-review" data-clickable="SidebarWidgetLatestReviews"><img src="https://2.img-dpreview.com/files/p/TS60x60PFFFFFF00~products/panasonic_dcl10/c2edd015c419448aa4aebca55d5f6321.png" width="60" height="60" border="0" alt="Panasonic Lumix DC-L10"></a></td><td class="title"><div class="title"><a href="https://www.dpreview.com/reviews/panasonic-dc-l10-comapct-camera-four-thirds-review" data-clickable="SidebarWidgetLatestReviews">Panasonic Lumix DC-L10</a></div></td></tr></tbody></table></div><div class="review" data-impressionable="SidebarWidgetLatestReviews"><table cellspacing="0" cellpadding="0" border="0" class="review"><tbody><tr><td class="image"><a href="https://www.dpreview.com/reviews/sony-a7r-vi-review" data-clickable="SidebarWidgetLatestReviews"><img src="https://3.img-dpreview.com/files/p/TS60x60PFFFFFF00~products/sony_a7rvi/ffcf3d09063843c5b8d67cdee38b57b5.png" width="60" height="60" border="0" alt="Sony a7R VI"></a></td><td class="title"><div class="title"><a href="https://www.dpreview.com/reviews/sony-a7r-vi-review" data-clickable="SidebarWidgetLatestReviews">Sony a7R VI</a></div></td></tr></tbody></table></div><div class="review" data-impressionable="SidebarWidgetLatestReviews"><table cellspacing="0" cellpadding="0" border="0" class="review"><tbody><tr><td class="image"><a href="https://www.dpreview.com/reviews/nikon-zr-in-depth-review-compact-full-frame-video-camera-6k-60" data-clickable="SidebarWidgetLatestReviews"><img src="https://1.img-dpreview.com/files/p/TS60x60PFFFFFF00~products/nikon_zr/2ebaa514fd0c4687988b4e69c0490b35.png" width="60" height="60" border="0" alt="Nikon ZR"></a></td><td class="title"><div class="title"><a href="https://www.dpreview.com/reviews/nikon-zr-in-depth-review-compact-full-frame-video-camera-6k-60" data-clickable="SidebarWidgetLatestReviews">Nikon ZR in-depth review</a></div></td><td class="scoreAndAward withBadge"><span class="award gold"></span><span class="score"><span class="value">90</span><span class="percentageSign">%</span></span></td></tr></tbody></table></div><div class="review" data-impressionable="SidebarWidgetLatestReviews"><table cellspacing="0" cellpadding="0" border="0" class="review"><tbody><tr><td class="image"><a href="https://www.dpreview.com/reviews/ricoh-gr-iv-monochrome-review" data-clickable="SidebarWidgetLatestReviews"><img src="https://3.img-dpreview.com/files/p/TS60x60PFFFFFF00~products/ricoh_grivmonochrome/ecf6b0b454b04c02b575b7ec1d009b29.png" width="60" height="60" border="0" alt="Ricoh GR IV Monochrome"></a></td><td class="title"><div class="title"><a href="https://www.dpreview.com/reviews/ricoh-gr-iv-monochrome-review" data-clickable="SidebarWidgetLatestReviews">Ricoh GR IV Monochrome review</a></div></td><td class="scoreAndAward withBadge"><span class="award silver"></span><span class="score"><span class="value">83</span><span class="percentageSign">%</span></span></td></tr></tbody></table></div><div class="review" data-impressionable="SidebarWidgetLatestReviews"><table cellspacing="0" cellpadding="0" border="0" class="review"><tbody><tr><td class="image"><a href="https://www.dpreview.com/reviews/sony-a7-v-review" data-clickable="SidebarWidgetLatestReviews"><img src="https://4.img-dpreview.com/files/p/TS60x60PFFFFFF00~products/sony_a7v/26dccb8463884562a76a5edfa03a1752.png" width="60" height="60" border="0" alt="Sony a7 V"></a></td><td class="title"><div class="title"><a href="https://www.dpreview.com/reviews/sony-a7-v-review" data-clickable="SidebarWidgetLatestReviews">Sony a7 V</a></div></td><td class="scoreAndAward withBadge"><span class="award gold"></span><span class="score"><span class="value">91</span><span class="percentageSign">%</span></span></td></tr></tbody></table></div></div><div class="seeMoreV2"><a href="https://www.dpreview.com/reviews">See all reviews</a> &raquo;</div></div></div><script type="text/javascript">LatestReviewsSidebarWidget()</script>
+
+
+<div class="widget challengeWinnersWidgetV2"><div class="widgetTitle">Finished challenges</div><div class="widgetContent"><div id="challengeWinnersWidget" data-impressionable="SidebarWidgetChallengeWinners"><div class="entriesContainer"><table cellspacing="0" cellpadding="0" border="0" class="entries"><tbody><tr><td class="image" style="height: 240px"><a href="https://www.dpreview.com/challenges/Entry.aspx?ID=1269509" style="width: 240px; height: 240px;" data-clickable="SidebarWidgetChallengeWinners"><img src="https://g4.img-dpreview.com/282814210D4E4581B52E9F0A7765B5CF.jpg" width="240" height="240" alt="Silver and Gold"></a></td><td class="image" style="height: 240px"><a href="https://www.dpreview.com/challenges/Entry.aspx?ID=1269412" style="width: 240px; height: 160px;" data-clickable="SidebarWidgetChallengeWinners"><img src="https://g1.img-dpreview.com/8C450FA61E3E4EE389F17D3E62D1E98C.jpg" width="240" height="160" alt="relaxing on the arctic ice"></a></td><td class="image" style="height: 240px"><a href="https://www.dpreview.com/challenges/Entry.aspx?ID=1269321" style="width: 160px; height: 240px;" data-clickable="SidebarWidgetChallengeWinners"><img src="https://g4.img-dpreview.com/DD0DF147B5424C5C97C2E80263FCE9F6.jpg" width="160" height="240" alt="City clock tower"></a></td></tr><tr><td class="caption">Silver and Gold by homebodyMacro<br>from Fortnight 75: My Best Non-bird Photo Shot after 2026-04-20</td><td class="caption">relaxing on the arctic ice by summicron<br>from Relaxation</td><td class="caption">City clock tower by Edward48<br>from Outdoor Clock.</td></tr></tbody></table></div><div class="paging"><div class="left"></div><div class="right"></div></div></div><div class="seeMoreV2"><a href="https://www.dpreview.com/challenges/" data-clickable="SidebarWidgetChallengeWinners">Discover more challenges</a> &raquo;</div><script type="text/javascript">WidgetChallengesV2()</script></div></div>
+
+
+<div id="adSlot_bottom_wrapper" class="ad-wrapper bottom"><div id="adSlot_bottom" class="ad bottom ad300x250"></div></div>
+
+
+<div class="widget topCamerasWidgetV2"><div class="widgetTitle">Most popular cameras</div><div class="widgetContent"><div class="cameras"><a class="camera" href="https://www.dpreview.com/products/panasonic/compacts/panasonic_dcl10" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Panasonic Lumix DC-L10</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 100.00%"></span></span><span class="views">3.8%</span></span></a><a class="camera" href="https://www.dpreview.com/products/sony/slrs/sony_a7cr" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Sony a7CR</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 49.30%"></span></span><span class="views">1.9%</span></span></a><a class="camera" href="https://www.dpreview.com/products/sony/slrs/sony_a7rvi" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Sony a7R VI</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 47.74%"></span></span><span class="views">1.8%</span></span></a><a class="camera" href="https://www.dpreview.com/products/nikon/slrs/nikon_z50ii" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Nikon Z50II</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 41.27%"></span></span><span class="views">1.6%</span></span></a><a class="camera" href="https://www.dpreview.com/products/sony/slrs/sony_a6100" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Sony a6100</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 40.82%"></span></span><span class="views">1.5%</span></span></a><a class="camera" href="https://www.dpreview.com/products/canon/slrs/canon_eosr6iii" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Canon EOS R6 Mark III</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 38.04%"></span></span><span class="views">1.4%</span></span></a><a class="camera" href="https://www.dpreview.com/products/nikon/slrs/nikon_z6iii" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Nikon Z6III</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 37.91%"></span></span><span class="views">1.4%</span></span></a><a class="camera" href="https://www.dpreview.com/products/fujifilm/slrs/fujifilm_xt5" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Fujifilm X-T5</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 35.60%"></span></span><span class="views">1.3%</span></span></a><a class="camera" href="https://www.dpreview.com/products/canon/slrs/canon_eosr5ii" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Canon EOS R5 Mark II</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 35.11%"></span></span><span class="views">1.3%</span></span></a><a class="camera" href="https://www.dpreview.com/products/nikon/slrs/nikon_z5ii" data-impressionable="SidebarWidgetTopCameras" data-clickable="SidebarWidgetTopCameras"><span class="name">Nikon Z5II</span><span class="barContainer"><span class="bar"><span class="fill" style="width: 34.77%"></span></span><span class="views">1.3%</span></span></a></div><div class="seeMoreV2"><a href="https://www.dpreview.com/products/slrs/statistics">Popular interchangable lens cameras</a> &raquo;</div><div class="seeMoreV2"><a href="https://www.dpreview.com/products/compacts/statistics">Popular compact cameras</a> &raquo;</div></div></div>
+
+
+<div id="adSlot_bottom_2_wrapper" class="ad-wrapper bottom_2"><div id="adSlot_bottom_2" class="ad bottom_2 ad300x250"></div></div>
+
+
+<div class="widget featuredContentWidget"><div class="widgetTitle">Features</div><div class="widgetContent"><div class="items"><a class="item" data-impressionable="SidebarWidgetFeatures" data-clickable="SidebarWidgetFeatures" href="https://www.dpreview.com/reviews" alt="Latest Camera Reviews" title="Latest Camera Reviews"><img src="https://2.img-dpreview.com/files/p/C0x243S3840x2048T300x160~feature_blocks/99e2c4efe716427e98739140d371b4c0.jpeg?v=5794" width="300" height="160" border="0" alt="Latest Camera Reviews"><span class="info"><span class="category">In-depth testing</span><span class="title">Latest Camera Reviews</span></span><span class="frame"></span></a><a class="item" data-impressionable="SidebarWidgetFeatures" data-clickable="SidebarWidgetFeatures" href="https://www.dpreview.com/features" alt="Feature Articles and Videos" title="Feature Articles and Videos"><img src="https://3.img-dpreview.com/files/p/C0x0S300x160~feature_blocks/2c8e245a180e4829b503ba65449a8fb5.jpeg?v=5794" width="300" height="160" border="0" alt="Feature Articles and Videos"><span class="info"><span class="category">Beyond the studio tests</span><span class="title">Feature Articles and Videos</span></span><span class="frame"></span></a><a class="item" data-impressionable="SidebarWidgetFeatures" data-clickable="SidebarWidgetFeatures" href="https://www.dpreview.com/sample-galleries" alt="Sample Galleries" title="Sample Galleries"><img src="https://2.img-dpreview.com/files/p/C0x0S300x160~feature_blocks/b83d74dcb4244ea29979c36337c3b0f7.jpeg?v=5794" width="300" height="160" border="0" alt="Sample Galleries"><span class="info"><span class="category">see how we see</span><span class="title">Sample Galleries</span></span><span class="frame"></span></a><a class="item" data-impressionable="SidebarWidgetFeatures" data-clickable="SidebarWidgetFeatures" href="https://www.dpreview.com/tag/throwback-thursday" alt="Classic Cameras from Days Past" title="Classic Cameras from Days Past"><img src="https://4.img-dpreview.com/files/p/C63x10S786x419T300x160~feature_blocks/b48fabeaff8a41e59681ed18159e729e.jpeg?v=5794" width="300" height="160" border="0" alt="Classic Cameras from Days Past"><span class="info"><span class="category">Throwback Thursday</span><span class="title">Classic Cameras from Days Past</span></span><span class="frame"></span></a><a class="item" data-impressionable="SidebarWidgetFeatures" data-clickable="SidebarWidgetFeatures" href="https://www.dpreview.com/tag/noise" alt="Shedding some light on the sources of noise" title="Shedding some light on the sources of noise"><img src="https://2.img-dpreview.com/files/p/C0x16S520x277T300x160~feature_blocks/e91e9bf455c84422a52627a12797e541.jpeg?v=5794" width="300" height="160" border="0" alt="Shedding some light on the sources of noise"><span class="info"><span class="category">What&#39;s that Noise?</span><span class="title">Shedding some light on the sources of noise</span></span><span class="frame"></span></a></div></div></div>
+
+
+<div id="adSlot_bottom_3_wrapper" class="ad-wrapper bottom_3"><div id="adSlot_bottom_3" class="ad bottom_3 ad300x250"></div></div>
+
+
+
+
+<div class="popout-container" id="sidebarPopoutContainer"></div>
+
+                    </div>
+            </div>
+        </div>
+
+    </div>
+
+    
+<div class="siteFooter">
+    <div class="sitFooterInner">
+        <div class="misc">
+            <div class="logo">
+                <a href="https://www.dpreview.com" title="dpreview.com: Digital Photograhy Review" class="dpr">www.dpreview.com</a>
+            </div>
+            <div class="social">
+                <div class="title">
+                    Follow us
+                </div>
+                <div class="icons"><a href="https://instagram.com/dpreview/" class="instagram" title="Instagram"><span class="icon"></span></a><a href=https://www.tiktok.com/@dpreviewtv class="tiktok" title="TikTok"><span class="icon"></span></a><a href="https://www.youtube.com/user/dpreviewcom" class="youtube" title="YouTube"><span class="icon"></span></a><a href="https://twitter.com/dpreview" class="twitter" title="Twitter"><span class="icon"></span></a><a href="https://www.facebook.com/pages/dpreviewcom-Digital-Photography-Review/77409488739" class="facebook" title="Facebook"><span class="icon"></span></a><a href="https://dpreview.tumblr.com" class="tumblr" title="Tumblr"><span class="icon"></span></a><a href="https://newsletters.dpreview.com/subscribe" rel="nofollow" class="newsletter" title="Sign up for our weekly newsletter!"><span class="icon"></span></a>
+                </div>
+            </div>
+                <div class="mobile">
+                    <a rel="nofollow" href="https://www.dpreview.com/device/mobile">Mobile site</a>
+                </div>
+        </div>
+        <div class="sitemapAndLegal">
+            <div class="sitemap">
+                <div class="area">
+                    <div class="title">About</div>
+                    <ul>
+                        <li><a href="https://www.dpreview.com/about">About us</a></li>
+                        <li><a href="https://www.gearpatrol.com/">Gear Patrol</a></li>
+                        <li><a href="https://www.dpreview.com/misc/jobs">Work for us</a></li>
+                        <li><a href="/commercial-enquiries">Advertise with us</a></li>
+                        <li><a href="https://www.dpreview.com/faq">FAQ</a></li>
+                        <li><a href="https://www.dpreview.com/feedback" id="feedbackMainFooterLink" rel="nofollow">Feedback / Contact us</a></li>
+                        <li><a href="https://www.dpreview.com/misc/privacypolicy">Privacy</a></li>
+                        <li><a href="https://www.dpreview.com/misc/termsandconditions">Legal</a></li>
+                        <li><a href="https://www.adcetera.com/?utm_campaign=affiliate_cl&utm_source=adclicensingplus&utm_content=licensing_and_accolades&utm_medium=web" rel="nofollow">Licensing and Accolades</a></li>
+                    </ul>
+                </div>
+                <div class="area">
+                    <div class="title">Editorial content</div>
+                    <ul>
+                        <li><a href="https://www.dpreview.com">News</a></li>
+                        <li><a href="https://www.dpreview.com/reviews?category=cameras">Camera reviews</a></li>
+                        <li><a href="https://www.dpreview.com/reviews?category=lenses">Lens reviews</a></li>
+                        <li><a href="https://www.dpreview.com/reviews?category=printers">Printer reviews</a></li>
+                        <li><a href="https://www.dpreview.com/buying-guides">Buying guides</a></li>
+                        <li><a href="https://www.dpreview.com/sample-galleries">Sample images</a></li>
+                        <li><a href="https://www.dpreview.com/videos">Videos</a></li>
+                        <li><a href="/editiorial-enquiries">Editorial enquiries</a></li>
+                    </ul>
+                </div>
+                <div class="area">
+                    <div class="title">Cameras &amp; Lenses</div>
+                    <ul>
+                        <li><a href="https://www.dpreview.com/products/cameras">Cameras</a></li>
+                        <li><a href="https://www.dpreview.com/products/lenses">Lenses</a></li>
+                        <li><a href="https://www.dpreview.com/products/search/cameras">Camera search</a></li>
+                        <li><a href="https://www.dpreview.com/products/compare/cameras">Camera comparison</a></li>
+                        <li><a href="https://www.dpreview.com/products/search/lenses">Lens search</a></li>
+                        <li><a href="https://www.dpreview.com/products/timeline">Product timeline</a></li>
+                        <li><a href="https://www.dpreview.com/products">Browse all products</a></li>
+                    </ul>
+                </div>
+                <div class="area">
+                    <div class="title">Community</div>
+                    <ul>
+                        <li><a href="https://www.dpreview.com/community-guidelines">Community Guidelines</a></li>
+                        <li><a href="https://www.dpreview.com/forums">Forums</a></li>
+                        <li><a href="https://www.dpreview.com/challenges">Challenges</a></li>
+                        <li><a href="https://www.dpreview.com/galleries">Galleries</a></li>
+                        
+                        <li><a href="https://www.dpreview.com/members/me" rel="nofollow">My Profile</a></li>
+                        <li><a href="https://www.dpreview.com/members/settings" rel="nofollow">My Settings</a></li>
+                        <li><a href="https://www.dpreview.com/members/me/gearlist" rel="nofollow">My GearList</a></li>
+                    </ul>
+                </div>
+                <div style="clear: both;"></div>
+            </div>
+            <div class="legal">
+                All content, design, and layout are Copyright &copy; 1998&ndash;2026 Digital Photography Review All Rights Reserved.<br>
+                Reproduction in whole or part in any form or medium without specific written permission is prohibited.<br>
+                When you use DPReview links to buy products, the site may earn a commission.
+<br />
+                &copy;GPS Media - Guides, Products, Services.
+            </div>
+        </div> 
+        <div style="clear: both;"></div>
+    </div>
+</div>
+
+    <script type="text/javascript">
+    $(document).ready(function()
+    {
+
+        // Twitter
+        $.ajax({
+            url: Utils.createAssetUrl("/resources/scripts/vendor/twitter/widgets.js"),
+            dataType: "script",
+            cache: true
+        })
+
+    });
+</script>
+
+
+    <div id="adSlot_desktop-sticky-footer_wrapper" class="ad-wrapper desktop-sticky-footer"><div id="adSlot_desktop-sticky-footer" class="ad desktop-sticky-footer sticky"></div></div>
+
+    
+    
+
+
+
+        <script type="text/javascript" src="https://s.skimresources.com/js/31959X1726082.skimlinks.js"></script>
+
+<script type="text/javascript" async src="https://btloader.com/tag?o=5698917485248512&upapi=true&domain=dpreview.com"></script>
+
+<script>!function(){"use strict";var e;e=document,function(){var t,n;function r(){var t=e.createElement("script");t.src="https://cafemedia-com.videoplayerhub.com/galleryplayer.js",e.head.appendChild(t)}function a(){var t=e.cookie.match("(^|[^;]+)\s*__adblocker\s*=\s*([^;]+)");return t&&t.pop()}function c(){clearInterval(n)}return{init:function(){var e;"true"===(t=a())?r():(e=0,n=setInterval((function(){100!==e&&"false" !== t || c(), "true" === t && (r(), c()), t = a(), e++}), 50))}}}().init()}();</script>    </body>
+</html>

--- a/tools/pagefetch/tests/test_detection.py
+++ b/tools/pagefetch/tests/test_detection.py
@@ -1,5 +1,7 @@
 """Bot-detection tests — one per pattern plus the meta-refresh case."""
 
+from pathlib import Path
+
 import pytest
 
 from pagefetch import (
@@ -14,6 +16,8 @@ from pagefetch.detection import (
     MIN_REAL_CONTENT_BYTES,
     html_to_text,
 )
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 REAL_PAGE = "<html><body>" + ("Lorem ipsum lens specs. " * 100) + "</body></html>"
 # A real content page comfortably above the size floor.
@@ -67,6 +71,35 @@ def test_each_bot_pattern_is_detected(snippet):
 def test_patterns_list_is_covered_by_parametrization():
     # Guard: if a new pattern is added, the parametrized test above must grow.
     assert len(BOT_DETECTION_PATTERNS) == 19
+
+
+def test_dpreview_real_body_is_not_bot_blocked():
+    # #870 regression: a real 137 KB DPReview spec page embeds the substring
+    # "checking your browser extensions and settings" inside ad-blocker help
+    # text. The Cloudflare pattern must not false-match on that text.
+    html = (FIXTURES / "dpreview_specifications.html").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    assert "checking your browser" in html.lower()  # the false-positive bait
+    assert is_bot_blocked(html) is False
+    assert looks_like_real_content(html) is True
+
+
+def test_cloudflare_checking_your_browser_still_detected():
+    # Guard against tightening the pattern so much that the real CF
+    # interstitial slips through. CF emits "Checking your browser before
+    # accessing <site>" — that exact shape must still register as a bot block.
+    cf = "<html><body>Checking your browser before accessing example.com</body></html>"
+    assert is_bot_blocked(cf) is True
+
+
+def test_checking_your_browser_substring_alone_is_not_bot_blocked():
+    # The bare substring without the " before " anchor (e.g. ad-blocker help
+    # text on real content pages) must not trigger a bot match.
+    benign = "<html><body>" + (
+        "We recommend checking your browser extensions and settings. " * 200
+    ) + "</body></html>"
+    assert is_bot_blocked(benign) is False
 
 
 def test_html_to_text_strips_scripts_styles_and_tags():


### PR DESCRIPTION
Closes #870.

## Problem
DPReview spec pages returned 137 KB of real content over urllib (correct `<title>...Specs: DPReview...</title>`, full spec body), but pagefetch discarded the response and escalated through every tier — all four reporting "Bot detection page still present." The user-visible result was identical to a hard block.

## Root cause
`BOT_DETECTION_PATTERNS` in `tools/pagefetch/detection.py` included a bare `r"Checking your browser"` pattern intended for Cloudflare interstitials. DPReview embeds the substring as part of an ad-blocker help message:

> "It's possible that more than one tool is active … We recommend **checking your browser** extensions and settings."

This is real page content, not a CF challenge. Saved as the fixture `tools/pagefetch/tests/fixtures/dpreview_specifications.html`.

## Fix
Anchor the pattern to the canonical Cloudflare phrasing (`Checking your browser before accessing …`):

```python
r"Checking your browser\b[^.]{0,40}\bbefore\b"
```

- ✅ Matches the real CF challenge text
- ✅ Rejects DPReview's `checking your browser extensions and settings`
- ✅ Rejects the entire 137 KB DPReview fixture

## Tests
Three new regression tests in `tools/pagefetch/tests/test_detection.py`:
- `test_dpreview_real_body_is_not_bot_blocked` — the saved 137 KB DPReview body is not bot-blocked and counts as real content
- `test_cloudflare_checking_your_browser_still_detected` — guards against over-tightening; the canonical CF phrase still registers
- `test_checking_your_browser_substring_alone_is_not_bot_blocked` — the bare substring without `before` does not trigger

Full suite green: `98 passed in 0.33s`.

## End-to-end verification
```
pagefetch https://www.dpreview.com/products/canon/slrs/canon_eosr5ii/specifications
→ ok: True  tier: urllib  bytes: 131816
→ title: Canon EOS R5 Mark II Specs: DPReview | …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)