### PR TITLE
chore(ci): skip lighthouse on lockfile-only PRs (ADR-039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      lighthouse: ${{ steps.filter.outputs.lighthouse }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -25,6 +26,17 @@ jobs:
               - 'tsconfig.json'
               - 'package.json'
               - 'package-lock.json'
+              - 'lighthouserc.json'
+              - '.github/workflows/**'
+            # Same paths as `code` minus the lockfile/manifest pair —
+            # dependency-only PRs produce byte-identical site output
+            # (see ADR-039), so re-measuring perf on them is single-run
+            # noise. Build still runs to verify deps compile.
+            lighthouse:
+              - 'src/**'
+              - 'public/**'
+              - 'astro.config.mjs'
+              - 'tsconfig.json'
               - 'lighthouserc.json'
               - '.github/workflows/**'
 
@@ -48,7 +60,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     needs: [build, changes]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.lighthouse == 'true'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Implements ADR-039 (#979): skip the Lighthouse CI job on PRs that touch only the lockfile and package manifest.

## Change

Adds a second `dorny/paths-filter` output named `lighthouse` whose path set is the existing `code` set minus `package.json` and `package-lock.json`. The lighthouse job now keys on `needs.changes.outputs.lighthouse` instead of `code`.

```diff
   changes:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      lighthouse: ${{ steps.filter.outputs.lighthouse }}
     steps:
       ...
       filters: |
         code:
           - 'src/**'
           ...
           - 'package.json'
           - 'package-lock.json'
           ...
+        # Same paths as `code` minus the lockfile/manifest pair —
+        # see ADR-039.
+        lighthouse:
+          - 'src/**'
+          ...
+          (no package.json / package-lock.json)

   lighthouse:
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.lighthouse == 'true'
```

## Behavior matrix

| PR type | `code` | `lighthouse` | build | lighthouse |
|---|---|---|---|---|
| Lockfile-only (Dependabot) | true | false | runs | **skipped (new)** |
| Code/content | true | true | runs | runs |
| Mixed lockfile + code | true | true | runs | runs |
| Docs-only | false | false | skipped | skipped |
| `.github/workflows/**` | true | true | runs | runs |
| `lighthouserc.json` | true | true | runs | runs |
| `astro.config.mjs` | true | true | runs | runs |

## Verification

This PR itself touches only `.github/workflows/ci.yml`, which is inside the `lighthouse` filter's path set — so the new behavior should be: this PR's CI runs both build and lighthouse, exactly as a CI-touching PR should. Confirms the filter doesn't accidentally exclude workflow changes.

Once merged, the next Dependabot bump should show `lighthouse=skipped` in its CI rollup. PR #961 (astro 6.4.2) is the natural first re-test target.

## Closes

- Closes #978 (the remaining acceptance criterion — ADR + config fix both landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
