### PR TITLE
fix: ignore generated MTF review.html + svg in prettier (#976)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,11 @@ docs/solid-ai-templates/
 docs/prototype/
 downloaded_files/
 
+# MTF digitizer generated artifacts — tool-emitted by
+# tools/mtfdigitizer/{svg,review}.py, not hand-edited source.
+docs/optical-specs/**/*-review.html
+docs/optical-specs/**/*-mtf*.svg
+
 # Python tooling — own pytest suites, not part of the front-end gate
 tools/
 


### PR DESCRIPTION
Closes #976.

## Why

Since the session-103 wrap (8e86931), every push to main fails the GitHub Pages deploy at the `build` step. `npm run validate` runs `prettier --check .` over the whole repo, and two committed HTML files written by `tools/mtfdigitizer/review.py` (PR #974) don't match Prettier's defaults:

```
[warn] docs/optical-specs/samyang-300mm-…-mtf-review.html
[warn] docs/optical-specs/sigma-56mm-…-mtf-1-review.html
[warn] Code style issues found in 2 files.
##[error]Process completed with exit code 1.
```

Failing run: https://github.com/Imbra-Ltd/wuseria/actions/runs/26690379644.

## What

Two patterns added to `.prettierignore`:

```
docs/optical-specs/**/*-review.html
docs/optical-specs/**/*-mtf*.svg
```

## Rationale

These are tool-emitted artifacts, not hand-edited source — same status as their `-overlay.png` siblings. Making the Python generator emit Prettier-compliant HTML would couple it to a JS formatter's moving defaults; a future Prettier version bump would just re-break the same gate.

The SVG pattern is preventive: Prettier silently ignores SVGs today (no parser inferred for the extension), but if a future version adds an SVG formatter (and #971 produces three of them today, more once the next three profiles land per session_next_theme.md), the same failure mode would hit.

## Verification

Locally:
- `npx prettier --check` on the two committed review HTMLs reproduces the CI error before the fix
- After the change, `npm run format` reports "All matched files use Prettier code style!"
- Full `npm run validate` is green end-to-end: lint, format, check, test (Vitest), build (461 pages), and `check:links` all pass

## Follow-up

This was caught because the session-103 wrap didn't run `npm run validate` before merge, violating CLAUDE.md §2.1. The deeper prevention (pre-commit hook that runs `prettier --check` on staged files only, cheaper than the full `validate`) is noted in the incident issue and can be filed as a separate task if pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)