### PR TITLE
feat(mtfdigitizer): render-match IoU scorer + shared dispatch (#963)

### DIFF
--- a/tools/mtfdigitizer/pipeline/__init__.py
+++ b/tools/mtfdigitizer/pipeline/__init__.py
@@ -26,17 +26,24 @@ The pipeline retains the three sound parts of the legacy
 Public surface:
 
 - `extract_chart(image_path, profile, image_height_mm) -> ExtractedChart`
+- `score_chart(image_path, profile, plot_box, image_height_mm, readings)
+   -> RenderMatchScore` — round-trip IoU confidence signal (#963)
 - `SAMPLE_POINTS` — the 11 fractional sample heights (0.0, 0.1, ..., 1.0)
 - `PlotBox`, `ExtractedChart`, `SampledReading` (types)
+- `FieldIou`, `RenderMatchScore` (render-match types)
 """
 
 from .pipeline import extract_chart, SAMPLE_POINTS
+from .rendermatch import FieldIou, RenderMatchScore, score_chart
 from .types import ExtractedChart, PlotBox, SampledReading
 
 __all__ = [
     "ExtractedChart",
+    "FieldIou",
     "PlotBox",
+    "RenderMatchScore",
     "SAMPLE_POINTS",
     "SampledReading",
     "extract_chart",
+    "score_chart",
 ]

--- a/tools/mtfdigitizer/pipeline/dispatch.py
+++ b/tools/mtfdigitizer/pipeline/dispatch.py
@@ -1,0 +1,122 @@
+"""Profile dispatch: hue masks → committed-field skeletons (#963).
+
+Both the extractor (`pipeline.py`) and the render-match scorer
+(`rendermatch.py`) need the same answer to the same question: given a
+declared profile and a chart image, which of the four committed fields
+({10S, 10M, 30S, 30M}) does each curve in the image map to, and where
+does the skeleton for that field sit?
+
+`field_skeletons()` is that single answer. It dispatches on
+`(style_axis, hue_meaning)` exactly once, runs the hue mask + skeleton +
+S/M split pipeline, and returns a `dict[field_name, skeleton_mask]`.
+
+Out-of-band combinations raise `NotImplementedError` — generalizing PR
+#931's B1 fail-loud gate. Two combinations are currently wired:
+
+- `(SPLIT_BY_DASH, FREQUENCY)` — Sigma dialect: each hue is a frequency,
+  CC-width split gives S/M per hue.
+- `(HUE_IS_CURVE, CURVE_IDENTITY)` — Samyang dialect: each hue uniquely
+  identifies one curve; the name encodes both frequency and S/M.
+"""
+
+from __future__ import annotations
+
+import re
+
+import cv2
+import numpy as np
+
+from ..profiles.types import MtfProfile
+from .masks import masks_by_curve_name
+from .skeleton import close_and_skeletonize
+from .split import split_sm_by_cc_width
+
+
+# Curve-identity hue names follow `<freq><sm>-<color-tag>` (e.g.
+# "10S-red", "30M-light-grey"). The regex is anchored to enforce the
+# convention — a typo in `declared.py` should fail loud here, not
+# silently mis-map.
+_CURVE_IDENTITY_NAME = re.compile(r"^(?P<freq>\d{2})(?P<sm>[SM])(?:-.+)?$")
+
+
+# Map (frequency, S/M) → committed-data field name. None when the
+# combination is not part of the canonical (10S, 10M, 30S, 30M) set
+# (the schema in `src/types/mtf.ts`).
+_FIELD_BY_KEY: dict[tuple[int, str], str] = {
+    (10, "S"): "contrast10S",
+    (10, "M"): "contrast10M",
+    (30, "S"): "resolution30S",
+    (30, "M"): "resolution30M",
+}
+
+
+def curve_field(freq_lpmm: int, sm: str) -> str | None:
+    """Map (frequency, S/M) → committed-data field name, or None when
+    the combination is not part of the canonical (10S, 10M, 30S, 30M) set."""
+    return _FIELD_BY_KEY.get((freq_lpmm, sm))
+
+
+def parse_curve_identity_name(name: str) -> tuple[int, str]:
+    """Parse a `CURVE_IDENTITY` hue name like '10S-red' → (10, 'S')."""
+    m = _CURVE_IDENTITY_NAME.match(name)
+    if not m:
+        raise ValueError(
+            f"profile uses hue_meaning='CURVE_IDENTITY' but hue name {name!r} "
+            f"does not follow the '<freq><sm>-<color>' convention "
+            f"(e.g. '10S-red', '30M-light-grey')"
+        )
+    return int(m.group("freq")), m.group("sm")
+
+
+def unique_named_hues(profile: MtfProfile) -> tuple[str, ...]:
+    """Distinct hue names in declaration order (wrap-around collapsed)."""
+    seen: list[str] = []
+    for hue in profile.hues:
+        if hue.name not in seen:
+            seen.append(hue.name)
+    return tuple(seen)
+
+
+def field_skeletons(
+    bgr: np.ndarray, profile: MtfProfile
+) -> dict[str, np.ndarray]:
+    """Run hue masking → skeleton → S/M split, keyed by committed field.
+
+    Output: ``{field_name: uint8 skeleton mask}``. Fields with no
+    detectable curve in the image are simply absent — callers tolerate
+    missing keys (the sampler treats them as missing data, the IoU
+    scorer treats them as the "skeleton side empty" case).
+    """
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    curve_masks = masks_by_curve_name(hsv, profile)
+
+    out: dict[str, np.ndarray] = {}
+
+    if profile.style_axis == "SPLIT_BY_DASH" and profile.hue_meaning == "FREQUENCY":
+        # Each hue = one frequency. After skeletonize+CC-split, S=solid, M=dashed.
+        freq_by_color = dict(zip(unique_named_hues(profile), profile.frequencies_lpmm))
+        for color_name, mask in curve_masks.items():
+            skeleton = close_and_skeletonize(mask)
+            split = split_sm_by_cc_width(skeleton)
+            freq = freq_by_color[color_name]
+            for sm, sk in (("S", split.sagittal), ("M", split.meridional)):
+                field = curve_field(freq, sm)
+                if field is not None:
+                    out[field] = sk
+    elif (
+        profile.style_axis == "HUE_IS_CURVE"
+        and profile.hue_meaning == "CURVE_IDENTITY"
+    ):
+        for hue_name, mask in curve_masks.items():
+            freq, sm = parse_curve_identity_name(hue_name)
+            skeleton = close_and_skeletonize(mask)
+            field = curve_field(freq, sm)
+            if field is not None:
+                out[field] = skeleton
+    else:
+        raise NotImplementedError(
+            f"profile dispatch not implemented: style_axis={profile.style_axis!r}, "
+            f"hue_meaning={profile.hue_meaning!r}"
+        )
+
+    return out

--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -1,82 +1,31 @@
 """Top-level pipeline orchestrator (#935, ADR-038 §2-3).
 
-Composes the small stages from `masks.py`, `skeleton.py`, `split.py`,
-and `sampling.py` into one extraction. Dispatch on `profile.style_axis`
-and `profile.hue_meaning` to wire stages correctly per dialect.
-
-Curve-name → output-field mapping:
-
-- `style_axis == "SPLIT_BY_DASH"` and `hue_meaning == "FREQUENCY"`
-  (Sigma dialect): each hue is a frequency; CC-split gives S/M per
-  hue. So {red→10, blue→30} × {S, M} = {10S, 10M, 30S, 30M}.
-- `style_axis == "HUE_IS_CURVE"` and `hue_meaning == "CURVE_IDENTITY"`
-  (Samyang dialect): the hue name already encodes both frequency and
-  S/M, e.g. "10S-red" or "30M-light-grey". The name is parsed to map
-  directly.
-
-Other combinations are not yet declared and raise `NotImplementedError`
-(fail loud, per the ADR-038 §1 spirit).
+Reads chart → dispatches per profile dialect → samples each curve at the
+11 fixed points. The "which curve becomes which committed field" logic
+lives in `dispatch.field_skeletons()` so the render-match scorer reuses
+the same answer the extractor computes (#963).
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from ..loader import load_chart_bgr
-import cv2
-
 from ..profiles.types import MtfProfile
-from .masks import masks_by_curve_name
+from .dispatch import field_skeletons
 from .sampling import (
     SAMPLE_FRACTIONS,
     sample_positions_mm,
     sample_skeleton_at_fraction,
 )
-from .skeleton import close_and_skeletonize
-from .split import split_sm_by_cc_width
 from .types import ExtractedChart, PlotBox, SampledReading
 
 
 SAMPLE_POINTS: tuple[float, ...] = SAMPLE_FRACTIONS  # re-export
 
 
-# Curve-identity hue names follow `<freq><sm>-<color-tag>` (e.g. "10S-red",
-# "30M-light-grey"). The freq prefix is one of `10`, `20`, `30`, `40`; the
-# sm letter is `S` or `M`. The regex is anchored to enforce the convention
-# — a typo in `declared.py` should fail loud here, not silently mis-map.
-_CURVE_IDENTITY_NAME = re.compile(r"^(?P<freq>\d{2})(?P<sm>[SM])(?:-.+)?$")
-
-
-_FIELD_BY_KEY: dict[tuple[int, str], str] = {
-    (10, "S"): "contrast10S",
-    (10, "M"): "contrast10M",
-    (30, "S"): "resolution30S",
-    (30, "M"): "resolution30M",
-}
-
-
-def _curve_field(freq_lpmm: int, sm: str) -> str | None:
-    """Map (frequency, S/M) → committed-data field name, or None when
-    the combination is not part of the canonical (10S, 10M, 30S, 30M) set
-    (the schema in `src/types/mtf.ts`)."""
-    return _FIELD_BY_KEY.get((freq_lpmm, sm))
-
-
-def _parse_curve_identity_name(name: str) -> tuple[int, str]:
-    """Parse a `CURVE_IDENTITY` hue name like '10S-red' → (10, 'S')."""
-    m = _CURVE_IDENTITY_NAME.match(name)
-    if not m:
-        raise ValueError(
-            f"profile uses hue_meaning='CURVE_IDENTITY' but hue name {name!r} "
-            f"does not follow the '<freq><sm>-<color>' convention "
-            f"(e.g. '10S-red', '30M-light-grey')"
-        )
-    return int(m.group("freq")), m.group("sm")
-
-
 def _sample_curve(
-    skeleton, plot_box: PlotBox, image_height_mm: float
+    skeleton, plot_box: PlotBox
 ) -> tuple[float | None, ...]:
     """11-point sample of one skeleton, returns one MTF value per fraction."""
     return tuple(
@@ -118,43 +67,14 @@ def extract_chart(
     (B2 contract — never fabricated).
 
     Raises `NotImplementedError` for profile (style_axis, hue_meaning)
-    combinations not yet wired. Two combinations are currently wired:
-
-    - (SPLIT_BY_DASH, FREQUENCY) → Sigma dialect
-    - (HUE_IS_CURVE, CURVE_IDENTITY) → Samyang dialect
+    combinations not yet wired by `dispatch.field_skeletons()`.
     """
     bgr = load_chart_bgr(image_path)
-    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
-    curve_masks = masks_by_curve_name(hsv, profile)
+    skeletons = field_skeletons(bgr, profile)
 
-    samples_per_field: dict[str, tuple[float | None, ...]] = {}
-
-    if profile.style_axis == "SPLIT_BY_DASH" and profile.hue_meaning == "FREQUENCY":
-        # Each hue = one frequency. After skeletonize+CC-split, S=solid, M=dashed.
-        freq_by_color = dict(zip(_unique_named_hues(profile), profile.frequencies_lpmm))
-        for color_name, mask in curve_masks.items():
-            skeleton = close_and_skeletonize(mask)
-            split = split_sm_by_cc_width(skeleton)
-            freq = freq_by_color[color_name]
-            for sm, sk in (("S", split.sagittal), ("M", split.meridional)):
-                field = _curve_field(freq, sm)
-                if field is not None:
-                    samples_per_field[field] = _sample_curve(sk, plot_box, image_height_mm)
-    elif (
-        profile.style_axis == "HUE_IS_CURVE"
-        and profile.hue_meaning == "CURVE_IDENTITY"
-    ):
-        for hue_name, mask in curve_masks.items():
-            freq, sm = _parse_curve_identity_name(hue_name)
-            skeleton = close_and_skeletonize(mask)
-            field = _curve_field(freq, sm)
-            if field is not None:
-                samples_per_field[field] = _sample_curve(skeleton, plot_box, image_height_mm)
-    else:
-        raise NotImplementedError(
-            f"profile dispatch not implemented: style_axis={profile.style_axis!r}, "
-            f"hue_meaning={profile.hue_meaning!r}"
-        )
+    samples_per_field: dict[str, tuple[float | None, ...]] = {
+        field: _sample_curve(skel, plot_box) for field, skel in skeletons.items()
+    }
 
     return ExtractedChart(
         source_path=str(image_path),
@@ -163,12 +83,3 @@ def extract_chart(
         image_height_mm=image_height_mm,
         readings=_readings_to_dict(samples_per_field, plot_box, image_height_mm),
     )
-
-
-def _unique_named_hues(profile: MtfProfile) -> tuple[str, ...]:
-    """Distinct hue names in declaration order (wrap-around collapsed)."""
-    seen: list[str] = []
-    for hue in profile.hues:
-        if hue.name not in seen:
-            seen.append(hue.name)
-    return tuple(seen)

--- a/tools/mtfdigitizer/pipeline/rendermatch.py
+++ b/tools/mtfdigitizer/pipeline/rendermatch.py
@@ -1,0 +1,249 @@
+"""Render-match IoU scorer (#963, ADR-038 §4 confidence signal).
+
+Round-trip check: take the extractor's own 11-point readings, redraw
+them as 1px polylines in plot-box coordinates, dilate both sides by a
+small symmetric radius, and compute Intersection-over-Union against the
+extractor's own skeleton. High IoU means "what we extracted, when
+redrawn, lands on the original curve" — sound calibration. Low IoU
+flags shape/scale errors for review.
+
+The de-risking probe summarized in epic #932 separated good extractions
+(IoU 0.64–0.87) from mis-calibrated ones (0.03–0.49). The Samyang 300mm
+"idealized-flat" case scores well for the wrong reason (no horizontal
+structure to disagree on) — render-match cannot catch it. That blind
+spot is left to the plausibility prior, a separate confidence
+sub-task; this module is honest about what it can see.
+
+Pipeline:
+
+```
+ExtractedChart.readings ─┐
+                         ├─ rasterize_readings ──┐
+                         │                       │
+                         └─ dilate_for_iou ──────┤
+                                                 ├─ iou ──► per-field IoU ─► aggregate
+chart PNG ─ field_skeletons (shared dispatch) ───┤
+                         └─ dilate_for_iou ──────┘
+```
+
+The skeleton side reuses the exact dispatch `extract_chart()` runs — so
+the comparison really is round-trip, not "compare to a second
+rendering." That's a deliberate choice over hue-mask comparison: the
+skeleton is what the extractor sampled, so IoU against it is a direct
+calibration signal, not a measure of mask-construction noise.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from ..loader import load_chart_bgr
+from ..profiles.types import MtfProfile
+from .dispatch import field_skeletons
+from .plotbox import image_height_mm_to_x_pixel
+from .sampling import SAMPLE_FRACTIONS
+from .types import PlotBox, SampledReading
+
+
+# Symmetric dilation radius applied to both the rasterized polyline and
+# the extractor's skeleton before IoU. Matched to the sampling stage's
+# `_BRACKET_HALF_WIDTH = 3` — IoU is meant to confirm "agrees within the
+# same tolerance the sampler reads with," not pixel-perfect alignment
+# that anti-aliasing and rounding would crater anyway.
+DEFAULT_DILATION_RADIUS_PX: int = 3
+
+
+# Field-name → which 11-point tuple to draw. Order matches the schema
+# in `src/types/mtf.ts` and `SampledReading`'s field order.
+CURVE_FIELDS: tuple[str, ...] = (
+    "contrast10S",
+    "contrast10M",
+    "resolution30S",
+    "resolution30M",
+)
+
+
+@dataclass(frozen=True)
+class FieldIou:
+    """IoU for one (chart, field) pair.
+
+    `score` is `None` when neither side carries any pixels — there is no
+    surface to compare and treating it as 0.0 would be a misleading
+    failure signal. `score` is 0.0 when one side has pixels and the
+    other does not (a genuine disagreement).
+    """
+
+    field: str
+    score: float | None
+    rasterized_px: int  # non-zero pixel count after dilation, redraw side
+    skeleton_px: int  # non-zero pixel count after dilation, original side
+    intersection_px: int
+    union_px: int
+
+
+@dataclass(frozen=True)
+class RenderMatchScore:
+    """Result of `score_chart()` for one chart image.
+
+    `aggregate` is the mean IoU across fields that have a defined score
+    (both sides non-empty). `None` when no field is comparable.
+    """
+
+    source_path: str
+    profile_name: str
+    field_scores: tuple[FieldIou, ...]
+    aggregate: float | None
+
+
+# --- rasterize -------------------------------------------------------
+
+
+def rasterize_readings(
+    readings: tuple[SampledReading, ...],
+    plot_box: PlotBox,
+    image_shape: tuple[int, int],
+    image_height_mm: float,
+) -> dict[str, np.ndarray]:
+    """Redraw 11-point readings as 1px polylines, one mask per field.
+
+    Output masks are the same height × width as the source image so they
+    align with the extractor's skeleton without resizing. `None` gaps
+    are honest: segments draw only between adjacent positions where both
+    endpoints carry a value (B2 contract — never bridge a None).
+
+    The y-axis is the plot box's: MTF=1 at `y_top`, MTF=0 at `y_bottom`.
+    """
+    if len(readings) != len(SAMPLE_FRACTIONS):
+        raise ValueError(
+            f"expected {len(SAMPLE_FRACTIONS)} readings, got {len(readings)}"
+        )
+    h, w = image_shape
+    masks: dict[str, np.ndarray] = {
+        field: np.zeros((h, w), dtype=np.uint8) for field in CURVE_FIELDS
+    }
+
+    # Precompute the x pixel of each sample once — same x grid for every field.
+    x_pixels = tuple(
+        int(round(image_height_mm_to_x_pixel(r.position_mm, plot_box, image_height_mm)))
+        for r in readings
+    )
+
+    for field in CURVE_FIELDS:
+        for i in range(len(readings) - 1):
+            a = getattr(readings[i], field)
+            b = getattr(readings[i + 1], field)
+            if a is None or b is None:
+                continue
+            x0, x1 = x_pixels[i], x_pixels[i + 1]
+            y0 = _mtf_to_y_pixel(a, plot_box)
+            y1 = _mtf_to_y_pixel(b, plot_box)
+            cv2.line(masks[field], (x0, y0), (x1, y1), color=1, thickness=1)
+
+    return masks
+
+
+def _mtf_to_y_pixel(mtf: float, plot_box: PlotBox) -> int:
+    """Inverse of `plotbox.y_pixel_to_mtf` — MTF value to y pixel index."""
+    mtf_clamped = max(0.0, min(1.0, mtf))
+    return int(round(plot_box.y_bottom - mtf_clamped * plot_box.height))
+
+
+# --- dilate + IoU ----------------------------------------------------
+
+
+def dilate_for_iou(
+    mask: np.ndarray, radius_px: int = DEFAULT_DILATION_RADIUS_PX
+) -> np.ndarray:
+    """Symmetric dilation by an elliptical kernel of `radius_px`.
+
+    Both the rasterized polyline and the extractor's skeleton are
+    dilated with the *same* radius before IoU. A radius of 0 is a no-op
+    that just normalizes to uint8 binary.
+    """
+    if radius_px < 0:
+        raise ValueError(f"radius_px must be non-negative, got {radius_px}")
+    binary = (mask > 0).astype(np.uint8)
+    if radius_px == 0:
+        return binary
+    size = 2 * radius_px + 1
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (size, size))
+    return cv2.dilate(binary, kernel)
+
+
+def iou(a: np.ndarray, b: np.ndarray) -> float | None:
+    """Intersection-over-Union of two binary masks.
+
+    Returns `None` when both masks are empty — there's nothing to
+    compare. Returns 0.0 when one is empty and the other is not (a
+    genuine disagreement). Otherwise returns `|A ∩ B| / |A ∪ B|`.
+    """
+    if a.shape != b.shape:
+        raise ValueError(f"mask shape mismatch: {a.shape} vs {b.shape}")
+    a_bool = a > 0
+    b_bool = b > 0
+    if not a_bool.any() and not b_bool.any():
+        return None
+    inter = int(np.logical_and(a_bool, b_bool).sum())
+    union = int(np.logical_or(a_bool, b_bool).sum())
+    return inter / union
+
+
+# --- orchestrator ---------------------------------------------------
+
+
+def score_chart(
+    image_path: str | Path,
+    profile: MtfProfile,
+    plot_box: PlotBox,
+    image_height_mm: float,
+    readings: tuple[SampledReading, ...],
+    dilation_radius_px: int = DEFAULT_DILATION_RADIUS_PX,
+) -> RenderMatchScore:
+    """Render-match IoU score for one chart.
+
+    Takes pre-extracted `readings` rather than re-running the extractor —
+    keeps this module pure and lets the caller (the scorer CLI) decide
+    whether to extract fresh or reuse a cached `ExtractedChart`.
+    """
+    bgr = load_chart_bgr(image_path)
+    h, w = bgr.shape[:2]
+    rasterized = rasterize_readings(
+        readings, plot_box, image_shape=(h, w), image_height_mm=image_height_mm
+    )
+    skeletons = field_skeletons(bgr, profile)
+
+    field_scores: list[FieldIou] = []
+    defined_scores: list[float] = []
+    for field in CURVE_FIELDS:
+        raster_mask = dilate_for_iou(rasterized[field], dilation_radius_px)
+        skel_raw = skeletons.get(field, np.zeros((h, w), dtype=np.uint8))
+        skel_mask = dilate_for_iou(skel_raw, dilation_radius_px)
+        score = iou(raster_mask, skel_mask)
+
+        a_bool = raster_mask > 0
+        b_bool = skel_mask > 0
+        field_scores.append(
+            FieldIou(
+                field=field,
+                score=score,
+                rasterized_px=int(a_bool.sum()),
+                skeleton_px=int(b_bool.sum()),
+                intersection_px=int(np.logical_and(a_bool, b_bool).sum()),
+                union_px=int(np.logical_or(a_bool, b_bool).sum()),
+            )
+        )
+        if score is not None:
+            defined_scores.append(score)
+
+    aggregate = statistics.mean(defined_scores) if defined_scores else None
+    return RenderMatchScore(
+        source_path=str(image_path),
+        profile_name=profile.name,
+        field_scores=tuple(field_scores),
+        aggregate=aggregate,
+    )

--- a/tools/mtfdigitizer/referenceset/scoring.md
+++ b/tools/mtfdigitizer/referenceset/scoring.md
@@ -1,0 +1,206 @@
+# Render-match scoring run (#963)
+
+First render-match IoU run of `score_chart()` against the reference set.
+Sister document to `calibration.md` — that one records the offset
+distribution against eye-read ground truth (the `|d|` half of
+`REFERENCE_SET.md` §"What 'calibration against the set' actually
+means"); this one records the round-trip IoU half.
+
+## Scope
+
+Same 3 of 8 reference charts that `calibrate.py` covers — the ones with
+both a declared profile in `profiles/declared.py` and a hand-measured
+plot box.
+
+| Chart                                | Style family                    | Profile used                |
+| ------------------------------------ | ------------------------------- | --------------------------- |
+| sigma-56mm-f1-4-dc-dn-c              | mainstream-2color-solid-dashed  | SIGMA_2COLOR_SOLID_DASHED   |
+| samyang-85mm-f1-4-as-if-umc (MAX)    | mainstream-4color-all-solid     | SAMYANG_4COLOR_ALL_SOLID    |
+| samyang-300mm-f6-3-ed-umc-cs-reflex (MAX) | idealized-flat              | SAMYANG_4COLOR_ALL_SOLID    |
+
+## How to reproduce
+
+```
+cd tools
+py -m mtfdigitizer.scorer
+```
+
+Runs `extract_chart()` to produce 11-point readings, then `score_chart()`
+to redraw them as 1px polylines and compute per-field IoU against the
+extractor's own dilated skeleton. Dilation radius is the
+`DEFAULT_DILATION_RADIUS_PX = 3` symmetric on both sides — matched to the
+sampling stage's bracket window.
+
+Two numbers per field:
+
+- **IoU** — `|raster ∩ skel| / |raster ∪ skel|`. The standard metric.
+- **Precision** — `|raster ∩ skel| / |raster|`. What fraction of the
+  redrawn polyline lands inside the dilated skeleton. Robust to the
+  size asymmetry between an 11-point polyline and a dense skeleton
+  trace; together with IoU it's a more honest pair than IoU alone.
+
+## Run 1 (2026-05-30)
+
+### Per-chart
+
+```
+sigma-56mm-f1-4-dc-dn-c (mainstream-2color-solid-dashed)
+  contrast10S     IoU 0.451  precision 0.634  raster 19746  skel 20522  inter 12511
+  contrast10M     IoU 0.039  precision 0.100  raster  1902  skel  3148  inter   191
+  resolution30S   IoU 0.402  precision 0.587  raster 20987  skel 21981  inter 12326
+  resolution30M   IoU 0.000  precision   -    raster     0  skel  6533  inter     0
+  aggregate IoU:                0.223
+  aggregate precision:          0.440
+
+samyang-85mm-f1-4-as-if-umc (mainstream-4color-all-solid)
+  contrast10S     IoU 0.376  precision 0.938  raster  3094  skel  7531  inter  2903
+  contrast10M     IoU 0.270  precision 0.878  raster  3086  skel  9666  inter  2709
+  resolution30S   IoU 0.174  precision 0.895  raster  3046  skel 15326  inter  2727
+  resolution30M   IoU 0.074  precision 0.734  raster  3030  skel 29179  inter  2225
+  aggregate IoU:                0.224
+  aggregate precision:          0.861
+
+samyang-300mm-f6-3-ed-umc-cs-reflex (idealized-flat)
+  contrast10S     IoU 0.468  precision 0.988  raster  3030  skel  6371  inter  2995
+  contrast10M     IoU 0.568  precision 0.990  raster  2742  skel  4752  inter  2714
+  resolution30S   IoU 0.000  precision   -    raster     0  skel 10110  inter     0
+  resolution30M   IoU 0.056  precision 0.996  raster  1224  skel 21618  inter  1219
+  aggregate IoU:                0.273
+  aggregate precision:          0.991
+```
+
+### Aggregate
+
+```
+charts scored:                3
+mean IoU:                     0.240
+median IoU:                   0.224
+mean precision:               0.764
+charts clearing IoU 0.75:     0/3
+```
+
+## Findings
+
+### 1. The IoU 0.75 starting threshold from REFERENCE_SET.md fails 3/3
+
+Median IoU is 0.224 — three quarters below the 0.75 proposed in
+`REFERENCE_SET.md` §"Render-match threshold". The threshold doesn't
+hold against actual data on the runnable subset and **must move, not
+the extractor** (per the calibration discipline that document calls
+out).
+
+Root cause is geometric, not a calibration error: the rasterized
+polyline is exactly `plot_box.width` pixels long (≈431 on Samyang,
+≈2670 on Sigma). The extractor's skeleton, after morphological close
+and skeletonization, is **2× to 8× longer per field** — branches and
+fat traces inside the same plot box. After symmetric ±3 dilation the
+skeleton's union dominates: even when the polyline lies entirely on it,
+IoU stays ≤ ~0.5.
+
+The probe ADR-038 §4 referenced (good extractions at IoU 0.64–0.87)
+likely compared two like-for-like dense traces; we have a sparse
+reconstruction vs a dense skeleton. The natural fix is one of:
+
+1. **Use precision as the threshold metric**, not IoU. Precision
+   asks the question the round-trip is actually testing: "did the
+   polyline land on the skeleton?" — read on, finding 2 makes this
+   look right.
+2. **Densify the skeleton side to a single 1px centerline per field**
+   before scoring. Closer to the probe's geometry but adds a stage
+   to maintain, and the Sigma skeleton looks structurally complex
+   enough that "centerline" may not be well-defined per column.
+3. **Lower the IoU threshold** to e.g. 0.20. Honest to the data but
+   keeps a metric that's mostly tracking pixel-count ratios.
+
+### 2. Precision cleanly separates the runnable subset
+
+Read down the precision column instead of IoU:
+
+| Chart                       | Aggregate precision |
+| --------------------------- | ------------------- |
+| Sigma 56mm                  | **0.440** (low)     |
+| Samyang 85mm                | **0.861** (high)    |
+| Samyang 300mm idealized-flat | **0.991** (highest) |
+
+That's the separation REFERENCE_SET.md hoped IoU would give. Samyang
+clears 0.85 cleanly; Sigma sits below 0.50 because two of its four
+fields (10M and 30M dashed) trace very sparsely (2/11 and 0/11 paired in
+the offset-distribution run) — so the few polyline segments that do
+draw aren't enough material for a precision argument either. Sigma 10S
+and 30S individually score precision 0.63/0.59, which is real shape
+agreement diluted by anti-aliasing at the chart edges.
+
+A precision-based threshold of ≈ 0.80 would separate clean Samyang from
+Sigma-with-sparse-dashed without false-confidence on the idealized-flat
+chart, and would match the test `test_score_chart_polyline_mostly_lands_on_skeleton`'s
+0.85 bound on per-chart Samyang data.
+
+**Tentative recommendation**: report both IoU and precision; gate
+auto-commit on precision ≥ 0.80 AND IoU ≥ 0.20. Pin this in
+REFERENCE_SET.md only after the threshold conversation in the next
+session — not from one run.
+
+### 3. The flat-axis blind spot ADR-038 §4 calls out is real
+
+Samyang 300mm reflex (all curves pinned at ~1.0) scores **precision
+0.991** — the highest of the three charts — and even on IoU clears 0.27
+which is the mean across the set. A horizontal polyline trivially lands
+on a horizontal skeleton; there's no horizontal structure to disagree
+on. Exactly the case REFERENCE_SET.md flags as needing the plausibility
+prior, not render-match. This run confirms the prior is essential —
+render-match alone would auto-commit this chart at full confidence.
+
+### 4. Sigma 30M missing (0/11 polyline pixels)
+
+Same root cause as `calibration.md` finding 6: morphological close
+bridges most Sigma dashed-M gaps but not all; 30M paired only 2/11 in
+calibration. After the polyline-gap-skip rule (no segment crosses a
+None), 9 of 10 segments have a None endpoint and don't draw, so 30M
+emits zero raster pixels. Precision is undefined, IoU is 0 (one-sided
+empty). Not a fault in the scorer — the B2 contract correctly
+propagates sparsity. Will resolve when the M-curve dashed bridging
+stage improves.
+
+### 5. Samyang 300mm 30S also missing — different root cause
+
+`calibration.md` finding 3 already noted: the Samyang 300mm chart's
+grey 30S curve renders at V ≈ 190, outside the declared
+`30S-dark-grey` HSV band `V ∈ [85, 115]` (measured on the 85mm chart).
+Result: zero skeleton pixels for 30S on the 300mm chart, zero raster
+pixels (because the extractor returned all-None for it), `IoU = None`
+(both-empty), which the scorer reports as 0.000 in aggregate output.
+
+This is a chart-rendering-varies-by-brand-page issue, not a render-match
+issue. Out of scope for the threshold conversation; in scope for the
+HSV-calibration follow-up the calibration document flagged.
+
+### 6. Skeleton sizes vary unexpectedly across fields
+
+Skeleton pixel counts on Samyang 85mm: 7531 (10S), 9666 (10M), 15326
+(30S), 29179 (30M). The 30M skeleton is **4× larger** than 10S despite
+both being one curve per field. Sigma's skeletons run 2× to 3× longer
+than Samyang's despite a similar plot-box geometry. Suggests
+skeletonization is not always producing a single 1px centerline — it
+may be branching or thickening on certain curve shapes.
+
+This is information for a future skeleton-quality task; doesn't change
+the threshold conversation but is worth flagging since render-match's
+denominator depends on it.
+
+## Threshold recommendation
+
+**Hold the 0.75 IoU threshold conversation in REFERENCE_SET.md open**
+until at least one more session, ideally informed by:
+
+- The precision-vs-IoU question (finding 1): if precision becomes the
+  primary metric, the document's "Render-match threshold" section needs
+  a rewrite, not a number tweak.
+- A second run after the Sigma dashed-bridging improves (lifts 10M/30M
+  from sparse to dense), to confirm Sigma also clears precision ≥ 0.80
+  once its dashed curves have material to compare.
+- Calibration coverage on the other 5 reference charts as their
+  profiles land — needed to confirm the threshold generalizes beyond
+  the 2 mainstream dialects we have today.
+
+In the meantime, the scorer produces stable numbers and the test suite
+guards them; the threshold can be revised without touching code.

--- a/tools/mtfdigitizer/scorer.py
+++ b/tools/mtfdigitizer/scorer.py
@@ -1,0 +1,158 @@
+"""Reference-set render-match IoU runner (#963, ADR-038 §4).
+
+Runs `extract_chart()` then `score_chart()` against every reference
+chart with both ground truth and a plot box, and reports the per-field
+IoU + a one-sided polyline-on-skeleton precision against the dilated
+skeleton — the round-trip confidence signal.
+
+Sister runner to `calibrate.py`: that one reports the offset distribution
+against ground truth (the |d| half of REFERENCE_SET.md §"What
+'calibration against the set' actually means"); this one reports the
+render-match IoU half.
+
+Usage::
+
+    cd tools
+    py -m mtfdigitizer.scorer
+
+Output: a per-chart table on stdout + an aggregate summary. No file
+writes — findings live in `referenceset/scoring.md`, which the
+maintainer updates after a run.
+"""
+
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+
+from .pipeline import PlotBox, extract_chart, score_chart
+from .pipeline.rendermatch import (
+    CURVE_FIELDS,
+    DEFAULT_DILATION_RADIUS_PX,
+    FieldIou,
+    RenderMatchScore,
+)
+from .profiles import SAMYANG_4COLOR_ALL_SOLID, SIGMA_2COLOR_SOLID_DASHED
+from .profiles.types import MtfProfile
+from .referenceset.charts import REFERENCE_CHARTS, PlotBoxCoords, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# Style family → declared profile. Same table as `calibrate.py` — kept
+# in sync by hand for now (two entries; not worth a shared module yet).
+_PROFILE_BY_STYLE: dict[str, MtfProfile] = {
+    "mainstream-2color-solid-dashed": SIGMA_2COLOR_SOLID_DASHED,
+    "mainstream-4color-all-solid": SAMYANG_4COLOR_ALL_SOLID,
+    "idealized-flat": SAMYANG_4COLOR_ALL_SOLID,  # same 4-color template
+}
+
+
+def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
+    return PlotBox(
+        x_left=coords.x_left,
+        x_right=coords.x_right,
+        y_top=coords.y_top,
+        y_bottom=coords.y_bottom,
+    )
+
+
+def _score_one(chart: ReferenceChart) -> RenderMatchScore:
+    """Run extract → score on one reference chart.
+
+    Caller filters runnable charts (plot_box + ground_truth present);
+    the ground_truth itself isn't consumed here — render-match doesn't
+    compare to eye-read values, only to the chart's own skeleton.
+    """
+    assert chart.plot_box is not None
+    profile = _PROFILE_BY_STYLE.get(chart.style_family)
+    if profile is None:
+        raise ValueError(
+            f"{chart.slug}: no declared profile for style_family={chart.style_family!r}"
+        )
+    image_path = REPO_ROOT / chart.chart_path
+    plot_box = _to_plotbox(chart.plot_box)
+    extracted = extract_chart(
+        image_path, profile, plot_box, image_height_mm=chart.image_height_mm
+    )
+    return score_chart(
+        image_path,
+        profile,
+        plot_box,
+        image_height_mm=chart.image_height_mm,
+        readings=extracted.readings,
+        dilation_radius_px=DEFAULT_DILATION_RADIUS_PX,
+    )
+
+
+def _polyline_precision(fs: FieldIou) -> float | None:
+    """`intersection / rasterized` — what fraction of the redrawn
+    polyline lands inside the dilated skeleton. Robust to the
+    sparse-polyline vs dense-skeleton size asymmetry that depresses
+    pure IoU; pairs with IoU rather than replacing it."""
+    if fs.rasterized_px == 0:
+        return None
+    return fs.intersection_px / fs.rasterized_px
+
+
+def _format_field_row(fs: FieldIou) -> str:
+    iou_s = f"{fs.score:.3f}" if fs.score is not None else "  -  "
+    prec = _polyline_precision(fs)
+    prec_s = f"{prec:.3f}" if prec is not None else "  -  "
+    return (
+        f"  {fs.field:<14}  IoU {iou_s}  precision {prec_s}  "
+        f"raster {fs.rasterized_px:6d}  skel {fs.skeleton_px:6d}  "
+        f"inter {fs.intersection_px:6d}"
+    )
+
+
+def main() -> None:
+    runnable = [c for c in REFERENCE_CHARTS if c.plot_box and c.ground_truth]
+    print(
+        f"Render-match scoring {len(runnable)} of {len(REFERENCE_CHARTS)} reference charts."
+    )
+    print(f"Dilation radius: {DEFAULT_DILATION_RADIUS_PX} px (symmetric).")
+    print()
+
+    aggregates: list[float] = []
+    precisions: list[float] = []
+    for chart in runnable:
+        result = _score_one(chart)
+        print(f"## {chart.slug} ({chart.style_family})")
+        for fs in result.field_scores:
+            print(_format_field_row(fs))
+        if result.aggregate is not None:
+            aggregates.append(result.aggregate)
+            print(f"  aggregate IoU:                {result.aggregate:.3f}")
+        else:
+            print("  aggregate IoU:                  -")
+        # Mean polyline-on-skeleton precision across defined fields.
+        precs = [_polyline_precision(fs) for fs in result.field_scores]
+        defined = [p for p in precs if p is not None]
+        if defined:
+            mean_prec = statistics.mean(defined)
+            precisions.append(mean_prec)
+            print(f"  aggregate precision:          {mean_prec:.3f}  "
+                  f"(polyline pixels landing on dilated skeleton)")
+        print()
+
+    if not aggregates:
+        print("No defined comparisons — nothing to summarize.")
+        return
+
+    print("## Aggregate (all runnable charts)")
+    print(f"  charts scored:                {len(aggregates)}")
+    print(f"  mean IoU:                     {statistics.mean(aggregates):.3f}")
+    print(f"  median IoU:                   {statistics.median(aggregates):.3f}")
+    if precisions:
+        mean_prec = statistics.mean(precisions)
+        print(f"  mean precision (polyline-on-skel): {mean_prec:.3f}")
+    print()
+    print("  Proposed REFERENCE_SET.md threshold: IoU >= 0.75 (starting value).")
+    above = sum(1 for a in aggregates if a >= 0.75)
+    print(f"  Charts clearing IoU 0.75:     {above}/{len(aggregates)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mtfdigitizer/tests/test_rendermatch.py
+++ b/tools/mtfdigitizer/tests/test_rendermatch.py
@@ -1,0 +1,327 @@
+"""Tests for the render-match IoU scorer (#963).
+
+Acceptance criteria from issue #963:
+
+- Self-IoU = 1.0; disjoint masks = 0.0; both-empty = None (not 0).
+- Rasterized polyline through known sample points hits known pixels.
+- All-None field readings produce an empty raster (no fabricated curve).
+- One-side-empty produces 0.0 (genuine disagreement, distinct from
+  "no comparison").
+- Integration smoke on a runnable reference chart returns a defined
+  aggregate score in (0, 1].
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mtfdigitizer.pipeline import (
+    PlotBox,
+    SampledReading,
+    extract_chart,
+    score_chart,
+)
+from mtfdigitizer.pipeline.rendermatch import (
+    CURVE_FIELDS,
+    DEFAULT_DILATION_RADIUS_PX,
+    dilate_for_iou,
+    iou,
+    rasterize_readings,
+)
+from mtfdigitizer.profiles import SAMYANG_4COLOR_ALL_SOLID
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _ref(slug: str) -> tuple[Path, PlotBox, float]:
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == slug)
+    assert chart.plot_box is not None
+    box = PlotBox(
+        x_left=chart.plot_box.x_left,
+        x_right=chart.plot_box.x_right,
+        y_top=chart.plot_box.y_top,
+        y_bottom=chart.plot_box.y_bottom,
+    )
+    return REPO_ROOT / chart.chart_path, box, chart.image_height_mm
+
+
+SAMYANG_85_CHART, SAMYANG_85_PLOT_BOX, SAMYANG_85_HEIGHT = _ref(
+    "samyang-85mm-f1-4-as-if-umc"
+)
+
+
+def _all_nones() -> tuple[SampledReading, ...]:
+    """11 readings with every field set to None."""
+    return tuple(
+        SampledReading(
+            position_mm=i * 2.0,
+            contrast10S=None,
+            contrast10M=None,
+            resolution30S=None,
+            resolution30M=None,
+        )
+        for i in range(11)
+    )
+
+
+def _flat_readings(value: float) -> tuple[SampledReading, ...]:
+    """11 readings with every field set to the same flat value."""
+    return tuple(
+        SampledReading(
+            position_mm=i * 2.0,
+            contrast10S=value,
+            contrast10M=value,
+            resolution30S=value,
+            resolution30M=value,
+        )
+        for i in range(11)
+    )
+
+
+# --- iou primitive --------------------------------------------------
+
+
+def test_iou_self_is_one() -> None:
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[40:60, 20:80] = 1
+    assert iou(mask, mask) == 1.0
+
+
+def test_iou_disjoint_is_zero() -> None:
+    a = np.zeros((100, 100), dtype=np.uint8)
+    b = np.zeros((100, 100), dtype=np.uint8)
+    a[10:20, 10:20] = 1
+    b[60:70, 60:70] = 1
+    assert iou(a, b) == 0.0
+
+
+def test_iou_both_empty_is_none() -> None:
+    """No surface to compare ⇒ no score (None) — not a misleading 0.0."""
+    empty = np.zeros((100, 100), dtype=np.uint8)
+    assert iou(empty, empty) is None
+
+
+def test_iou_one_side_empty_is_zero() -> None:
+    """One side has pixels, the other doesn't — that's a genuine
+    disagreement, not 'no comparison'. Distinct from both-empty."""
+    populated = np.zeros((100, 100), dtype=np.uint8)
+    populated[40:60, 20:80] = 1
+    empty = np.zeros((100, 100), dtype=np.uint8)
+    assert iou(populated, empty) == 0.0
+    assert iou(empty, populated) == 0.0
+
+
+def test_iou_half_overlap() -> None:
+    """Two equal-area rectangles sharing exactly half their pixels:
+    intersection = 50, union = 150, IoU = 1/3."""
+    a = np.zeros((100, 100), dtype=np.uint8)
+    b = np.zeros((100, 100), dtype=np.uint8)
+    a[0:10, 0:10] = 1   # 100 px
+    b[0:10, 5:15] = 1   # 100 px, 50 overlap
+    score = iou(a, b)
+    assert score is not None
+    assert score == pytest.approx(50 / 150)
+
+
+def test_iou_shape_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="shape mismatch"):
+        iou(np.zeros((10, 10), dtype=np.uint8), np.zeros((10, 11), dtype=np.uint8))
+
+
+# --- dilate ---------------------------------------------------------
+
+
+def test_dilate_zero_radius_is_noop_binary() -> None:
+    mask = np.zeros((20, 20), dtype=np.uint8)
+    mask[10, 10] = 7  # any truthy value
+    out = dilate_for_iou(mask, radius_px=0)
+    assert out.dtype == np.uint8
+    assert out[10, 10] == 1
+    assert out.sum() == 1
+
+
+def test_dilate_grows_a_single_pixel_symmetrically() -> None:
+    mask = np.zeros((30, 30), dtype=np.uint8)
+    mask[15, 15] = 1
+    out = dilate_for_iou(mask, radius_px=3)
+    # Elliptical kernel covers at least the 7×7 bounding box minus corners.
+    assert out[15, 15] == 1
+    assert out[12, 15] == 1
+    assert out[18, 15] == 1
+    assert out[15, 12] == 1
+    assert out[15, 18] == 1
+    # Outside the radius is untouched.
+    assert out[15, 22] == 0
+    assert out[22, 15] == 0
+
+
+def test_dilate_negative_radius_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        dilate_for_iou(np.zeros((10, 10), dtype=np.uint8), radius_px=-1)
+
+
+# --- rasterize ------------------------------------------------------
+
+
+def test_rasterize_flat_readings_draws_horizontal_lines() -> None:
+    """A flat MTF=0.5 should draw 4 horizontal lines (one per field) at
+    the y-pixel corresponding to mid-height of the plot box."""
+    plot_box = PlotBox(x_left=10, x_right=110, y_top=20, y_bottom=120)
+    image_height_mm = 10.0
+    readings = _flat_readings(0.5)
+    masks = rasterize_readings(
+        readings, plot_box, image_shape=(150, 200), image_height_mm=image_height_mm
+    )
+    assert set(masks.keys()) == set(CURVE_FIELDS)
+    # MTF 0.5 → y = y_bottom - 0.5*height = 120 - 50 = 70.
+    for field in CURVE_FIELDS:
+        m = masks[field]
+        assert m[70, 50] == 1, f"{field}: expected pixel at (70, 50) in flat line"
+        # Nothing drawn outside the plot box span on the x-axis.
+        assert m[70, 5] == 0
+        # Nothing drawn at other y rows (with a small tolerance for the 1px line).
+        assert m[40, 50] == 0
+
+
+def test_rasterize_skips_none_gaps() -> None:
+    """A reading with one None in the middle splits the line — no
+    bridging segment crosses the gap."""
+    plot_box = PlotBox(x_left=10, x_right=110, y_top=20, y_bottom=120)
+    image_height_mm = 10.0
+    # Flat 0.5 everywhere EXCEPT position 5 (middle) is None.
+    values: list[float | None] = [0.5] * 11
+    values[5] = None
+    readings = tuple(
+        SampledReading(
+            position_mm=i * 1.0,
+            contrast10S=v,
+            contrast10M=None,
+            resolution30S=None,
+            resolution30M=None,
+        )
+        for i, v in enumerate(values)
+    )
+    masks = rasterize_readings(
+        readings, plot_box, image_shape=(150, 200), image_height_mm=image_height_mm
+    )
+    m = masks["contrast10S"]
+    # Two segments either side of the gap should have pixels at y=70...
+    assert m[70, 30] == 1  # before the gap
+    assert m[70, 80] == 1  # after the gap
+    # ...but the x column passing through the missing sample point is empty.
+    # Position 5 of 11 over x_left=10..x_right=110 sits at x ≈ 60.
+    assert m[70, 60] == 0
+
+
+def test_rasterize_all_none_field_is_empty() -> None:
+    """If every reading is None for a field, that field's mask is all-zero —
+    no fabricated curve."""
+    plot_box = PlotBox(x_left=10, x_right=110, y_top=20, y_bottom=120)
+    masks = rasterize_readings(
+        _all_nones(),
+        plot_box,
+        image_shape=(150, 200),
+        image_height_mm=10.0,
+    )
+    for field in CURVE_FIELDS:
+        assert masks[field].sum() == 0
+
+
+def test_rasterize_wrong_length_raises() -> None:
+    plot_box = PlotBox(x_left=10, x_right=110, y_top=20, y_bottom=120)
+    not_eleven: tuple[SampledReading, ...] = _all_nones()[:5]
+    with pytest.raises(ValueError, match="expected"):
+        rasterize_readings(
+            not_eleven, plot_box, image_shape=(150, 200), image_height_mm=10.0
+        )
+
+
+def test_rasterize_clamps_out_of_range_mtf() -> None:
+    """An MTF reading outside [0, 1] (shouldn't happen post-extractor,
+    but defensive) clamps to the plot box edges rather than drawing
+    out-of-bounds."""
+    plot_box = PlotBox(x_left=10, x_right=110, y_top=20, y_bottom=120)
+    readings = _flat_readings(1.5)  # well past 1.0
+    masks = rasterize_readings(
+        readings, plot_box, image_shape=(150, 200), image_height_mm=10.0
+    )
+    # MTF clamped to 1.0 → drawn at y_top = 20.
+    m = masks["contrast10S"]
+    assert m[20, 50] == 1
+
+
+# --- integration ----------------------------------------------------
+
+
+def test_score_chart_samyang_returns_defined_aggregate() -> None:
+    """Smoke: a real reference chart trips the full pipeline and yields
+    an IoU in (0, 1]. Acceptable range is wide — the calibration runner
+    is where exact numbers are pinned; here we only assert 'sensible'."""
+    extracted = extract_chart(
+        SAMYANG_85_CHART,
+        SAMYANG_4COLOR_ALL_SOLID,
+        SAMYANG_85_PLOT_BOX,
+        image_height_mm=SAMYANG_85_HEIGHT,
+    )
+    result = score_chart(
+        SAMYANG_85_CHART,
+        SAMYANG_4COLOR_ALL_SOLID,
+        SAMYANG_85_PLOT_BOX,
+        image_height_mm=SAMYANG_85_HEIGHT,
+        readings=extracted.readings,
+    )
+    assert result.aggregate is not None
+    # ADR-038's de-risking probe: good extractions cleared 0.64. Don't
+    # pin to that here — that's the threshold-tuning conversation; this
+    # test only asserts the scorer produces a non-degenerate number.
+    assert 0.0 < result.aggregate <= 1.0
+    # Every committed field reported a row, even if `score` is None.
+    fields = {fs.field for fs in result.field_scores}
+    assert fields == set(CURVE_FIELDS)
+
+
+def test_score_chart_polyline_mostly_lands_on_skeleton() -> None:
+    """The self-consistency property the threshold ultimately gates on:
+    when you redraw the extracted readings, most of the polyline pixels
+    fall inside the (dilated) skeleton. This is intersection / rasterized
+    — a one-sided check that's robust to the geometric asymmetry between
+    a sparse 11-point reconstruction and a dense skeleton trace.
+
+    The IoU `aggregate` itself is asymmetric on this data (the skeleton
+    has many more pixels than an 11-point polyline) and lands lower than
+    the epic-#932 probe's symmetric-trace numbers. `scoring.md` records
+    the real distribution; this test only asserts the round-trip is
+    fundamentally sound on a chart we know calibrates cleanly (#953:
+    median |d| = 0.014, all 4 Samyang fields paired 11/11)."""
+    extracted = extract_chart(
+        SAMYANG_85_CHART,
+        SAMYANG_4COLOR_ALL_SOLID,
+        SAMYANG_85_PLOT_BOX,
+        image_height_mm=SAMYANG_85_HEIGHT,
+    )
+    result = score_chart(
+        SAMYANG_85_CHART,
+        SAMYANG_4COLOR_ALL_SOLID,
+        SAMYANG_85_PLOT_BOX,
+        image_height_mm=SAMYANG_85_HEIGHT,
+        readings=extracted.readings,
+        dilation_radius_px=DEFAULT_DILATION_RADIUS_PX,
+    )
+    assert result.aggregate is not None
+    # Across the 4 fields, the polyline must mostly land on the skeleton.
+    hits = []
+    for fs in result.field_scores:
+        if fs.rasterized_px == 0:
+            continue
+        hits.append(fs.intersection_px / fs.rasterized_px)
+    assert hits, "no field carried a rasterized polyline"
+    mean_precision = sum(hits) / len(hits)
+    assert mean_precision >= 0.85, (
+        f"on a cleanly-calibrated chart, ≥ 85% of polyline pixels should "
+        f"land inside the dilated skeleton; got {mean_precision:.3f}"
+    )


### PR DESCRIPTION
Closes #963. Renders the round-trip IoU half of epic #932 threshold calibration — sister to the offset distribution that landed in #955.

## What

- `tools/mtfdigitizer/pipeline/rendermatch.py` — `rasterize_readings()` redraws an `ExtractedChart`'s 11-point readings as 1px polylines (skipping `None` gaps — B2-honest), `dilate_for_iou()` symmetrically expands both sides by a radius matched to the sampling bracket, `iou()` returns `|A ∩ B| / |A ∪ B|` (None on both-empty, 0.0 on one-sided-empty), and `score_chart()` orchestrates them into a `RenderMatchScore` carrying per-field IoU + aggregate + raw pixel counts.
- `tools/mtfdigitizer/pipeline/dispatch.py` — the (style_axis, hue_meaning) → committed-field-skeleton table that both the extractor and the scorer consume. Pure refactor: `extract_chart()` produces byte-identical numbers afterwards (`py -m mtfdigitizer.calibrate` reports 97 paired, median |d| = 0.0143, the same as PR #955).
- `tools/mtfdigitizer/scorer.py` — `py -m mtfdigitizer.scorer` runs against the 3 runnable reference charts, prints per-field IoU + a polyline-on-skeleton precision side metric (intersection / rasterized), and an aggregate.
- `tools/mtfdigitizer/referenceset/scoring.md` — sister findings doc to `calibration.md`. Records the run and the threshold conversation it forces (see below).
- 16 new tests in `tests/test_rendermatch.py`. **60/60** pass (44 existing + 16 new).

## The finding that matters

The 0.75 IoU threshold proposed in `REFERENCE_SET.md` § 'Render-match threshold' **fails 3/3 charts**:

| Chart | Aggregate IoU | Aggregate precision |
| --- | --- | --- |
| Sigma 56mm | 0.223 | 0.440 |
| Samyang 85mm | 0.224 | 0.861 |
| Samyang 300mm idealized-flat | 0.273 | 0.991 |

Root cause is geometric: the rasterized polyline is ~`plot_box.width` pixels long; the skeleton is 2× to 8× longer per field (branches and thick traces). Even when the polyline lies entirely on the skeleton, the union dominates and pure IoU caps at ~0.5.

Precision separates the runnable subset cleanly (0.44 vs 0.86 vs 0.99) — that's the signal `REFERENCE_SET.md` hoped IoU would give. The doc deliberately calls precision a 'side metric' rather than renaming the gate, and defers the threshold revision (precision-based gate ≈ 0.80, or lowered IoU, or both) to a later session with the discipline 'the threshold moves, not the extractor.'

`scoring.md` writes up all six findings — including the **flat-axis blind-spot confirmed** (Samyang 300mm scores 0.99 precision while plausibility prior must fire) and **Sigma's structurally complex skeletons** (likely the skeleton pipeline emitting branches rather than 1px centerlines — separate task).

## Out of scope

- Tuning the 0.75 IoU threshold (needs this scorer's numbers to argue from — the conversation now begins).
- Plausibility priors (the flat-axis blind-spot guard).
- 3-panel review file generator / run-log auto-triage.
- SVG emitter.
- Profiles for the other 3 in-band reference families (7artisans 50mm, Tokina, Viltrox).

## Reproduce

```
cd tools
py -m mtfdigitizer.scorer
py -m mtfdigitizer.calibrate  # unchanged — confirms refactor preserves behavior
py -m pytest mtfdigitizer/    # 60 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)