### PR TITLE
feat(mtfdigitizer): SVG emitter from readings (#971)

### DIFF
--- a/docs/optical-specs/samyang-300mm-f6-3-ed-umc-cs-reflex/samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.svg
+++ b/docs/optical-specs/samyang-300mm-f6-3-ed-umc-cs-reflex/samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 218" role="img" aria-label="MTF chart, generated from readings">
+<style>.grid-line { stroke: #d8d8d8; stroke-width: 0.5; }.axis-label { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }.axis-y { text-anchor: end; }.axis-x { text-anchor: middle; }.axis-title { font-size: 7px; fill: #666666; text-anchor: middle; }.curve { fill: none; stroke-width: 1.5; }.curve-10 { stroke: #c89b3c; }.curve-30 { stroke: #6b9bd2; }.curve-m { stroke-dasharray: 4 2; }.dot { fill: white; stroke-width: 1; }.dot-10 { stroke: #c89b3c; }.dot-30 { stroke: #6b9bd2; }.legend-text { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }</style>
+<line class="grid-line" x1="36" y1="172.0" x2="304" y2="172.0"/>
+<line class="grid-line" x1="36" y1="140.0" x2="304" y2="140.0"/>
+<line class="grid-line" x1="36" y1="108.0" x2="304" y2="108.0"/>
+<line class="grid-line" x1="36" y1="76.0" x2="304" y2="76.0"/>
+<line class="grid-line" x1="36" y1="44.0" x2="304" y2="44.0"/>
+<line class="grid-line" x1="36" y1="12.0" x2="304" y2="12.0"/>
+<text class="axis-label axis-y" x="32" y="175.0">0.0</text>
+<text class="axis-label axis-y" x="32" y="143.0">0.2</text>
+<text class="axis-label axis-y" x="32" y="111.0">0.4</text>
+<text class="axis-label axis-y" x="32" y="79.0">0.6</text>
+<text class="axis-label axis-y" x="32" y="47.0">0.8</text>
+<text class="axis-label axis-y" x="32" y="15.0">1.0</text>
+<text class="axis-label axis-x" x="36.0" y="186">C</text>
+<text class="axis-label axis-x" x="62.8" y="186">1.4</text>
+<text class="axis-label axis-x" x="89.6" y="186">2.8</text>
+<text class="axis-label axis-x" x="116.4" y="186">4.2</text>
+<text class="axis-label axis-x" x="143.2" y="186">5.6</text>
+<text class="axis-label axis-x" x="170.0" y="186">7</text>
+<text class="axis-label axis-x" x="196.8" y="186">8.4</text>
+<text class="axis-label axis-x" x="223.6" y="186">9.8</text>
+<text class="axis-label axis-x" x="250.4" y="186">11.2</text>
+<text class="axis-label axis-x" x="277.2" y="186">12.6</text>
+<text class="axis-label axis-x" x="304.0" y="186">14</text>
+<text class="axis-title" x="170.0" y="198">Image height (mm)</text>
+<polyline class="curve curve-10" points="36.0,14.7 62.8,14.7 89.6,14.7 116.4,14.7 143.2,14.7 170.0,14.7 196.8,14.7 223.6,14.7 250.4,14.7 277.2,14.3 304.0,14.5"/>
+<polyline class="curve curve-10 curve-m" points="36.0,13.9 62.8,13.9 89.6,13.9 116.4,13.9 143.2,13.9 170.0,13.9 196.8,13.9 223.6,13.9 250.4,13.9 277.2,14.7" stroke-dasharray="4 2"/>
+<polyline class="curve curve-30 curve-m" points="196.8,15.4 223.6,15.4 250.4,15.4 277.2,15.8 304.0,15.8" stroke-dasharray="4 2"/>
+<circle class="dot dot-10" cx="36.0" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="62.8" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="89.6" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="116.4" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="143.2" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="170.0" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="196.8" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="250.4" cy="14.7" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="14.3" r="2"/>
+<circle class="dot dot-10" cx="304.0" cy="14.5" r="2"/>
+<circle class="dot dot-10" cx="36.0" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="62.8" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="89.6" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="116.4" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="143.2" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="170.0" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="196.8" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="250.4" cy="13.9" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="14.7" r="2"/>
+<circle class="dot dot-30" cx="196.8" cy="15.4" r="2"/>
+<circle class="dot dot-30" cx="223.6" cy="15.4" r="2"/>
+<circle class="dot dot-30" cx="250.4" cy="15.4" r="2"/>
+<circle class="dot dot-30" cx="277.2" cy="15.8" r="2"/>
+<circle class="dot dot-30" cx="304.0" cy="15.8" r="2"/>
+<line x1="36" y1="209" x2="48" y2="209" stroke="#c89b3c" stroke-width="1.5"/>
+<text class="legend-text" x="51" y="212">10 lp/mm S</text>
+<line x1="92" y1="209" x2="104" y2="209" stroke="#c89b3c" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="107" y="212">10 lp/mm M</text>
+<line x1="148" y1="209" x2="160" y2="209" stroke="#6b9bd2" stroke-width="1.5"/>
+<text class="legend-text" x="163" y="212">30 lp/mm S</text>
+<line x1="204" y1="209" x2="216" y2="209" stroke="#6b9bd2" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="219" y="212">30 lp/mm M</text>
+</svg>

--- a/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/samyang-85mm-f1-4-as-if-umc-mtf.svg
+++ b/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/samyang-85mm-f1-4-as-if-umc-mtf.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 218" role="img" aria-label="MTF chart, generated from readings">
+<style>.grid-line { stroke: #d8d8d8; stroke-width: 0.5; }.axis-label { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }.axis-y { text-anchor: end; }.axis-x { text-anchor: middle; }.axis-title { font-size: 7px; fill: #666666; text-anchor: middle; }.curve { fill: none; stroke-width: 1.5; }.curve-10 { stroke: #c89b3c; }.curve-30 { stroke: #6b9bd2; }.curve-m { stroke-dasharray: 4 2; }.dot { fill: white; stroke-width: 1; }.dot-10 { stroke: #c89b3c; }.dot-30 { stroke: #6b9bd2; }.legend-text { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }</style>
+<line class="grid-line" x1="36" y1="172.0" x2="304" y2="172.0"/>
+<line class="grid-line" x1="36" y1="140.0" x2="304" y2="140.0"/>
+<line class="grid-line" x1="36" y1="108.0" x2="304" y2="108.0"/>
+<line class="grid-line" x1="36" y1="76.0" x2="304" y2="76.0"/>
+<line class="grid-line" x1="36" y1="44.0" x2="304" y2="44.0"/>
+<line class="grid-line" x1="36" y1="12.0" x2="304" y2="12.0"/>
+<text class="axis-label axis-y" x="32" y="175.0">0.0</text>
+<text class="axis-label axis-y" x="32" y="143.0">0.2</text>
+<text class="axis-label axis-y" x="32" y="111.0">0.4</text>
+<text class="axis-label axis-y" x="32" y="79.0">0.6</text>
+<text class="axis-label axis-y" x="32" y="47.0">0.8</text>
+<text class="axis-label axis-y" x="32" y="15.0">1.0</text>
+<text class="axis-label axis-x" x="36.0" y="186">C</text>
+<text class="axis-label axis-x" x="62.8" y="186">2.2</text>
+<text class="axis-label axis-x" x="89.6" y="186">4.3</text>
+<text class="axis-label axis-x" x="116.4" y="186">6.5</text>
+<text class="axis-label axis-x" x="143.2" y="186">8.6</text>
+<text class="axis-label axis-x" x="170.0" y="186">10.8</text>
+<text class="axis-label axis-x" x="196.8" y="186">13.0</text>
+<text class="axis-label axis-x" x="223.6" y="186">15.1</text>
+<text class="axis-label axis-x" x="250.4" y="186">17.3</text>
+<text class="axis-label axis-x" x="277.2" y="186">19.4</text>
+<text class="axis-label axis-x" x="304.0" y="186">21.6</text>
+<text class="axis-title" x="170.0" y="198">Image height (mm)</text>
+<polyline class="curve curve-10" points="36.0,28.0 62.8,27.2 89.6,26.7 116.4,26.1 143.2,25.7 170.0,25.7 196.8,25.7 223.6,25.7 250.4,27.2 277.2,33.9 304.0,48.2"/>
+<polyline class="curve curve-10 curve-m" points="36.0,28.8 62.8,27.2 89.6,26.7 116.4,25.3 143.2,24.8 170.0,24.0 196.8,23.0 223.6,22.3 250.4,26.5 277.2,33.1 304.0,46.7" stroke-dasharray="4 2"/>
+<polyline class="curve curve-30" points="36.0,61.5 62.8,60.6 89.6,60.4 116.4,63.0 143.2,68.8 170.0,75.4 196.8,80.8 223.6,82.1 250.4,79.8 277.2,81.7 304.0,91.6"/>
+<polyline class="curve curve-30 curve-m" points="36.0,62.3 62.8,63.2 89.6,65.1 116.4,64.2 143.2,68.8 170.0,73.0 196.8,80.4 223.6,75.6 250.4,79.0 277.2,81.3 304.0,86.5" stroke-dasharray="4 2"/>
+<circle class="dot dot-10" cx="36.0" cy="28.0" r="2"/>
+<circle class="dot dot-10" cx="62.8" cy="27.2" r="2"/>
+<circle class="dot dot-10" cx="89.6" cy="26.7" r="2"/>
+<circle class="dot dot-10" cx="116.4" cy="26.1" r="2"/>
+<circle class="dot dot-10" cx="143.2" cy="25.7" r="2"/>
+<circle class="dot dot-10" cx="170.0" cy="25.7" r="2"/>
+<circle class="dot dot-10" cx="196.8" cy="25.7" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="25.7" r="2"/>
+<circle class="dot dot-10" cx="250.4" cy="27.2" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="33.9" r="2"/>
+<circle class="dot dot-10" cx="304.0" cy="48.2" r="2"/>
+<circle class="dot dot-10" cx="36.0" cy="28.8" r="2"/>
+<circle class="dot dot-10" cx="62.8" cy="27.2" r="2"/>
+<circle class="dot dot-10" cx="89.6" cy="26.7" r="2"/>
+<circle class="dot dot-10" cx="116.4" cy="25.3" r="2"/>
+<circle class="dot dot-10" cx="143.2" cy="24.8" r="2"/>
+<circle class="dot dot-10" cx="170.0" cy="24.0" r="2"/>
+<circle class="dot dot-10" cx="196.8" cy="23.0" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="22.3" r="2"/>
+<circle class="dot dot-10" cx="250.4" cy="26.5" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="33.1" r="2"/>
+<circle class="dot dot-10" cx="304.0" cy="46.7" r="2"/>
+<circle class="dot dot-30" cx="36.0" cy="61.5" r="2"/>
+<circle class="dot dot-30" cx="62.8" cy="60.6" r="2"/>
+<circle class="dot dot-30" cx="89.6" cy="60.4" r="2"/>
+<circle class="dot dot-30" cx="116.4" cy="63.0" r="2"/>
+<circle class="dot dot-30" cx="143.2" cy="68.8" r="2"/>
+<circle class="dot dot-30" cx="170.0" cy="75.4" r="2"/>
+<circle class="dot dot-30" cx="196.8" cy="80.8" r="2"/>
+<circle class="dot dot-30" cx="223.6" cy="82.1" r="2"/>
+<circle class="dot dot-30" cx="250.4" cy="79.8" r="2"/>
+<circle class="dot dot-30" cx="277.2" cy="81.7" r="2"/>
+<circle class="dot dot-30" cx="304.0" cy="91.6" r="2"/>
+<circle class="dot dot-30" cx="36.0" cy="62.3" r="2"/>
+<circle class="dot dot-30" cx="62.8" cy="63.2" r="2"/>
+<circle class="dot dot-30" cx="89.6" cy="65.1" r="2"/>
+<circle class="dot dot-30" cx="116.4" cy="64.2" r="2"/>
+<circle class="dot dot-30" cx="143.2" cy="68.8" r="2"/>
+<circle class="dot dot-30" cx="170.0" cy="73.0" r="2"/>
+<circle class="dot dot-30" cx="196.8" cy="80.4" r="2"/>
+<circle class="dot dot-30" cx="223.6" cy="75.6" r="2"/>
+<circle class="dot dot-30" cx="250.4" cy="79.0" r="2"/>
+<circle class="dot dot-30" cx="277.2" cy="81.3" r="2"/>
+<circle class="dot dot-30" cx="304.0" cy="86.5" r="2"/>
+<line x1="36" y1="209" x2="48" y2="209" stroke="#c89b3c" stroke-width="1.5"/>
+<text class="legend-text" x="51" y="212">10 lp/mm S</text>
+<line x1="92" y1="209" x2="104" y2="209" stroke="#c89b3c" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="107" y="212">10 lp/mm M</text>
+<line x1="148" y1="209" x2="160" y2="209" stroke="#6b9bd2" stroke-width="1.5"/>
+<text class="legend-text" x="163" y="212">30 lp/mm S</text>
+<line x1="204" y1="209" x2="216" y2="209" stroke="#6b9bd2" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="219" y="212">30 lp/mm M</text>
+</svg>

--- a/docs/optical-specs/sigma-56mm-f1-4-dc-dn-c/sigma-56mm-f1-4-dc-dn-c-mtf-1.svg
+++ b/docs/optical-specs/sigma-56mm-f1-4-dc-dn-c/sigma-56mm-f1-4-dc-dn-c-mtf-1.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 218" role="img" aria-label="MTF chart, generated from readings">
+<style>.grid-line { stroke: #d8d8d8; stroke-width: 0.5; }.axis-label { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }.axis-y { text-anchor: end; }.axis-x { text-anchor: middle; }.axis-title { font-size: 7px; fill: #666666; text-anchor: middle; }.curve { fill: none; stroke-width: 1.5; }.curve-10 { stroke: #c89b3c; }.curve-30 { stroke: #6b9bd2; }.curve-m { stroke-dasharray: 4 2; }.dot { fill: white; stroke-width: 1; }.dot-10 { stroke: #c89b3c; }.dot-30 { stroke: #6b9bd2; }.legend-text { font-size: 7px; fill: #666666; font-family: ui-monospace, monospace; }</style>
+<line class="grid-line" x1="36" y1="172.0" x2="304" y2="172.0"/>
+<line class="grid-line" x1="36" y1="140.0" x2="304" y2="140.0"/>
+<line class="grid-line" x1="36" y1="108.0" x2="304" y2="108.0"/>
+<line class="grid-line" x1="36" y1="76.0" x2="304" y2="76.0"/>
+<line class="grid-line" x1="36" y1="44.0" x2="304" y2="44.0"/>
+<line class="grid-line" x1="36" y1="12.0" x2="304" y2="12.0"/>
+<text class="axis-label axis-y" x="32" y="175.0">0.0</text>
+<text class="axis-label axis-y" x="32" y="143.0">0.2</text>
+<text class="axis-label axis-y" x="32" y="111.0">0.4</text>
+<text class="axis-label axis-y" x="32" y="79.0">0.6</text>
+<text class="axis-label axis-y" x="32" y="47.0">0.8</text>
+<text class="axis-label axis-y" x="32" y="15.0">1.0</text>
+<text class="axis-label axis-x" x="36.0" y="186">C</text>
+<text class="axis-label axis-x" x="62.8" y="186">1.4</text>
+<text class="axis-label axis-x" x="89.6" y="186">2.8</text>
+<text class="axis-label axis-x" x="116.4" y="186">4.2</text>
+<text class="axis-label axis-x" x="143.2" y="186">5.6</text>
+<text class="axis-label axis-x" x="170.0" y="186">7</text>
+<text class="axis-label axis-x" x="196.8" y="186">8.4</text>
+<text class="axis-label axis-x" x="223.6" y="186">9.8</text>
+<text class="axis-label axis-x" x="250.4" y="186">11.2</text>
+<text class="axis-label axis-x" x="277.2" y="186">12.6</text>
+<text class="axis-label axis-x" x="304.0" y="186">14</text>
+<text class="axis-title" x="170.0" y="198">Image height (mm)</text>
+<polyline class="curve curve-10" points="36.0,15.7 62.8,15.5 89.6,15.9 116.4,15.9 143.2,16.3 170.0,16.5 196.8,17.4 223.6,17.2 250.4,18.6 277.2,29.1 304.0,62.3"/>
+<polyline class="curve curve-10 curve-m" points="277.2,21.0 304.0,23.5" stroke-dasharray="4 2"/>
+<polyline class="curve curve-30" points="36.0,33.9 62.8,33.6 89.6,32.6 116.4,33.5 143.2,36.1 170.0,40.8 196.8,43.5 223.6,43.3 250.4,49.3 277.2,82.2 304.0,119.0"/>
+<circle class="dot dot-10" cx="36.0" cy="15.7" r="2"/>
+<circle class="dot dot-10" cx="62.8" cy="15.5" r="2"/>
+<circle class="dot dot-10" cx="89.6" cy="15.9" r="2"/>
+<circle class="dot dot-10" cx="116.4" cy="15.9" r="2"/>
+<circle class="dot dot-10" cx="143.2" cy="16.3" r="2"/>
+<circle class="dot dot-10" cx="170.0" cy="16.5" r="2"/>
+<circle class="dot dot-10" cx="196.8" cy="17.4" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="17.2" r="2"/>
+<circle class="dot dot-10" cx="250.4" cy="18.6" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="29.1" r="2"/>
+<circle class="dot dot-10" cx="304.0" cy="62.3" r="2"/>
+<circle class="dot dot-10" cx="223.6" cy="16.5" r="2"/>
+<circle class="dot dot-10" cx="277.2" cy="21.0" r="2"/>
+<circle class="dot dot-10" cx="304.0" cy="23.5" r="2"/>
+<circle class="dot dot-30" cx="36.0" cy="33.9" r="2"/>
+<circle class="dot dot-30" cx="62.8" cy="33.6" r="2"/>
+<circle class="dot dot-30" cx="89.6" cy="32.6" r="2"/>
+<circle class="dot dot-30" cx="116.4" cy="33.5" r="2"/>
+<circle class="dot dot-30" cx="143.2" cy="36.1" r="2"/>
+<circle class="dot dot-30" cx="170.0" cy="40.8" r="2"/>
+<circle class="dot dot-30" cx="196.8" cy="43.5" r="2"/>
+<circle class="dot dot-30" cx="223.6" cy="43.3" r="2"/>
+<circle class="dot dot-30" cx="250.4" cy="49.3" r="2"/>
+<circle class="dot dot-30" cx="277.2" cy="82.2" r="2"/>
+<circle class="dot dot-30" cx="304.0" cy="119.0" r="2"/>
+<circle class="dot dot-30" cx="170.0" cy="36.3" r="2"/>
+<circle class="dot dot-30" cx="223.6" cy="33.9" r="2"/>
+<line x1="36" y1="209" x2="48" y2="209" stroke="#c89b3c" stroke-width="1.5"/>
+<text class="legend-text" x="51" y="212">10 lp/mm S</text>
+<line x1="92" y1="209" x2="104" y2="209" stroke="#c89b3c" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="107" y="212">10 lp/mm M</text>
+<line x1="148" y1="209" x2="160" y2="209" stroke="#6b9bd2" stroke-width="1.5"/>
+<text class="legend-text" x="163" y="212">30 lp/mm S</text>
+<line x1="204" y1="209" x2="216" y2="209" stroke="#6b9bd2" stroke-width="1.5" stroke-dasharray="3 2"/>
+<text class="legend-text" x="219" y="212">30 lp/mm M</text>
+</svg>

--- a/tools/mtfdigitizer/__init__.py
+++ b/tools/mtfdigitizer/__init__.py
@@ -12,6 +12,6 @@ The package is scaffolded incrementally as epic #932 lands:
 - `pipeline/rendermatch.py` — round-trip IoU + precision scorer (#963)
 - `priors.py`       — physical-plausibility priors (#966)
 - `triage.py`       — auto-triage gate combining both signals (#968)
-- `svg.py`          — SVG emitter (from numbers)
+- `svg.py`          — SVG emitter from readings (#971)
 - `review.py`       — 3-panel review file generator
 """

--- a/tools/mtfdigitizer/svg.py
+++ b/tools/mtfdigitizer/svg.py
@@ -1,0 +1,398 @@
+"""MTF SVG emitter (#971, ADR-038 §5).
+
+Renders an ``ExtractedChart`` (the pipeline's 11-point readings) into a
+standalone SVG document, used as:
+
+1. **Provenance** — committed alongside the source PNG in
+   ``docs/optical-specs/<slug>/`` as a record of what the extractor
+   read from the chart.
+2. **Review-file right panel** — the "regenerated from readings" pane
+   in the upcoming 3-panel review file, paired against the original
+   raster and the overlay (ADR-038 §4).
+
+Lens-page display is **not** this module's job — ``src/components/
+static/MtfChart.astro`` already renders MTF SVGs at build time from the
+same ``MtfData`` shape. This module produces a Python-side artifact
+with the same visual conventions (plot box, line styles, palette) so the
+review file's right panel previews what the lens page will look like,
+without claiming byte-identity with the Astro component (their HTML
+shapes differ — scoped class hashes, whitespace, attribute order — and
+chasing byte-identity for a swap we may never want would be expensive).
+
+The single source of truth is the readings. Both renderers consume them;
+neither owns them.
+
+Usage::
+
+    cd tools
+    py -m mtfdigitizer.svg              # emit all runnable reference charts
+    py -m mtfdigitizer.svg --check      # verify outputs without writing
+
+Output paths: ``docs/optical-specs/<slug>/<chart-stem>.svg`` — one SVG
+per source PNG in the runnable reference set.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .pipeline import ExtractedChart, SampledReading, extract_chart
+from .pipeline.rendermatch import CURVE_FIELDS
+from .pipeline.types import PlotBox
+from .profiles import SAMYANG_4COLOR_ALL_SOLID, SIGMA_2COLOR_SOLID_DASHED
+from .profiles.types import MtfProfile
+from .referenceset import REFERENCE_CHARTS
+from .referenceset.charts import PlotBoxCoords, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --- visual conventions ---------------------------------------------
+#
+# Mirrors `src/components/static/MtfChart.astro`. Same viewBox, same
+# padding ratios, same line semantics (solid S / dashed M / accent for
+# 10 lp/mm, blue for 30 lp/mm). Palette is hard-coded here rather than
+# pulled from CSS custom properties: this SVG is standalone, no theme
+# context applies.
+
+_VIEWBOX_W = 320
+# The Astro component renders the legend as a sibling <div> below the
+# SVG. The provenance SVG is standalone — no sibling DOM — so its
+# legend has to live inside the viewBox. We extend the canvas by
+# `_LEGEND_STRIP_H` past the Astro component's 200px height to give the
+# legend its own row, keeping the data area visually identical.
+_LEGEND_STRIP_H = 18
+_VIEWBOX_H = 200 + _LEGEND_STRIP_H
+_PAD_TOP = 12
+_PAD_RIGHT = 16
+_PAD_BOTTOM = 28 + _LEGEND_STRIP_H
+_PAD_LEFT = 36
+
+_PLOT_W = _VIEWBOX_W - _PAD_LEFT - _PAD_RIGHT
+# The plot area sizes off the unextended 200px height so the gridlines
+# and x-axis labels land at the same coordinates as MtfChart.astro.
+_PLOT_H = 200 - _PAD_TOP - (_PAD_BOTTOM - _LEGEND_STRIP_H)
+
+# Y-axis gridlines, 0.0 to 1.0 in 0.2 steps (6 lines).
+_Y_TICKS: tuple[float, ...] = (0.0, 0.2, 0.4, 0.6, 0.8, 1.0)
+
+# Palette. The Astro component uses `var(--color-accent)` (warm gold) +
+# `#6b9bd2` (cool blue). The provenance SVG is rendered against a light
+# review panel and needs to read on white paper too, so we pick concrete
+# colors with sufficient contrast on both.
+_COLOR_10 = "#c89b3c"  # 10 lp/mm — warm gold, matches site accent
+_COLOR_30 = "#6b9bd2"  # 30 lp/mm — cool blue
+_COLOR_GRID = "#d8d8d8"
+_COLOR_AXIS_TEXT = "#666666"
+
+
+def _x_pixel(position_mm: float, max_mm: float) -> float:
+    """Map a position in mm to its x pixel inside the SVG viewBox."""
+    if max_mm <= 0:
+        raise ValueError(f"max_mm must be positive, got {max_mm}")
+    return _PAD_LEFT + (position_mm / max_mm) * _PLOT_W
+
+
+def _y_pixel(mtf: float) -> float:
+    """Map an MTF value (0..1) to its y pixel inside the SVG viewBox."""
+    return _PAD_TOP + (1.0 - mtf) * _PLOT_H
+
+
+def _polyline_segments(
+    readings: tuple[SampledReading, ...], field: str, max_mm: float
+) -> list[str]:
+    """Return one SVG ``points=`` string per continuous run of non-None values.
+
+    A ``None`` at any position breaks the polyline — segments draw only
+    between adjacent positions where both endpoints carry a value (the
+    B2 contract; matches ``rasterize_readings`` in
+    ``pipeline/rendermatch.py``). A single-point run is dropped: a
+    polyline with one vertex is invisible and adds noise to the DOM.
+    """
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for reading in readings:
+        value = getattr(reading, field)
+        if value is None:
+            if len(current) >= 2:
+                segments.append(current)
+            current = []
+            continue
+        x = _x_pixel(reading.position_mm, max_mm)
+        y = _y_pixel(value)
+        current.append(f"{x:.1f},{y:.1f}")
+    if len(current) >= 2:
+        segments.append(current)
+    return [" ".join(s) for s in segments]
+
+
+def _field_style(field: str) -> tuple[str, str]:
+    """Return (stroke_color, dash_array_or_empty) for one committed field."""
+    match field:
+        case "contrast10S":
+            return _COLOR_10, ""
+        case "contrast10M":
+            return _COLOR_10, "4 2"
+        case "resolution30S":
+            return _COLOR_30, ""
+        case "resolution30M":
+            return _COLOR_30, "4 2"
+        case _:
+            raise ValueError(f"unknown field: {field}")
+
+
+def _format_position_label(position_mm: float) -> str:
+    """Center reads as 'C'; positive positions print as plain numbers."""
+    if position_mm == 0:
+        return "C"
+    if position_mm == int(position_mm):
+        return str(int(position_mm))
+    return f"{position_mm:.1f}"
+
+
+def render_svg(chart: ExtractedChart) -> str:
+    """Render an ``ExtractedChart`` to a standalone SVG document.
+
+    The SVG carries its own ``<style>`` block so it stands alone in a
+    file viewer or a review-file composition — no external CSS, no theme
+    context. The 11 sample points appear as polyline vertices and as
+    dots, matching ``MtfChart.astro``'s convention.
+
+    Visual choices:
+
+    - Plot box (320x200, pad 12/16/28/36) mirrors the Astro component
+      so a side-by-side review file reads as the same chart.
+    - 10 lp/mm uses warm gold; 30 lp/mm uses cool blue. S is solid, M
+      dashed. The chart's source PNG conventions are not mimicked — the
+      provenance SVG always uses the digitizer's own palette so a
+      maintainer scanning many review files reads the same color for
+      "10S" regardless of the source brand.
+    - ``None`` readings break the polyline at that vertex (B2 contract).
+    """
+    max_mm = chart.image_height_mm
+    body: list[str] = []
+
+    body.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {_VIEWBOX_W} {_VIEWBOX_H}" '
+        f'role="img" aria-label="MTF chart, generated from readings">'
+    )
+    body.append(_render_style_block())
+    body.extend(_render_grid())
+    body.extend(_render_y_axis_labels())
+    body.extend(_render_x_axis_labels(chart.readings))
+    body.append(_render_x_axis_title())
+    body.extend(_render_curves(chart.readings, max_mm))
+    body.extend(_render_dots(chart.readings, max_mm))
+    body.extend(_render_legend())
+    body.append("</svg>")
+    return "\n".join(body) + "\n"
+
+
+def _render_style_block() -> str:
+    return (
+        "<style>"
+        f".grid-line {{ stroke: {_COLOR_GRID}; stroke-width: 0.5; }}"
+        f".axis-label {{ font-size: 7px; fill: {_COLOR_AXIS_TEXT}; "
+        f"font-family: ui-monospace, monospace; }}"
+        ".axis-y { text-anchor: end; }"
+        ".axis-x { text-anchor: middle; }"
+        f".axis-title {{ font-size: 7px; fill: {_COLOR_AXIS_TEXT}; "
+        f"text-anchor: middle; }}"
+        ".curve { fill: none; stroke-width: 1.5; }"
+        f".curve-10 {{ stroke: {_COLOR_10}; }}"
+        f".curve-30 {{ stroke: {_COLOR_30}; }}"
+        ".curve-m { stroke-dasharray: 4 2; }"
+        ".dot { fill: white; stroke-width: 1; }"
+        f".dot-10 {{ stroke: {_COLOR_10}; }}"
+        f".dot-30 {{ stroke: {_COLOR_30}; }}"
+        ".legend-text { font-size: 7px; fill: " + _COLOR_AXIS_TEXT
+        + "; font-family: ui-monospace, monospace; }"
+        "</style>"
+    )
+
+
+def _render_grid() -> list[str]:
+    lines: list[str] = []
+    x1 = _PAD_LEFT
+    x2 = _VIEWBOX_W - _PAD_RIGHT
+    for tick in _Y_TICKS:
+        y = _y_pixel(tick)
+        lines.append(
+            f'<line class="grid-line" x1="{x1}" y1="{y:.1f}" '
+            f'x2="{x2}" y2="{y:.1f}"/>'
+        )
+    return lines
+
+
+def _render_y_axis_labels() -> list[str]:
+    x = _PAD_LEFT - 4
+    return [
+        f'<text class="axis-label axis-y" x="{x}" y="{_y_pixel(t) + 3:.1f}">'
+        f'{t:.1f}</text>'
+        for t in _Y_TICKS
+    ]
+
+
+def _render_x_axis_labels(readings: tuple[SampledReading, ...]) -> list[str]:
+    if not readings:
+        return []
+    max_mm = readings[-1].position_mm
+    y = _VIEWBOX_H - _PAD_BOTTOM + 14
+    return [
+        f'<text class="axis-label axis-x" x="{_x_pixel(r.position_mm, max_mm):.1f}" '
+        f'y="{y}">{_format_position_label(r.position_mm)}</text>'
+        for r in readings
+    ]
+
+
+def _render_x_axis_title() -> str:
+    x = _PAD_LEFT + _PLOT_W / 2
+    # Sits at the same coordinate as MtfChart.astro (y=198) regardless
+    # of the legend strip, so the data area is visually identical.
+    y = 198
+    return (
+        f'<text class="axis-title" x="{x:.1f}" y="{y}">'
+        f"Image height (mm)</text>"
+    )
+
+
+def _render_curves(
+    readings: tuple[SampledReading, ...], max_mm: float
+) -> list[str]:
+    elements: list[str] = []
+    for field in CURVE_FIELDS:
+        _, dash = _field_style(field)
+        css_class = _curve_css_class(field)
+        for points in _polyline_segments(readings, field, max_mm):
+            extra = f' stroke-dasharray="{dash}"' if dash else ""
+            elements.append(
+                f'<polyline class="{css_class}" points="{points}"{extra}/>'
+            )
+    return elements
+
+
+def _curve_css_class(field: str) -> str:
+    freq = "10" if field.startswith("contrast") else "30"
+    sm = "m" if field.endswith("M") else "s"
+    base = f"curve curve-{freq}"
+    return f"{base} curve-m" if sm == "m" else base
+
+
+def _render_dots(
+    readings: tuple[SampledReading, ...], max_mm: float
+) -> list[str]:
+    elements: list[str] = []
+    for field in CURVE_FIELDS:
+        css_class = "dot dot-10" if field.startswith("contrast") else "dot dot-30"
+        for reading in readings:
+            value = getattr(reading, field)
+            if value is None:
+                continue
+            cx = _x_pixel(reading.position_mm, max_mm)
+            cy = _y_pixel(value)
+            elements.append(
+                f'<circle class="{css_class}" cx="{cx:.1f}" cy="{cy:.1f}" r="2"/>'
+            )
+    return elements
+
+
+def _render_legend() -> list[str]:
+    # Legend lives in its own strip below the x-axis title (the Astro
+    # component renders it as a sibling `<div>`; the provenance file is
+    # standalone, so the legend has to live inside the viewBox without
+    # crowding the data area).
+    items = (
+        ("10 lp/mm S", _COLOR_10, False),
+        ("10 lp/mm M", _COLOR_10, True),
+        ("30 lp/mm S", _COLOR_30, False),
+        ("30 lp/mm M", _COLOR_30, True),
+    )
+    elements: list[str] = []
+    x = _PAD_LEFT
+    y = _VIEWBOX_H - 6  # baseline near the bottom of the legend strip
+    swatch_w = 12
+    gap_swatch_text = 3
+    item_gap = 56
+    for i, (label, color, dashed) in enumerate(items):
+        cx = x + i * item_gap
+        dash_attr = ' stroke-dasharray="3 2"' if dashed else ""
+        elements.append(
+            f'<line x1="{cx}" y1="{y - 3}" x2="{cx + swatch_w}" y2="{y - 3}" '
+            f'stroke="{color}" stroke-width="1.5"{dash_attr}/>'
+        )
+        elements.append(
+            f'<text class="legend-text" x="{cx + swatch_w + gap_swatch_text}" '
+            f'y="{y}">{label}</text>'
+        )
+    return elements
+
+
+# --- CLI -------------------------------------------------------------
+
+
+_PROFILE_BY_STYLE: dict[str, MtfProfile] = {
+    "mainstream-2color-solid-dashed": SIGMA_2COLOR_SOLID_DASHED,
+    "mainstream-4color-all-solid": SAMYANG_4COLOR_ALL_SOLID,
+    "idealized-flat": SAMYANG_4COLOR_ALL_SOLID,  # same 4-color template
+}
+
+
+def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
+    return PlotBox(
+        x_left=coords.x_left,
+        x_right=coords.x_right,
+        y_top=coords.y_top,
+        y_bottom=coords.y_bottom,
+    )
+
+
+def _emit_chart(chart: ReferenceChart, *, check_only: bool) -> Path:
+    """Extract one reference chart and write its SVG. Returns the output path."""
+    assert chart.plot_box is not None
+    profile = _PROFILE_BY_STYLE.get(chart.style_family)
+    if profile is None:
+        raise ValueError(
+            f"{chart.slug}: no declared profile for style_family={chart.style_family!r}"
+        )
+    image_path = REPO_ROOT / chart.chart_path
+    extracted = extract_chart(
+        image_path,
+        profile,
+        _to_plotbox(chart.plot_box),
+        image_height_mm=chart.image_height_mm,
+    )
+    svg = render_svg(extracted)
+
+    out_path = image_path.with_suffix(".svg")
+    if not check_only:
+        out_path.write_text(svg, encoding="utf-8")
+    return out_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Render to memory only, don't write files. Used in CI/tests.",
+    )
+    args = parser.parse_args()
+
+    runnable = [c for c in REFERENCE_CHARTS if c.plot_box and c.ground_truth]
+    print(f"Emitting SVG for {len(runnable)} of {len(REFERENCE_CHARTS)} reference charts.")
+    if args.check:
+        print("(--check: rendering only, no files written)")
+    print()
+
+    for chart in runnable:
+        out_path = _emit_chart(chart, check_only=args.check)
+        relative = out_path.relative_to(REPO_ROOT)
+        action = "would write" if args.check else "wrote"
+        print(f"  {chart.slug:<40}  {action}  {relative}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mtfdigitizer/tests/test_svg.py
+++ b/tools/mtfdigitizer/tests/test_svg.py
@@ -1,0 +1,323 @@
+"""Tests for the MTF SVG emitter (#971).
+
+Acceptance criteria from issue #971:
+
+- Polyline `points=` reflects the readings (shape correctness).
+- A `None` reading breaks the polyline (no segment across a gap — B2
+  contract, matches `rasterize_readings` in `pipeline/rendermatch.py`).
+- All four committed fields (10S/10M/30S/30M) render as separate
+  polylines with the right styles (10 solid + dashed, 30 solid + dashed).
+- Plot bounds reflect `image_height_mm`: the last sample point lands at
+  the right edge of the plot area, the first at the left.
+- The output is a self-contained SVG document (no external CSS, parseable
+  as XML) so a file viewer can render it standalone.
+- Integration: a real `ExtractedChart` from the runnable reference set
+  emits an SVG with non-empty polylines for at least one field.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from mtfdigitizer.pipeline import (
+    ExtractedChart,
+    PlotBox,
+    SampledReading,
+    extract_chart,
+)
+from mtfdigitizer.profiles import SIGMA_2COLOR_SOLID_DASHED
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
+from mtfdigitizer.svg import (
+    _PAD_LEFT,
+    _PAD_RIGHT,
+    _VIEWBOX_H,
+    _VIEWBOX_W,
+    _polyline_segments,
+    render_svg,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# --- fixtures -------------------------------------------------------
+
+
+def _readings(values_per_field: dict[str, tuple[float | None, ...]]) -> tuple[SampledReading, ...]:
+    """Build 11 SampledReading rows at uniform 0..14mm positions.
+
+    Defaults each field to None when not supplied — exercises the
+    independent-field rendering path.
+    """
+    positions = tuple(round(i * 1.4, 1) for i in range(11))
+    blank: tuple[None, ...] = (None,) * 11
+    c10s = values_per_field.get("contrast10S", blank)
+    c10m = values_per_field.get("contrast10M", blank)
+    r30s = values_per_field.get("resolution30S", blank)
+    r30m = values_per_field.get("resolution30M", blank)
+    return tuple(
+        SampledReading(
+            position_mm=positions[i],
+            contrast10S=c10s[i],
+            contrast10M=c10m[i],
+            resolution30S=r30s[i],
+            resolution30M=r30m[i],
+        )
+        for i in range(11)
+    )
+
+
+def _chart(readings: tuple[SampledReading, ...]) -> ExtractedChart:
+    return ExtractedChart(
+        source_path="test://chart.png",
+        profile_name="test",
+        plot_box=PlotBox(x_left=0, x_right=100, y_top=0, y_bottom=100),
+        image_height_mm=14.0,
+        readings=readings,
+    )
+
+
+# --- _polyline_segments ---------------------------------------------
+
+
+def test_polyline_continuous_run_is_one_segment() -> None:
+    """All 11 values present → one segment with 11 vertices."""
+    readings = _readings({"contrast10S": tuple(0.9 - i * 0.05 for i in range(11))})
+    segments = _polyline_segments(readings, "contrast10S", max_mm=14.0)
+    assert len(segments) == 1
+    # 11 vertices → 11 "x,y" pairs separated by spaces.
+    assert len(segments[0].split(" ")) == 11
+
+
+def test_polyline_none_breaks_into_two_segments() -> None:
+    """A single None in the middle splits the polyline into two runs."""
+    values: tuple[float | None, ...] = (
+        0.95, 0.95, 0.95, 0.95, None, 0.80, 0.78, 0.75, 0.72, 0.70, 0.65,
+    )
+    readings = _readings({"contrast10S": values})
+    segments = _polyline_segments(readings, "contrast10S", max_mm=14.0)
+    assert len(segments) == 2
+    # 4 vertices before the gap, 6 after.
+    assert len(segments[0].split(" ")) == 4
+    assert len(segments[1].split(" ")) == 6
+
+
+def test_polyline_drops_single_point_runs() -> None:
+    """Isolated values surrounded by None produce no segment.
+
+    A 1-vertex polyline is invisible; emitting one would clutter the
+    DOM with elements that render nothing.
+    """
+    values: tuple[float | None, ...] = (
+        0.9, None, 0.8, None, None, None, None, None, None, None, None,
+    )
+    readings = _readings({"contrast10S": values})
+    segments = _polyline_segments(readings, "contrast10S", max_mm=14.0)
+    assert segments == []
+
+
+def test_polyline_all_none_produces_no_segments() -> None:
+    """All-None field → no rendered polyline."""
+    readings = _readings({})  # everything blank
+    segments = _polyline_segments(readings, "contrast10S", max_mm=14.0)
+    assert segments == []
+
+
+def test_polyline_first_vertex_at_left_edge() -> None:
+    """Reading at position_mm=0.0 → x coordinate at _PAD_LEFT."""
+    readings = _readings({"contrast10S": (0.9,) + (None,) * 10})
+    # Append another value at position 14 to satisfy the 2-vertex rule.
+    rebuilt = (
+        SampledReading(
+            position_mm=0.0, contrast10S=0.9,
+            contrast10M=None, resolution30S=None, resolution30M=None,
+        ),
+        SampledReading(
+            position_mm=14.0, contrast10S=0.5,
+            contrast10M=None, resolution30S=None, resolution30M=None,
+        ),
+    ) + tuple(
+        SampledReading(
+            position_mm=float(i), contrast10S=None,
+            contrast10M=None, resolution30S=None, resolution30M=None,
+        )
+        for i in range(2, 11)
+    )
+    segments = _polyline_segments(rebuilt[:2], "contrast10S", max_mm=14.0)
+    first_xy = segments[0].split(" ")[0]
+    x_str = first_xy.split(",")[0]
+    assert float(x_str) == pytest.approx(_PAD_LEFT)
+
+
+def test_polyline_last_vertex_at_right_edge() -> None:
+    """Reading at position_mm == image_height_mm → x at viewBox right minus pad."""
+    last_x_expected = _VIEWBOX_W - _PAD_RIGHT
+    readings = (
+        SampledReading(
+            position_mm=0.0, contrast10S=0.9,
+            contrast10M=None, resolution30S=None, resolution30M=None,
+        ),
+        SampledReading(
+            position_mm=14.0, contrast10S=0.5,
+            contrast10M=None, resolution30S=None, resolution30M=None,
+        ),
+    )
+    segments = _polyline_segments(readings, "contrast10S", max_mm=14.0)
+    last_xy = segments[0].split(" ")[-1]
+    x_str = last_xy.split(",")[0]
+    assert float(x_str) == pytest.approx(last_x_expected)
+
+
+# --- render_svg whole-document ---------------------------------------
+
+
+def test_render_svg_is_parseable_xml() -> None:
+    """A standalone SVG must parse cleanly as XML — no broken tags."""
+    readings = _readings(
+        {"contrast10S": tuple(0.9 for _ in range(11))}
+    )
+    svg = render_svg(_chart(readings))
+    # ET.fromstring raises on malformed XML.
+    root = ET.fromstring(svg)
+    assert root.tag == "{http://www.w3.org/2000/svg}svg"
+
+
+def test_render_svg_viewbox_matches_constants() -> None:
+    """Standalone provenance SVG extends the Astro 320x200 canvas by a
+    legend strip below the plot — the legend lives in-document, not in
+    a sibling `<div>`."""
+    readings = _readings({"contrast10S": tuple(0.9 for _ in range(11))})
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    assert root.get("viewBox") == f"0 0 {_VIEWBOX_W} {_VIEWBOX_H}"
+    # Width unchanged; height grew by the legend strip.
+    assert _VIEWBOX_W == 320
+    assert _VIEWBOX_H > 200
+
+
+def test_render_svg_renders_all_four_fields_as_separate_polylines() -> None:
+    """Each of the 4 committed fields produces its own polyline element."""
+    values = tuple(0.9 - i * 0.05 for i in range(11))
+    readings = _readings({
+        "contrast10S": values,
+        "contrast10M": values,
+        "resolution30S": values,
+        "resolution30M": values,
+    })
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    polylines = root.findall("{http://www.w3.org/2000/svg}polyline")
+    assert len(polylines) == 4
+
+
+def test_render_svg_skipped_field_emits_no_polyline() -> None:
+    """A field with all-None readings produces zero polylines for that field."""
+    readings = _readings({"contrast10S": tuple(0.9 for _ in range(11))})
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    polylines = root.findall("{http://www.w3.org/2000/svg}polyline")
+    # Only contrast10S is populated → exactly one polyline.
+    assert len(polylines) == 1
+
+
+def test_render_svg_solid_vs_dashed_styling() -> None:
+    """S curves are solid (no stroke-dasharray); M curves are dashed."""
+    values = tuple(0.9 - i * 0.05 for i in range(11))
+    readings = _readings({
+        "contrast10S": values,
+        "contrast10M": values,
+        "resolution30S": values,
+        "resolution30M": values,
+    })
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    polylines = root.findall("{http://www.w3.org/2000/svg}polyline")
+    classes = {p.get("class"): p.get("stroke-dasharray") for p in polylines}
+    # Each S class has no inline dasharray, each M does.
+    s_classes = [c for c in classes if c and "curve-m" not in c]
+    m_classes = [c for c in classes if c and "curve-m" in c]
+    assert all(classes[c] is None for c in s_classes)
+    assert all(classes[c] == "4 2" for c in m_classes)
+
+
+def test_render_svg_none_in_middle_produces_two_polylines() -> None:
+    """One field with a gap → two polylines for that field."""
+    values: tuple[float | None, ...] = (
+        0.95, 0.95, 0.95, 0.95, None, 0.80, 0.78, 0.75, 0.72, 0.70, 0.65,
+    )
+    readings = _readings({"contrast10S": values})
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    polylines = root.findall("{http://www.w3.org/2000/svg}polyline")
+    assert len(polylines) == 2
+
+
+def test_render_svg_dots_match_non_none_readings() -> None:
+    """One circle per non-None reading per populated field."""
+    values: tuple[float | None, ...] = (
+        0.9, 0.9, None, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9,
+    )
+    readings = _readings({"contrast10S": values})
+    svg = render_svg(_chart(readings))
+    root = ET.fromstring(svg)
+    circles = root.findall("{http://www.w3.org/2000/svg}circle")
+    # 10 non-None values in one field → 10 circles.
+    assert len(circles) == 10
+
+
+def test_render_svg_axis_title_present() -> None:
+    """The x-axis title 'Image height (mm)' appears once."""
+    readings = _readings({"contrast10S": tuple(0.9 for _ in range(11))})
+    svg = render_svg(_chart(readings))
+    assert svg.count("Image height (mm)") == 1
+
+
+def test_render_svg_center_label_uses_C() -> None:
+    """Position 0.0 prints as 'C' (matches MtfChart.astro)."""
+    readings = _readings({"contrast10S": tuple(0.9 for _ in range(11))})
+    svg = render_svg(_chart(readings))
+    # The 'C' label appears as an axis-x text element.
+    assert re.search(r'<text class="axis-label axis-x"[^>]*>C</text>', svg)
+
+
+# --- integration on a real reference chart --------------------------
+
+
+def test_render_svg_on_real_sigma_chart_has_content() -> None:
+    """Smoke: a real extracted chart renders an SVG with populated polylines."""
+    chart_entry = next(
+        c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c"
+    )
+    assert chart_entry.plot_box is not None
+    image_path = REPO_ROOT / chart_entry.chart_path
+    plot_box = PlotBox(
+        x_left=chart_entry.plot_box.x_left,
+        x_right=chart_entry.plot_box.x_right,
+        y_top=chart_entry.plot_box.y_top,
+        y_bottom=chart_entry.plot_box.y_bottom,
+    )
+    extracted = extract_chart(
+        image_path,
+        SIGMA_2COLOR_SOLID_DASHED,
+        plot_box,
+        image_height_mm=chart_entry.image_height_mm,
+    )
+    svg = render_svg(extracted)
+    root = ET.fromstring(svg)
+    polylines = root.findall("{http://www.w3.org/2000/svg}polyline")
+    # The Sigma extractor produces dense contrast10S / resolution30S
+    # readings and sparse 10M / 30M (gaps from the B2 contract). The
+    # honest floor is "at least one polyline" — adjusting upward would
+    # smuggle in extractor-coverage assumptions that the SVG emitter
+    # has no business holding. The polyline counts per field are the
+    # extractor's domain (calibration.md / scoring.md), not the
+    # emitter's.
+    assert len(polylines) >= 1
+    # No polyline is empty.
+    for p in polylines:
+        points = p.get("points") or ""
+        assert points.strip(), "polyline points= must not be empty"


### PR DESCRIPTION
Closes #971. Next unchecked item in epic #932.

## What this adds

`tools/mtfdigitizer/svg.py` — pure-Python SVG writer that turns an `ExtractedChart`'s 11-point readings into a standalone provenance SVG. Same plot box, same line styles, similar palette as `src/components/static/MtfChart.astro` — so the upcoming review file's right panel previews what the lens page renders, without claiming byte-identity with the Astro component (chasing that across whitespace, scoped class hashes, and attribute order would be expensive for a swap we may never want).

## What this does NOT do

- Replace `MtfChart.astro` on lens pages — the Astro component keeps rendering on the page; this PR only adds a Python-side artifact for the provenance / review-file role. Lens-page integration is a separate task.
- Build the 3-panel review-file generator — that's the next epic checklist item, and depends on this PR.

## Visual choices

- ViewBox `320×218` — the data area is at the same coordinates as `MtfChart.astro` (`320×200`); the extra 18px is a strip for the legend, which must live in-document since standalone SVGs cannot rely on a sibling `<div>`.
- B2 None handling: a None reading breaks the polyline at that vertex, single-point runs are dropped. Matches `rasterize_readings` in `pipeline/rendermatch.py`.
- Palette hard-coded (warm gold for 10 lp/mm, cool blue for 30 lp/mm) — the provenance file is theme-agnostic, no CSS custom properties apply.

## Acceptance criteria from #971

- [x] `render_svg(chart)` returns a complete standalone SVG document
- [x] None readings honored — segments draw only between adjacent non-None positions
- [x] `py -m mtfdigitizer.svg` runs against the 3 runnable reference charts and writes one .svg per chart under `docs/optical-specs/<slug>/`
- [x] pytest suite covers: shape, None handling, four-field rendering, plot bounds, XML validity, real-chart integration
- [x] No new heavy dependency (pure string templating)
- [x] `__init__.py` docstring marks svg.py landed

## Test results

```
mtfdigitizer/tests/test_svg.py ................                          [ 83%]
============================ 123 passed in 10.53s =============================
```

16 new tests; 107 → 123 total mtfdigitizer tests.

## Committed artifacts

The three runnable reference charts now ship with their committed SVGs under `docs/optical-specs/<slug>/`:

- `sigma-56mm-f1-4-dc-dn-c-mtf-1.svg`
- `samyang-85mm-f1-4-as-if-umc-mtf.svg`
- `samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.svg`

These are not consumed by Astro builds — they sit alongside the source PNGs as the provenance record the digitizer produced. Re-running `py -m mtfdigitizer.svg` regenerates them deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)