### PR TITLE
feat(mtfdigitizer): ground truth + calibration runner for reference set (#953)

### DIFF
--- a/tools/mtfdigitizer/README.md
+++ b/tools/mtfdigitizer/README.md
@@ -16,6 +16,7 @@ Under construction. Foundation work in progress:
 - [x] [#933](https://github.com/Imbra-Ltd/wuseria/issues/933) — reference set
 - [x] [#934](https://github.com/Imbra-Ltd/wuseria/issues/934) — profile abstraction + advisory auto-suggest
 - [x] [#935](https://github.com/Imbra-Ltd/wuseria/issues/935) — adaptive extraction pipeline with 11-point sampling
+- [x] [#953](https://github.com/Imbra-Ltd/wuseria/issues/953) — ground truth + plot boxes; offset distribution measured (calibration half 1 of 2)
 - [ ] Remaining tasks under epic [#932](https://github.com/Imbra-Ltd/wuseria/issues/932)
 
 `extract_chart(image_path, profile, plot_box, image_height_mm)` is the
@@ -29,9 +30,11 @@ mtfdigitizer/
   README.md           # this file
   __init__.py         # package marker + module map
   loader.py           # alpha-aware image loader (shared)
+  calibrate.py        # reference-set calibration runner (#953)
   referenceset/       # eye-verified ground-truth charts (#933)
     REFERENCE_SET.md  # what's in the set, why, verified-shape notes
-    charts.py         # machine-readable manifest
+    calibration.md    # latest calibration run + findings (#953)
+    charts.py         # machine-readable manifest (chart + plot box + ground truth)
   profiles/           # declared chart profiles + auto-suggest (#934)
     types.py          # MtfProfile, HueRange, ProfileMatch, ProfileMismatch
     declared.py       # SIGMA_2COLOR_SOLID_DASHED, SAMYANG_4COLOR_ALL_SOLID
@@ -131,9 +134,22 @@ The two open ADR-038 parameters proposed against this set:
 - **Render-match threshold** — `0.75` IoU initial value
 - **Offset tolerance band** — `±0.05` MTF units (uniform vertical offset)
 
-Reasoning in `referenceset/REFERENCE_SET.md` §Proposed thresholds. Both will
-be refined against the real extractor in #935 — these are starting points,
-not final.
+Reasoning in `referenceset/REFERENCE_SET.md` §Proposed thresholds. The
+offset band side of the calibration ran in #953 against the 3 charts whose
+profile is declared today; see `referenceset/calibration.md` for the
+measurement and findings. Render-match calibration is still blocked on the
+confidence-signal sub-task of #932.
+
+## Calibration
+
+```bash
+cd tools
+py -m mtfdigitizer.calibrate
+```
+
+Runs `extract_chart()` for every reference chart with both `plot_box` and
+`ground_truth` populated and reports the |d| (absolute offset) distribution
+per field. See `referenceset/calibration.md` for the latest run's findings.
 
 ## Running the tests
 

--- a/tools/mtfdigitizer/calibrate.py
+++ b/tools/mtfdigitizer/calibrate.py
@@ -1,0 +1,201 @@
+"""Reference-set calibration runner (#953, ADR-038 §4).
+
+Runs `extract_chart()` against every reference chart that has both
+ground truth and a plot box, and reports the per-position offset (Δ)
+distribution against the eye-read values.
+
+This delivers the **offset distribution** half of the calibration
+defined in `referenceset/REFERENCE_SET.md` §"What 'calibration against
+the set' actually means". The other half — render-match IoU — needs the
+confidence signal sub-task to land first; this runner is silent on it.
+
+Usage::
+
+    cd tools
+    py -m mtfdigitizer.calibrate
+
+Output: a per-chart Δ table on stdout + an aggregate summary at the end.
+No file writes — the findings live in
+`referenceset/calibration.md`, which the maintainer updates after a run.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+from .pipeline import PlotBox, SampledReading, extract_chart
+from .pipeline.sampling import SAMPLE_FRACTIONS
+from .profiles import SAMYANG_4COLOR_ALL_SOLID, SIGMA_2COLOR_SOLID_DASHED
+from .profiles.types import MtfProfile
+from .referenceset.charts import REFERENCE_CHARTS, PlotBoxCoords, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# Style family → declared profile. Only the two families with profiles
+# today are wired. Extending the calibration to other families requires
+# (1) a profile in `profiles/declared.py` and (2) ground truth + plot
+# box on the chart entry. Profile work is tracked separately under #932.
+_PROFILE_BY_STYLE: dict[str, MtfProfile] = {
+    "mainstream-2color-solid-dashed": SIGMA_2COLOR_SOLID_DASHED,
+    "mainstream-4color-all-solid": SAMYANG_4COLOR_ALL_SOLID,
+    "idealized-flat": SAMYANG_4COLOR_ALL_SOLID,  # same 4-color template
+}
+
+
+@dataclass(frozen=True)
+class FieldDelta:
+    """One field's Δ stats across the 11 sample positions of one chart."""
+
+    chart_slug: str
+    aperture: str
+    field: str
+    deltas: tuple[float, ...]  # |extracted - gt| for positions where both exist
+    gt_value_count: int  # positions where ground truth is not None
+    extracted_none_count: int  # positions where extractor returned None
+    paired_count: int  # positions where both sides had a value
+
+    @property
+    def median_abs_delta(self) -> float | None:
+        return statistics.median(self.deltas) if self.deltas else None
+
+    @property
+    def p95_abs_delta(self) -> float | None:
+        if not self.deltas:
+            return None
+        # statistics.quantiles needs ≥ 2 points; for fewer, return the max.
+        if len(self.deltas) < 2:
+            return self.deltas[0]
+        return statistics.quantiles(self.deltas, n=20)[-1]  # 95th percentile
+
+
+def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
+    return PlotBox(
+        x_left=coords.x_left,
+        x_right=coords.x_right,
+        y_top=coords.y_top,
+        y_bottom=coords.y_bottom,
+    )
+
+
+def _extracted_value(reading: SampledReading, field: str) -> float | None:
+    return getattr(reading, field)
+
+
+def _compare_field(
+    chart: ReferenceChart,
+    aperture: str,
+    field: str,
+    extracted: tuple[SampledReading, ...],
+    ground_truth: tuple[float | None, ...],
+) -> FieldDelta:
+    deltas: list[float] = []
+    gt_value_count = 0
+    extracted_none_count = 0
+    paired_count = 0
+    for reading, gt in zip(extracted, ground_truth):
+        ext = _extracted_value(reading, field)
+        if gt is not None:
+            gt_value_count += 1
+        if ext is None:
+            extracted_none_count += 1
+        if gt is not None and ext is not None:
+            deltas.append(abs(ext - gt))
+            paired_count += 1
+    return FieldDelta(
+        chart_slug=chart.slug,
+        aperture=aperture,
+        field=field,
+        deltas=tuple(deltas),
+        gt_value_count=gt_value_count,
+        extracted_none_count=extracted_none_count,
+        paired_count=paired_count,
+    )
+
+
+def _calibrate_chart(chart: ReferenceChart) -> list[FieldDelta]:
+    """Run extract_chart on one reference chart and return per-field stats.
+
+    The chart must carry both `plot_box` and `ground_truth`; the caller
+    filters runnable charts.
+    """
+    assert chart.plot_box is not None
+    assert chart.ground_truth is not None
+    profile = _PROFILE_BY_STYLE.get(chart.style_family)
+    if profile is None:
+        raise ValueError(
+            f"{chart.slug}: no declared profile for style_family={chart.style_family!r}"
+        )
+
+    image_path = REPO_ROOT / chart.chart_path
+    plot_box = _to_plotbox(chart.plot_box)
+    result = extract_chart(
+        image_path, profile, plot_box, image_height_mm=chart.image_height_mm
+    )
+
+    out: list[FieldDelta] = []
+    # The ground truth dict may carry multiple apertures; the extractor
+    # was given a single plot box (MAX panel today), so only compare the
+    # apertures that match. In practice a single key today.
+    for aperture, fields in chart.ground_truth.items():
+        for field, gt_values in fields.items():
+            out.append(_compare_field(chart, aperture, field, result.readings, gt_values))
+    return out
+
+
+def _format_field_row(delta: FieldDelta) -> str:
+    med = delta.median_abs_delta
+    p95 = delta.p95_abs_delta
+    med_s = f"{med:.3f}" if med is not None else "  -  "
+    p95_s = f"{p95:.3f}" if p95 is not None else "  -  "
+    return (
+        f"  {delta.field:<14}  med |d| {med_s}  p95 |d| {p95_s}  "
+        f"paired {delta.paired_count:2d}/11  "
+        f"ext-None {delta.extracted_none_count:2d}"
+    )
+
+
+def main() -> None:
+    runnable = [
+        c for c in REFERENCE_CHARTS if c.plot_box and c.ground_truth
+    ]
+    print(f"Calibrating {len(runnable)} of {len(REFERENCE_CHARTS)} reference charts.")
+    print(f"Sample fractions: {SAMPLE_FRACTIONS}")
+    print()
+
+    all_deltas: list[float] = []
+    for chart in runnable:
+        print(f"## {chart.slug} ({chart.style_family})")
+        field_deltas = _calibrate_chart(chart)
+        for fd in field_deltas:
+            print(_format_field_row(fd))
+            all_deltas.extend(fd.deltas)
+        print()
+
+    if not all_deltas:
+        print("No paired comparisons — nothing to summarize.")
+        return
+
+    median = statistics.median(all_deltas)
+    p95 = (
+        statistics.quantiles(all_deltas, n=20)[-1]
+        if len(all_deltas) >= 2
+        else all_deltas[0]
+    )
+    print("## Aggregate (all charts, all fields)")
+    print(f"  paired comparisons:    {len(all_deltas)}")
+    print(f"  median |d|:           {median:.4f}")
+    print(f"  p95 |d|:              {p95:.4f}")
+    print(f"  max |d|:              {max(all_deltas):.4f}")
+    print()
+    print("  Reference offset tolerance band proposed by REFERENCE_SET.md: +/-0.05.")
+    in_band = sum(1 for d in all_deltas if d <= 0.05)
+    print(f"  Comparisons within +/-0.05: {in_band}/{len(all_deltas)} "
+          f"({100 * in_band / len(all_deltas):.1f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mtfdigitizer/referenceset/calibration.md
+++ b/tools/mtfdigitizer/referenceset/calibration.md
@@ -1,0 +1,155 @@
+# Calibration run (#953)
+
+First calibration of `extract_chart()` against the reference set's
+eye-read ground truth. Sister document to `REFERENCE_SET.md` — that one
+declares the proposed thresholds; this one records what running the
+extractor against ground truth actually produces.
+
+This is the **offset distribution** half of the calibration defined in
+`REFERENCE_SET.md` §"What 'calibration against the set' actually means".
+The other half — render-match IoU — needs the confidence-signal
+sub-task of epic #932 to land first.
+
+## Scope
+
+3 of 8 reference charts run today: those whose `style_family` has a
+declared profile in `profiles/declared.py`.
+
+| Chart                                | Style family                    | Profile used                |
+| ------------------------------------ | ------------------------------- | --------------------------- |
+| sigma-56mm-f1-4-dc-dn-c              | mainstream-2color-solid-dashed  | SIGMA_2COLOR_SOLID_DASHED   |
+| samyang-85mm-f1-4-as-if-umc (MAX)    | mainstream-4color-all-solid     | SAMYANG_4COLOR_ALL_SOLID    |
+| samyang-300mm-f6-3-ed-umc-cs-reflex (MAX) | idealized-flat              | SAMYANG_4COLOR_ALL_SOLID    |
+
+The other 5 charts (chart 4 same-color-dashed, 5 soft promo, 6
+2color-frequency, 7 B&W dashed, 8 multifreq) need profile declarations
+that don't exist yet. ADR-038 §1 says other dialects land per-brand as
+the digitizer encounters them; that is separate work.
+
+## How to reproduce
+
+```
+cd tools
+py -m mtfdigitizer.calibrate
+```
+
+Reads the in-source ground truth from `referenceset/charts.py` and runs
+`extract_chart()` for each chart with both `plot_box` and `ground_truth`
+populated. Output: per-chart `|d|` (absolute offset) median + p95 per
+field, then an aggregate.
+
+## Run from 2026-05-30 (commit before this write-up)
+
+### Per-chart
+
+```
+sigma-56mm-f1-4-dc-dn-c (mainstream-2color-solid-dashed)
+  contrast10S     med |d| 0.007  p95 |d| 0.044  paired  9/11  ext-None  2
+  contrast10M     med |d| 0.009  p95 |d| 0.024  paired  2/11  ext-None  9
+  resolution30S   med |d| 0.009  p95 |d| 0.034  paired  9/11  ext-None  2
+  resolution30M   med |d| 0.009  p95 |d| 0.025  paired  2/11  ext-None  9
+
+samyang-85mm-f1-4-as-if-umc (mainstream-4color-all-solid)
+  contrast10S     med |d| 0.016  p95 |d| 0.029  paired 11/11  ext-None  0
+  contrast10M     med |d| 0.015  p95 |d| 0.180  paired 11/11  ext-None  0
+  resolution30S   med |d| 0.016  p95 |d| 0.056  paired 11/11  ext-None  0
+  resolution30M   med |d| 0.012  p95 |d| 0.036  paired 11/11  ext-None  0
+
+samyang-300mm-f6-3-ed-umc-cs-reflex (idealized-flat)
+  contrast10S     med |d| 0.017  p95 |d| 0.017  paired 11/11  ext-None  0
+  contrast10M     med |d| 0.012  p95 |d| 0.019  paired 10/11  ext-None  1
+  resolution30S   med |d|   -    p95 |d|   -    paired  0/11  ext-None 11
+  resolution30M   med |d| 0.021  p95 |d| 0.024  paired  5/11  ext-None  6
+```
+
+### Aggregate
+
+```
+paired comparisons:    92
+median |d|:           0.0147
+p95 |d|:              0.0366
+max |d|:              0.1467
+within +/-0.05:       89/92 (96.7%)
+```
+
+## Findings
+
+### 1. The ±0.05 tolerance band proposed in REFERENCE_SET.md is justified by data
+
+Aggregate median |d| = 0.015 — half the band. 96.7% of paired
+comparisons land within ±0.05. The band's lower anchor (the #931 trace
+noise floor at Δ ≈ 0.023) sits cleanly between this median and the p95
+of 0.037. No reason to tighten or loosen.
+
+### 2. Plot-box boundaries clip data on the Sigma chart
+
+`extract_chart()` returns `None` for **all four fields at positions
+0.00mm and 14.00mm** on the Sigma 56mm chart, but returns clean values
+on the same positions for both Samyang charts. The cause is the bracket
+window: at fraction 0.0 the window scans `[x_left - 3, x_left + 3]`,
+which sits in the y-axis label region on the Sigma chart but in the
+plot region on the Samyangs (because the Samyang plot box is measured
+tighter).
+
+This is a real defect surfaced by calibration — not a tolerance
+question. It costs 8 paired comparisons today (2 positions × 4 fields)
+and would cost more on any chart where the plot box doesn't include the
+axis line cleanly. Worth a follow-up issue against `pipeline/sampling.py`
+or `referenceset/charts.py` plot-box conventions.
+
+### 3. The Samyang profile's dark-grey HSV band is brand-page-specific
+
+The Samyang 300mm chart's grey 30S curve renders at V ≈ 190 — outside
+the declared `30S-dark-grey` band of V ∈ [85, 115], which was measured
+on the 85mm chart. Result: extractor reports `None` for 30S at all 11
+positions on the 300mm chart (the 0/11 paired line above).
+
+This is the chart-rendering-varies-by-brand-page warning from ADR-038
+§4, observed in the wild for the first time. The fix isn't to widen the
+band (would risk matching gridlines on the 85mm chart); it's likely
+either a per-chart HSV calibration step or a more robust S/V-normalized
+matcher. Not a calibration-tuning question — out of scope here.
+
+### 4. The idealized-flat case reads cleanly, confirming the ADR-038 §4 trap
+
+The Samyang 300mm reflex is the chart REFERENCE_SET.md flags as the
+"flat-axis blind-spot probe case": all curves pinned at ~1.0, so any
+extractor that traces them gets a high render-match score for the wrong
+reason. The calibration confirms it: `extract_chart()` reads it at
+median |d| = 0.017 (cleanest of the three charts on the fields where it
+gets data), all 10S/10M comparisons within ±0.05. A render-match check
+alone would auto-commit this chart at high confidence. **This is the
+exact case the plausibility prior must catch.**
+
+### 5. The known Samyang pink-edge limit shows up as the worst single divergence
+
+Max |d| = 0.147 at Samyang 85mm 10M position 21.6mm (extractor 0.783 vs
+eye-read 0.93). The pink curve genuinely fades below the saturation
+threshold at the chart edge — the README's "Known limits, deferred"
+section calls this out for the Samyang chart. The calibration shows
+which single point dominates the p95 number and confirms the failure
+mode matches the documented expectation.
+
+### 6. Sigma dashed-M readings are sparse but honest (B2 contract)
+
+10M and 30M paired 2/11 on Sigma — the morphological close bridges
+*most* dash gaps but not all, and B2 (`None` on a missed bracket)
+correctly fires at positions where the bridged skeleton has no pixel.
+This is the contract working, not a fault. The README already records
+this as a known limit. A future SVG emitter will interpolate or hold
+None per its own policy.
+
+## Threshold recommendation
+
+The render-match threshold question (0.75 IoU) cannot be answered
+without the render-match scorer. The offset tolerance band proposed at
+±0.05 holds against the runnable subset and **should not be moved on
+this data alone**.
+
+Open items before the threshold conversation can close:
+
+- Render-match scorer (epic #932 confidence-signal sub-task).
+- Plot-box bracket-window fix or convention clarification — finding 2.
+- Cross-chart HSV calibration for the Samyang grey bands — finding 3.
+- Calibration coverage for the other 5 reference charts as their
+  profiles are declared.

--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -1,8 +1,14 @@
-"""Machine-readable MTF reference set (#933).
+"""Machine-readable MTF reference set (#933, extended in #953).
 
 Eight eye-verified charts spanning the chart-style families found in
 `docs/optical-specs/`. Used to calibrate the render-match threshold and
 offset tolerance band of the digitizer (ADR-038 §4).
+
+Three of the eight charts carry ground-truth values + a hand-measured
+plot box — the subset `extract_chart()` can run today (Sigma 2-color
+and Samyang 4-color profiles, the two declared in `profiles/declared.py`).
+The other five are tracked for shape coverage; calibration on them
+unblocks once their profile lands.
 
 Field semantics:
 
@@ -13,6 +19,10 @@ Field semantics:
 - `frequencies_lpmm`  — spatial frequencies plotted (lp/mm)
 - `image_height_mm`   — chart x-axis extent in mm
 - `notes`             — one-line shape summary; full verification in REFERENCE_SET.md
+- `plot_box`          — hand-measured pixel corners of the plot region (or None)
+- `ground_truth`      — eye-read MTF values at the 11 SAMPLE_FRACTIONS
+                        (`{aperture_label: {field_name: tuple_of_11_values_or_None}}`),
+                        or None for charts not yet calibrated
 
 Style families (single source of truth):
 
@@ -32,6 +42,28 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class PlotBoxCoords:
+    """Pixel corners of the plot region in the source PNG.
+
+    Same semantics as `pipeline.types.PlotBox` but lives here so the
+    reference set has no import dependency on `pipeline`.
+    `to_plotbox()` lifts to the runtime type.
+    """
+
+    x_left: int
+    x_right: int
+    y_top: int
+    y_bottom: int
+
+
+# Ground-truth shape: one tuple of 11 values per (aperture, field).
+# A value is the eye-read MTF at the corresponding SAMPLE_FRACTIONS index,
+# or None when the curve genuinely does not extend to that position
+# (e.g. the curve is clipped past the visible edge). 11 entries, always.
+GroundTruthCurves = dict[str, dict[str, tuple[float | None, ...]]]
+
+
+@dataclass(frozen=True)
 class ReferenceChart:
     """One eye-verified reference chart entry."""
 
@@ -42,6 +74,61 @@ class ReferenceChart:
     frequencies_lpmm: tuple[int, ...]
     image_height_mm: float
     notes: str
+    # Calibration-only fields, populated where the chart can run through
+    # `extract_chart()` today. None on the five charts whose profile or
+    # plot-box hasn't been declared yet.
+    plot_box: PlotBoxCoords | None = None
+    ground_truth: GroundTruthCurves | None = None
+
+
+# Eye-read ground truth tables for the runnable subset. Each tuple holds
+# 11 MTF values at the SAMPLE_FRACTIONS (0.0, 0.1, …, 1.0) — i.e. at the
+# image-height positions the calibration runner samples. Values were read
+# from the source PNG against the chart's printed gridlines; the precision
+# is ~±0.02 (one gridline tick is 0.10–0.20, eye-reading to half a tick).
+# Same provenance as the prose shape notes in REFERENCE_SET.md.
+
+# Sigma 56mm — x positions: 0, 1.4, 2.8, 4.2, 5.6, 7.0, 8.4, 9.8, 11.2, 12.6, 14.0
+_SIGMA_56_GT: GroundTruthCurves = {
+    "f/1.4": {
+        # Red solid — 10S — flat at top until knee near 11mm
+        "contrast10S": (0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.94, 0.86, 0.68),
+        # Red dashed — 10M — sits slightly above 10S until edge
+        "contrast10M": (0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.96, 0.93, 0.87),
+        # Blue solid — 30S — starts ~0.86, slow sag, steep edge drop
+        "resolution30S": (0.86, 0.86, 0.86, 0.85, 0.84, 0.82, 0.81, 0.80, 0.74, 0.60, 0.33),
+        # Blue dashed — 30M — sits above 30S, gentler edge drop
+        "resolution30M": (0.87, 0.87, 0.87, 0.88, 0.87, 0.86, 0.86, 0.85, 0.83, 0.68, 0.60),
+    },
+}
+
+# Samyang 85mm MAX panel — x positions: 0, 2.16, 4.32, 6.48, 8.64, 10.8, 12.96, 15.12, 17.28, 19.44, 21.6
+_SAMYANG_85_GT: GroundTruthCurves = {
+    "MAX": {
+        # Dark red — 10S — flat near top, sharp knee past 17mm
+        "contrast10S": (0.91, 0.92, 0.93, 0.94, 0.94, 0.94, 0.94, 0.93, 0.91, 0.86, 0.78),
+        # Pink — 10M — similar to 10S but holds at edge
+        "contrast10M": (0.91, 0.92, 0.93, 0.93, 0.94, 0.94, 0.94, 0.94, 0.94, 0.93, 0.93),
+        # Dark grey — 30S — gradual drop with a slight uptick at edge
+        "resolution30S": (0.70, 0.68, 0.66, 0.63, 0.62, 0.60, 0.58, 0.57, 0.57, 0.54, 0.52),
+        # Light grey — 30M — near-linear drop
+        "resolution30M": (0.70, 0.67, 0.66, 0.64, 0.62, 0.61, 0.60, 0.59, 0.58, 0.57, 0.57),
+    },
+}
+
+# Samyang 300mm reflex — x positions: 0, 1.4, 2.8, ..., 14.0
+# All four curves pinned at 1.0 across the entire field (idealized-flat).
+# This chart's value in the set is the plausibility prior, not a render-match
+# test — every extractor scores this chart well by IoU and that's the bug
+# the prior catches. Ground truth here is "what the chart literally shows."
+_SAMYANG_300_GT: GroundTruthCurves = {
+    "MAX": {
+        "contrast10S": (1.0,) * 11,
+        "contrast10M": (1.0,) * 11,
+        "resolution30S": (1.0,) * 11,
+        "resolution30M": (1.0,) * 11,
+    },
+}
 
 
 REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
@@ -53,6 +140,8 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
         notes="canonical clean chart; 10S/M flat ~0.97 to 10mm then dips; 30S falls 0.86→0.3 at edge",
+        plot_box=PlotBoxCoords(x_left=186, x_right=2987, y_top=83, y_bottom=1700),
+        ground_truth=_SIGMA_56_GT,
     ),
     ReferenceChart(
         slug="samyang-85mm-f1-4-as-if-umc",
@@ -62,6 +151,10 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         frequencies_lpmm=(10, 30),
         image_height_mm=21.6,
         notes="two stacked panels; MAX shows S/M divergence at edges, F8 mostly recovers except 30M edge dip",
+        # MAX panel only — F8 panel calibration deferred (requires a
+        # second plot box; the runnable subset is MAX-only today).
+        plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=43, y_bottom=463),
+        ground_truth=_SAMYANG_85_GT,
     ),
     ReferenceChart(
         slug="samyang-300mm-f6-3-ed-umc-cs-reflex",
@@ -71,6 +164,9 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
         notes="ALL curves pinned at ~1.0 across both apertures; the flat-axis blind-spot probe case",
+        # Same layout as the Samyang 85mm (identical template); MAX panel.
+        plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=43, y_bottom=463),
+        ground_truth=_SAMYANG_300_GT,
     ),
     ReferenceChart(
         slug="7artisans-50mm-f1-2-mark-ii",

--- a/tools/mtfdigitizer/tests/test_pipeline.py
+++ b/tools/mtfdigitizer/tests/test_pipeline.py
@@ -8,10 +8,8 @@ Acceptance criteria from issue #935:
 - Reproduces the reference set's shapes
 - Tests pass
 
-Plot boxes for the two reference charts were measured during this
-session's probe pass (`y_top`/`y_bottom` from the long vertical-axis
-run, `x_left`/`x_right` from the long horizontal-axis run, all on
-alpha-composited images).
+Plot boxes are pulled from `referenceset/charts.py` so the calibration
+runner and the test suite use the same hand-measured boxes — see #953.
 """
 
 from __future__ import annotations
@@ -38,18 +36,31 @@ from mtfdigitizer.profiles import (
     SAMYANG_4COLOR_ALL_SOLID,
     SIGMA_2COLOR_SOLID_DASHED,
 )
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-SIGMA_56_CHART = REPO_ROOT / "docs/optical-specs/sigma-56mm-f1-4-dc-dn-c/sigma-56mm-f1-4-dc-dn-c-mtf-1.png"
-SAMYANG_85_CHART = REPO_ROOT / "docs/optical-specs/samyang-85mm-f1-4-as-if-umc/samyang-85mm-f1-4-as-if-umc-mtf.png"
+def _ref(slug: str) -> tuple[Path, PlotBox, float]:
+    """Pull (chart_path, plot_box, image_height_mm) from the reference set.
 
-# Reference plot boxes measured by axis-line search on the alpha-composited
-# reference charts. See session 99's commit message for the probe code.
-SIGMA_56_PLOT_BOX = PlotBox(x_left=186, x_right=2987, y_top=83, y_bottom=1700)
-SAMYANG_85_MAX_PLOT_BOX = PlotBox(x_left=31, x_right=461, y_top=43, y_bottom=463)
+    Tests use the same plot boxes the calibration runner uses, so re-measuring
+    one only happens in `referenceset/charts.py`.
+    """
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == slug)
+    assert chart.plot_box is not None, f"{slug}: no plot_box in referenceset"
+    box = PlotBox(
+        x_left=chart.plot_box.x_left,
+        x_right=chart.plot_box.x_right,
+        y_top=chart.plot_box.y_top,
+        y_bottom=chart.plot_box.y_bottom,
+    )
+    return REPO_ROOT / chart.chart_path, box, chart.image_height_mm
+
+
+SIGMA_56_CHART, SIGMA_56_PLOT_BOX, _ = _ref("sigma-56mm-f1-4-dc-dn-c")
+SAMYANG_85_CHART, SAMYANG_85_MAX_PLOT_BOX, _ = _ref("samyang-85mm-f1-4-as-if-umc")
 
 
 # --- Acceptance: 11 fixed points ------------------------------------------

--- a/tools/mtfdigitizer/tests/test_reference_set.py
+++ b/tools/mtfdigitizer/tests/test_reference_set.py
@@ -80,6 +80,66 @@ def test_chart_path_starts_with_docs_optical_specs() -> None:
         )
 
 
+def test_ground_truth_charts_carry_plot_box() -> None:
+    """A chart with ground truth must have a plot box (you need both
+    to run the calibration runner). The inverse is also enforced — a
+    chart with a plot box but no ground truth is unfinished work."""
+    for chart in REFERENCE_CHARTS:
+        if chart.ground_truth is not None:
+            assert chart.plot_box is not None, (
+                f"{chart.slug}: has ground_truth but no plot_box"
+            )
+        if chart.plot_box is not None:
+            assert chart.ground_truth is not None, (
+                f"{chart.slug}: has plot_box but no ground_truth"
+            )
+
+
+def test_ground_truth_has_eleven_values_per_curve() -> None:
+    """The 11-point sampling grid is fixed (ADR-038 §3); ground truth
+    rows must match it. A wrong length means the row was hand-typed
+    incorrectly and would silently mis-align with the extractor output."""
+    for chart in REFERENCE_CHARTS:
+        if chart.ground_truth is None:
+            continue
+        for aperture, fields in chart.ground_truth.items():
+            for field_name, values in fields.items():
+                assert len(values) == 11, (
+                    f"{chart.slug} [{aperture}] {field_name}: "
+                    f"expected 11 values, got {len(values)}"
+                )
+
+
+def test_ground_truth_values_in_mtf_range() -> None:
+    """MTF values must sit in [0, 1] — anything outside is a typo."""
+    for chart in REFERENCE_CHARTS:
+        if chart.ground_truth is None:
+            continue
+        for aperture, fields in chart.ground_truth.items():
+            for field_name, values in fields.items():
+                for i, v in enumerate(values):
+                    if v is None:
+                        continue
+                    assert 0.0 <= v <= 1.0, (
+                        f"{chart.slug} [{aperture}] {field_name}[{i}] = {v}: "
+                        f"out of MTF range [0, 1]"
+                    )
+
+
+def test_ground_truth_field_names_are_canonical() -> None:
+    """Field names must match the SampledReading schema in pipeline/types.py."""
+    canonical = {"contrast10S", "contrast10M", "resolution30S", "resolution30M"}
+    for chart in REFERENCE_CHARTS:
+        if chart.ground_truth is None:
+            continue
+        for aperture, fields in chart.ground_truth.items():
+            unknown = set(fields) - canonical
+            assert not unknown, (
+                f"{chart.slug} [{aperture}]: unknown fields {unknown}; "
+                f"must be a subset of {canonical}"
+            )
+
+
 # Note: a specs-log.md check belongs to a project-wide audit, not to the
 # reference-set sanity tests. CLAUDE.md §1.2 requires it for every lens
 # folder; verifying that is out of scope for #933 and tracked separately.


### PR DESCRIPTION
Closes #953 — the offset-distribution half of the calibration defined in `REFERENCE_SET.md` §"What 'calibration against the set' actually means".

The render-match IoU half is still blocked on the confidence-signal sub-task of #932 and is explicitly out of scope here.

## What changed

- `referenceset/charts.py` — `ReferenceChart` extended with optional `plot_box` + `ground_truth` fields. Three of eight charts populated (the runnable subset whose `style_family` has a declared profile today).
- `calibrate.py` — `py -m mtfdigitizer.calibrate` runs `extract_chart()` against every chart with both fields populated; reports per-field median |d|, p95 |d|, paired count, and an aggregate.
- `referenceset/calibration.md` — first run's numbers + findings.
- `tests/test_pipeline.py` — pulls plot boxes from `charts.py` instead of duplicating them locally, so re-measuring lives in one place.
- `tests/test_reference_set.py` — new invariant tests on the ground-truth shape (length 11, MTF range, canonical field names, paired with plot box).

## Findings (full write-up in `referenceset/calibration.md`)

- Aggregate median |d| = 0.015, p95 = 0.037, max = 0.147; 96.7% within ±0.05. The proposed offset tolerance band is justified by data — don't move it on this run.
- The idealized-flat case (Samyang 300mm reflex) traces at median |d| = 0.017 — confirms the ADR-038 §4 prediction that render-match alone scores this chart well, and only the plausibility prior can flag it correctly.
- Two real issues surfaced and filed:
  - **#954** — `extract_chart()` returns `None` at positions 0.0 and 1.0 on the Sigma chart; bracket-window straddles the y-axis label region.
  - Samyang's `30S-dark-grey` HSV band was calibrated on the 85mm chart; the 300mm reflex renders that curve at V≈190 outside the declared V∈[85,115] band, so 30S reads `None` everywhere. ADR-038 §4 brand-page-rendering-varies finding observed in the wild. No follow-up filed yet — likely needs profile-tuning convention discussion before a fix.

## Out of scope / what calibration is still missing

- Render-match IoU scorer (blocks tuning the 0.75 threshold).
- Calibration coverage for the other 5 reference charts (blocked on their profile declaration).
- Cross-chart HSV calibration (the 30S finding).

The 0.75 render-match threshold remains the proposed starting value. It is **not** tuned by this PR — the data needed to tune it does not yet exist.

## Quality

- 43 tests pass (`py -m pytest mtfdigitizer/` from `tools/`)
- Calibration runner reproduces stable numbers
- `tools/` is excluded from `npm run validate` per CLAUDE.md §1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
