### PR TITLE
fix(docs): dead Image links in 19 Samyang analysis.md files (#930)

### DIFF
--- a/docs/optical-specs/samyang-100mm-f2-8-ed-umc-macro/analysis.md
+++ b/docs/optical-specs/samyang-100mm-f2-8-ed-umc-macro/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 100mm f/2.8 ED UMC Macro -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=331)
-Image: [samyang-100mm-f2-8-macro.png](samyang-100mm-f2-8-macro.png)
+Image: [samyang-100mm-f2-8-ed-umc-macro-mtf.png](samyang-100mm-f2-8-ed-umc-macro-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-10mm-f2-8-ed-as-ncs-cs/analysis.md
+++ b/docs/optical-specs/samyang-10mm-f2-8-ed-as-ncs-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 10mm f/2.8 ED AS NCS CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=343)
-Image: [samyang-10mm-f2-8.png](samyang-10mm-f2-8.png)
+Image: [samyang-10mm-f2-8-ed-as-ncs-cs-mtf.png](samyang-10mm-f2-8-ed-as-ncs-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-12mm-f2-0-ncs-cs/analysis.md
+++ b/docs/optical-specs/samyang-12mm-f2-0-ncs-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 12mm f/2 NCS CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=351)
-Image: [samyang-12mm-f2.png](samyang-12mm-f2.png)
+Image: [samyang-12mm-f2-0-ncs-cs-mtf.png](samyang-12mm-f2-0-ncs-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-12mm-f2-8-ed-as-ncs-fish-eye/analysis.md
+++ b/docs/optical-specs/samyang-12mm-f2-8-ed-as-ncs-fish-eye/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 12mm f/2.8 ED AS NCS Fish-eye -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=190)
-Image: [samyang-12mm-f2-8.png](samyang-12mm-f2-8.png)
+Image: [samyang-12mm-f2-8-ed-as-ncs-fish-eye-mtf.png](samyang-12mm-f2-8-ed-as-ncs-fish-eye-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-135mm-f2-0-ed-umc/analysis.md
+++ b/docs/optical-specs/samyang-135mm-f2-0-ed-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 135mm f/2 ED UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=323)
-Image: [samyang-135mm-f2-ed-umc.png](samyang-135mm-f2-ed-umc.png)
+Image: [samyang-135mm-f2-0-ed-umc-mtf.png](samyang-135mm-f2-0-ed-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-14mm-f2-8-ed-as-if-umc/analysis.md
+++ b/docs/optical-specs/samyang-14mm-f2-8-ed-as-if-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 14mm f/2.8 ED AS IF UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=194)
-Image: [samyang-14mm-f2-8.png](samyang-14mm-f2-8.png)
+Image: [samyang-14mm-f2-8-ed-as-if-umc-mtf.png](samyang-14mm-f2-8-ed-as-if-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-16mm-f2-0-ed-as-umc-cs/analysis.md
+++ b/docs/optical-specs/samyang-16mm-f2-0-ed-as-umc-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 16mm f/2 ED AS UMC CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=347)
-Image: [samyang-16mm-f2.png](samyang-16mm-f2.png)
+Image: [samyang-16mm-f2-0-ed-as-umc-cs-mtf.png](samyang-16mm-f2-0-ed-as-umc-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-20mm-f1-8-ed-as-umc/analysis.md
+++ b/docs/optical-specs/samyang-20mm-f1-8-ed-as-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 20mm f/1.8 ED AS UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=182)
-Image: [samyang-20mm-f1-8.png](samyang-20mm-f1-8.png)
+Image: [samyang-20mm-f1-8-ed-as-umc-mtf.png](samyang-20mm-f1-8-ed-as-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-21mm-f1-4-ed-as-umc-cs/analysis.md
+++ b/docs/optical-specs/samyang-21mm-f1-4-ed-as-umc-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 21mm F1.4 ED AS UMC CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=367)
-Image: [samyang-21mm-f1-4.png](samyang-21mm-f1-4.png)
+Image: [samyang-21mm-f1-4-ed-as-umc-cs-mtf.png](samyang-21mm-f1-4-ed-as-umc-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-300mm-f6-3-ed-umc-cs-reflex/analysis.md
+++ b/docs/optical-specs/samyang-300mm-f6-3-ed-umc-cs-reflex/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 300mm f/6.3 ED UMC CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=355)
-Image: [samyang-300mm-f6-3-ed-umc-cs.png](samyang-300mm-f6-3-ed-umc-cs.png)
+Image: [samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.png](samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-35mm-f1-2-ed-as-umc-cs/analysis.md
+++ b/docs/optical-specs/samyang-35mm-f1-2-ed-as-umc-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 35mm f/1.2 ED AS UMC CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=186)
-Image: [samyang-35mm-f1-2.png](samyang-35mm-f1-2.png)
+Image: [samyang-35mm-f1-2-ed-as-umc-cs-mtf.png](samyang-35mm-f1-2-ed-as-umc-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-35mm-f1-4-as-umc/analysis.md
+++ b/docs/optical-specs/samyang-35mm-f1-4-as-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 35mm f/1.4 AS UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=287)
-Image: [samyang-35mm-f1-4.png](samyang-35mm-f1-4.png)
+Image: [samyang-35mm-f1-4-as-umc-mtf.png](samyang-35mm-f1-4-as-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-50mm-f1-2-as-umc-cs/analysis.md
+++ b/docs/optical-specs/samyang-50mm-f1-2-as-umc-cs/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 50mm f/1.2 AS UMC CS -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=363)
-Image: [samyang-50mm-f1-2.png](samyang-50mm-f1-2.png)
+Image: [samyang-50mm-f1-2-as-umc-cs-mtf.png](samyang-50mm-f1-2-as-umc-cs-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-50mm-f1-4-as-umc/analysis.md
+++ b/docs/optical-specs/samyang-50mm-f1-4-as-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 50mm f/1.4 AS UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=299)
-Image: [samyang-50mm-f1-4.png](samyang-50mm-f1-4.png)
+Image: [samyang-50mm-f1-4-as-umc-mtf.png](samyang-50mm-f1-4-as-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/analysis.md
+++ b/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 85mm f/1.4 AS IF UMC -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=311)
-Image: [samyang-85mm-f1-4.png](samyang-85mm-f1-4.png)
+Image: [samyang-85mm-f1-4-as-if-umc-mtf.png](samyang-85mm-f1-4-as-if-umc-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-8mm-f2-8-ed-as-if-umc-fisheye/analysis.md
+++ b/docs/optical-specs/samyang-8mm-f2-8-ed-as-if-umc-fisheye/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 8mm f/2.8 ED AS IF UMC Fisheye -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=339)
-Image: [samyang-8mm-f2-8-ed-as-if-umc-fisheye.png](samyang-8mm-f2-8-ed-as-if-umc-fisheye.png)
+Image: [samyang-8mm-f2-8-ed-as-if-umc-fisheye-mtf.png](samyang-8mm-f2-8-ed-as-if-umc-fisheye-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-8mm-f3-5-aspherical-if-mc-fish-eye/analysis.md
+++ b/docs/optical-specs/samyang-8mm-f3-5-aspherical-if-mc-fish-eye/analysis.md
@@ -1,7 +1,7 @@
 # Samyang 8mm f/3.5 Aspherical IF MC Fish-eye -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=335)
-Image: [samyang-8mm-f3-5.png](samyang-8mm-f3-5.png)
+Image: [samyang-8mm-f3-5-aspherical-if-mc-fish-eye-mtf.png](samyang-8mm-f3-5-aspherical-if-mc-fish-eye-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-af-12mm-f2-0/analysis.md
+++ b/docs/optical-specs/samyang-af-12mm-f2-0/analysis.md
@@ -1,7 +1,7 @@
 # Samyang AF 12mm f/2.0 -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=543)
-Image: [samyang-af-12mm-f2-0.png](samyang-af-12mm-f2-0.png)
+Image: [samyang-af-12mm-f2-0-mtf.png](samyang-af-12mm-f2-0-mtf.png)
 
 ## Chart legend
 

--- a/docs/optical-specs/samyang-af-75mm-f1-8/analysis.md
+++ b/docs/optical-specs/samyang-af-75mm-f1-8/analysis.md
@@ -1,7 +1,7 @@
 # Samyang AF 75mm f/1.8 -- MTF Chart Analysis
 
 Source: [Official Samyang product page](https://www.lksamyang.com/en/product/product-view.php?seq=617)
-Image: [samyang-af-75mm-f1-8.png](samyang-af-75mm-f1-8.png)
+Image: [samyang-af-75mm-f1-8-mtf.png](samyang-af-75mm-f1-8-mtf.png)
 
 ## Chart legend
 


### PR DESCRIPTION
## Summary
- Replaces 19 dead `Image:` links in Samyang `docs/optical-specs/<slug>/analysis.md` files
- Each link now points at `<slug>-mtf.png` (the convention since the ADR-031/033 migration), instead of the old short-form filenames from the flat `docs/mtf-charts/` layout
- Sweep across all other brands found no further dead links

Closes #930.

## Test plan
- [x] Audit script confirms 0 dead Image links across `docs/optical-specs/`
- [x] Pre-commit (prettier) passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)