### PR TITLE
fix(mtfdigitizer): re-measure Sigma 56mm plot box to data-edge convention (#954)

### DIFF
--- a/tools/mtfdigitizer/README.md
+++ b/tools/mtfdigitizer/README.md
@@ -78,6 +78,14 @@ Other combinations raise `NotImplementedError` (fail loud).
   hard and out of scope for #935. Test fixtures hardcode the reference
   charts' boxes; production callers will need a detector or per-chart
   hand entry until that task lands.
+- **Plot-box convention is data-edge, not axis-line.** Corners are the
+  first/last column with skeleton pixels, not the printed y-axis or
+  legend lines. On many charts these coincide (Samyang); on others the
+  printed axis sits 100+ pixels left of the first data column (Sigma).
+  Measuring to the axis line causes fraction-0.0 samples to return
+  `None` because the ±3 bracket window misses the first data column.
+  See #954 for the diagnosis and `referenceset/calibration.md` for the
+  measurement procedure.
 - **Samyang pink 10M reads low at the edge** — anti-aliased pink fades
   below the saturation threshold near the chart edge, dropping curve
   pixels. The 0.10-0.20 divergence at the edge is within the band PR

--- a/tools/mtfdigitizer/referenceset/calibration.md
+++ b/tools/mtfdigitizer/referenceset/calibration.md
@@ -38,16 +38,16 @@ Reads the in-source ground truth from `referenceset/charts.py` and runs
 populated. Output: per-chart `|d|` (absolute offset) median + p95 per
 field, then an aggregate.
 
-## Run from 2026-05-30 (commit before this write-up)
+## Run 2 (after #954 plot-box fix)
 
 ### Per-chart
 
 ```
 sigma-56mm-f1-4-dc-dn-c (mainstream-2color-solid-dashed)
-  contrast10S     med |d| 0.007  p95 |d| 0.044  paired  9/11  ext-None  2
-  contrast10M     med |d| 0.009  p95 |d| 0.024  paired  2/11  ext-None  9
-  resolution30S   med |d| 0.009  p95 |d| 0.034  paired  9/11  ext-None  2
-  resolution30M   med |d| 0.009  p95 |d| 0.025  paired  2/11  ext-None  9
+  contrast10S     med |d| 0.006  p95 |d| 0.039  paired 11/11  ext-None  0
+  contrast10M     med |d| 0.014  p95 |d| 0.094  paired  3/11  ext-None  8
+  resolution30S   med |d| 0.007  p95 |d| 0.044  paired 11/11  ext-None  0
+  resolution30M   med |d| 0.013  p95 |d| 0.015  paired  2/11  ext-None  9
 
 samyang-85mm-f1-4-as-if-umc (mainstream-4color-all-solid)
   contrast10S     med |d| 0.016  p95 |d| 0.029  paired 11/11  ext-None  0
@@ -60,6 +60,50 @@ samyang-300mm-f6-3-ed-umc-cs-reflex (idealized-flat)
   contrast10M     med |d| 0.012  p95 |d| 0.019  paired 10/11  ext-None  1
   resolution30S   med |d|   -    p95 |d|   -    paired  0/11  ext-None 11
   resolution30M   med |d| 0.021  p95 |d| 0.024  paired  5/11  ext-None  6
+```
+
+### Aggregate
+
+```
+paired comparisons:    97
+median |d|:           0.0143
+p95 |d|:              0.0400
+max |d|:              0.1467
+within +/-0.05:       93/97 (95.9%)
+```
+
+### What changed since run 1
+
+| Metric                | Run 1 (axis-line box) | Run 2 (data-edge box) |
+| --------------------- | --------------------- | --------------------- |
+| Sigma 10S paired      | 9/11                  | **11/11**             |
+| Sigma 30S paired      | 9/11                  | **11/11**             |
+| Sigma 10M paired      | 2/11                  | **3/11**              |
+| Aggregate paired      | 92                    | **97**                |
+| Median \|d\|          | 0.0147                | **0.0143**            |
+| p95 \|d\|             | 0.0366                | 0.0400                |
+| Within ±0.05          | 96.7%                 | 95.9%                 |
+
+5 paired comparisons recovered at the chart edges. The p95 and "within
+±0.05" numbers move slightly the wrong way because the recovered Sigma
+boundary readings sit further from ground truth than the interior ones
+do (Sigma 10S p95 went from 0.044 to 0.039, but 30S p95 went from 0.034
+to 0.044 — picking up the boundary point on a steeper curve adds a
+higher-error data point). Net: more honest data, similar quality.
+
+## Run from 2026-05-30 (run 1, pre-#954-fix, for reference)
+
+Original run before the Sigma plot-box was re-measured. The numbers
+above ("Run 2") supersede this; kept here for diff context.
+
+### Per-chart
+
+```
+sigma-56mm-f1-4-dc-dn-c (mainstream-2color-solid-dashed)
+  contrast10S     med |d| 0.007  p95 |d| 0.044  paired  9/11  ext-None  2
+  contrast10M     med |d| 0.009  p95 |d| 0.024  paired  2/11  ext-None  9
+  resolution30S   med |d| 0.009  p95 |d| 0.034  paired  9/11  ext-None  2
+  resolution30M   med |d| 0.009  p95 |d| 0.025  paired  2/11  ext-None  9
 ```
 
 ### Aggregate
@@ -81,21 +125,26 @@ comparisons land within ±0.05. The band's lower anchor (the #931 trace
 noise floor at Δ ≈ 0.023) sits cleanly between this median and the p95
 of 0.037. No reason to tighten or loosen.
 
-### 2. Plot-box boundaries clip data on the Sigma chart
+### 2. Plot-box boundary clipping was a convention mismatch (RESOLVED #954)
 
-`extract_chart()` returns `None` for **all four fields at positions
-0.00mm and 14.00mm** on the Sigma 56mm chart, but returns clean values
-on the same positions for both Samyang charts. The cause is the bracket
-window: at fraction 0.0 the window scans `[x_left - 3, x_left + 3]`,
-which sits in the y-axis label region on the Sigma chart but in the
-plot region on the Samyangs (because the Samyang plot box is measured
-tighter).
+Run 1 returned `None` for all four Sigma fields at fractions 0.0 and
+1.0. Root cause: the Sigma plot box was measured to the printed y-axis
+line (x=186), but the leftmost curve column sits at x=311 — a 125-pixel
+whitespace gap that exceeds the ±3 bracket window. The Samyang reference
+charts use a different convention (plot box measured to the first/last
+data column), which is why they extracted cleanly at the same fractions.
 
-This is a real defect surfaced by calibration — not a tolerance
-question. It costs 8 paired comparisons today (2 positions × 4 fields)
-and would cost more on any chart where the plot box doesn't include the
-axis line cleanly. Worth a follow-up issue against `pipeline/sampling.py`
-or `referenceset/charts.py` plot-box conventions.
+Fix: re-measure the Sigma plot box to `(309, 2980)`, aligned with the
+printed "0" and "12.5" tick label positions (verified by tick-spacing
+probe). The data-edge convention is now the project-wide standard.
+Bracket window stays at ±3 — widening it (tried during the fix) catches
+the Sigma edges but pulls in extra anti-aliased pixels on the Samyang
+charts and degrades their edge readings by 0.02–0.04.
+
+Convention for future plot-box measurements: **plot box corners are the
+first/last column with skeleton pixels, not the printed axis lines.**
+The two conventions can coincide (Samyang) or not (Sigma) — never
+assume.
 
 ### 3. The Samyang profile's dark-grey HSV band is brand-page-specific
 
@@ -149,7 +198,8 @@ this data alone**.
 Open items before the threshold conversation can close:
 
 - Render-match scorer (epic #932 confidence-signal sub-task).
-- Plot-box bracket-window fix or convention clarification — finding 2.
 - Cross-chart HSV calibration for the Samyang grey bands — finding 3.
 - Calibration coverage for the other 5 reference charts as their
   profiles are declared.
+
+Resolved since run 1: finding 2 (plot-box convention) — see fix #954.

--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -140,7 +140,15 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
         notes="canonical clean chart; 10S/M flat ~0.97 to 10mm then dips; 30S falls 0.86→0.3 at edge",
-        plot_box=PlotBoxCoords(x_left=186, x_right=2987, y_top=83, y_bottom=1700),
+        # Plot-box convention: corners at the **data edge**, not at the
+        # printed axis lines. Sigma's printed y-axis sits at x=186 but
+        # the leftmost curve column is x=311; the printed x-axis ends
+        # at x=2987 but the rightmost curve column is x=2980. Measuring
+        # to the data edge makes fraction-0.0 and fraction-1.0 samples
+        # land inside the curve mask. Verified by tick-position probe:
+        # the printed "0" tick is at x=309, "12.5" tick at x=2694, and
+        # image_height_mm=14.0 extends 1.5mm past "12.5" to x=2980. (#954)
+        plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
         ground_truth=_SIGMA_56_GT,
     ),
     ReferenceChart(

--- a/tools/mtfdigitizer/tests/test_pipeline.py
+++ b/tools/mtfdigitizer/tests/test_pipeline.py
@@ -236,6 +236,34 @@ def test_sigma_56_10S_holds_high_until_knee() -> None:
     )
 
 
+def test_sigma_56_reads_at_both_chart_edges() -> None:
+    """#954 regression — extract_chart MUST return a value at fractions
+    0.0 and 1.0 on the Sigma chart. Both edges returned None before the
+    plot-box convention was fixed (axis-line measurement instead of
+    data-edge). A future re-measurement that drifts back to the axis
+    line would silently re-break boundary readings."""
+    result = extract_chart(
+        SIGMA_56_CHART,
+        SIGMA_2COLOR_SOLID_DASHED,
+        SIGMA_56_PLOT_BOX,
+        image_height_mm=14.0,
+    )
+    center = result.readings[0]   # fraction 0.0
+    edge = result.readings[-1]    # fraction 1.0
+    assert center.contrast10S is not None, (
+        "Sigma 10S at fraction 0.0 must read a value, not None (#954)"
+    )
+    assert center.resolution30S is not None, (
+        "Sigma 30S at fraction 0.0 must read a value, not None (#954)"
+    )
+    assert edge.contrast10S is not None, (
+        "Sigma 10S at fraction 1.0 must read a value, not None (#954)"
+    )
+    assert edge.resolution30S is not None, (
+        "Sigma 30S at fraction 1.0 must read a value, not None (#954)"
+    )
+
+
 # --- Plot-box arithmetic --------------------------------------------------
 
 


### PR DESCRIPTION
Closes #954.

## Diagnosis (different from what the issue body proposed)

The issue body framed this as a bracket-window bug in `pipeline/sampling.py`. The real cause turned out to be a plot-box convention mismatch between the Sigma reference chart and the Samyang ones:

- **Samyang charts:** plot box measured to the first/last column with skeleton pixels (data-edge convention). First-data column sits +2 px from `x_left`; the existing ±3 bracket window catches it.
- **Sigma chart:** plot box measured to the printed y-axis line. First-data column sits +125 px from `x_left` because there's a wide whitespace gap between the y-axis and the first plotted curve. The ±3 window scans `[186, 189]` — pure axis-line region, no curve pixels — and returns `None`.

The bracket window doesn't need to change. The plot box does.

## Fix

Re-measure Sigma's plot box to `(309, 2980)`:
- `x_left = 309` aligned to the printed "0" tick label position (verified by tick-spacing probe — the chart's printed ticks "0, 2.5, 5, 7.5, 10, 12.5" sit at predictable linear-spaced positions).
- `x_right = 2980` aligned to the last column with curve data. `image_height_mm = 14.0` extends 1.5mm past the printed "12.5" tick, which lands cleanly at 2980.

Document the data-edge convention in `tools/mtfdigitizer/README.md` so future plot-box measurements don't drift back to the axis-line convention.

## Verification

Calibration runner numbers:

| Metric                | Run 1 (axis-line box) | Run 2 (data-edge box) |
| --------------------- | --------------------- | --------------------- |
| Sigma 10S paired      | 9/11                  | **11/11**             |
| Sigma 30S paired      | 9/11                  | **11/11**             |
| Sigma 10M paired      | 2/11                  | **3/11**              |
| Aggregate paired      | 92                    | **97**                |
| Median \|d\|          | 0.0147                | **0.0143**            |
| p95 \|d\|             | 0.0366                | 0.0400                |
| Within ±0.05          | 96.7%                 | 95.9%                 |

5 paired comparisons recovered. The p95 and within-band numbers move slightly because the recovered Sigma boundary points land on steeper sections of the curve and are noisier — same as picking up any "harder" data points. Net: more honest data at similar quality.

## What I tried first that didn't work

I initially also widened the bracket window at fractions 0.0 and 1.0 to ±6 px (`_BRACKET_HALF_WIDTH_BOUNDARY`). With the data-edge plot box, this is unnecessary — the ±3 window already catches the +2 px first-data offset on Samyang charts. Worse, on the Samyang charts where the curve drops steeply at the edge, ±6 pulled in more pixel rows and shifted the median MTF reading by 0.02–0.04 (the wrong direction). Reverted.

## Quality

- 44 tests pass (added `test_sigma_56_reads_at_both_chart_edges` as a regression guard — without the plot-box fix it fails on all four Sigma fields at fractions 0.0 and 1.0)
- Calibration runner stable across re-runs

## Files

- `tools/mtfdigitizer/referenceset/charts.py` — Sigma plot box `(186, 2987)` → `(309, 2980)`, with comment explaining the convention.
- `tools/mtfdigitizer/tests/test_pipeline.py` — new regression test.
- `tools/mtfdigitizer/referenceset/calibration.md` — run 2 numbers + finding 2 marked resolved.
- `tools/mtfdigitizer/README.md` — convention documented in "Known limits, deferred".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
