### PR TITLE
feat: render digitizer-emitted MTF charts on lens pages

### DIFF
--- a/src/components/static/MtfChart.astro
+++ b/src/components/static/MtfChart.astro
@@ -19,14 +19,25 @@ const maxPos = Math.max(...chart.readings.map((r) => r.position));
 const xScale = (pos: number): number => PAD.left + (pos / maxPos) * plotW;
 const yScale = (val: number): number => PAD.top + (1 - val) * plotH;
 
-// Build SVG polyline points
-function toPoints(values: number[]): string {
-  return chart.readings
-    .map(
-      (r, i) =>
-        `${xScale(r.position).toFixed(1)},${yScale(values[i]).toFixed(1)}`,
-    )
-    .join(" ");
+// Build SVG polyline-segment strings, breaking at nulls so a missing
+// reading creates a visible gap rather than a straight interpolation
+// across it. Returns one points-string per contiguous run of non-null
+// readings — the renderer emits one <polyline> per run.
+function toSegments(values: (number | null)[]): string[] {
+  const segments: string[] = [];
+  let current: string[] = [];
+  for (let i = 0; i < chart.readings.length; i++) {
+    const v = values[i];
+    if (v == null) {
+      if (current.length >= 2) segments.push(current.join(" "));
+      current = [];
+      continue;
+    }
+    const r = chart.readings[i];
+    current.push(`${xScale(r.position).toFixed(1)},${yScale(v).toFixed(1)}`);
+  }
+  if (current.length >= 2) segments.push(current.join(" "));
+  return segments;
 }
 
 const contrast10S = chart.readings.map((r) => r.contrast10S);
@@ -84,41 +95,65 @@ const xTicks = chart.readings.map((r) => r.position);
   </text>
 
   {/* Data lines — 10 lp/mm (contrast) */}
-  <polyline points={toPoints(contrast10S)} class="line line-10s"></polyline>
-  <polyline points={toPoints(contrast10M)} class="line line-10m"></polyline>
+  {
+    toSegments(contrast10S).map((seg) => (
+      <polyline points={seg} class="line line-10s" />
+    ))
+  }
+  {
+    toSegments(contrast10M).map((seg) => (
+      <polyline points={seg} class="line line-10m" />
+    ))
+  }
 
   {/* Data lines — 30 lp/mm (resolution) */}
-  <polyline points={toPoints(resolution30S)} class="line line-30s"></polyline>
-  <polyline points={toPoints(resolution30M)} class="line line-30m"></polyline>
+  {
+    toSegments(resolution30S).map((seg) => (
+      <polyline points={seg} class="line line-30s" />
+    ))
+  }
+  {
+    toSegments(resolution30M).map((seg) => (
+      <polyline points={seg} class="line line-30m" />
+    ))
+  }
 
-  {/* Data points */}
+  {/* Data points — skip null fields */}
   {
     chart.readings.map((r) => (
       <>
-        <circle
-          cx={xScale(r.position)}
-          cy={yScale(r.contrast10S)}
-          r="2"
-          class="dot dot-10"
-        />
-        <circle
-          cx={xScale(r.position)}
-          cy={yScale(r.contrast10M)}
-          r="2"
-          class="dot dot-10"
-        />
-        <circle
-          cx={xScale(r.position)}
-          cy={yScale(r.resolution30S)}
-          r="2"
-          class="dot dot-30"
-        />
-        <circle
-          cx={xScale(r.position)}
-          cy={yScale(r.resolution30M)}
-          r="2"
-          class="dot dot-30"
-        />
+        {r.contrast10S != null && (
+          <circle
+            cx={xScale(r.position)}
+            cy={yScale(r.contrast10S)}
+            r="2"
+            class="dot dot-10"
+          />
+        )}
+        {r.contrast10M != null && (
+          <circle
+            cx={xScale(r.position)}
+            cy={yScale(r.contrast10M)}
+            r="2"
+            class="dot dot-10"
+          />
+        )}
+        {r.resolution30S != null && (
+          <circle
+            cx={xScale(r.position)}
+            cy={yScale(r.resolution30S)}
+            r="2"
+            class="dot dot-30"
+          />
+        )}
+        {r.resolution30M != null && (
+          <circle
+            cx={xScale(r.position)}
+            cy={yScale(r.resolution30M)}
+            r="2"
+            class="dot dot-30"
+          />
+        )}
       </>
     ))
   }

--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -47,27 +47,29 @@ describe("mtf-readings data integrity", () => {
     }
   });
 
-  it("all values are in 0-1 range", () => {
-    for (const [slug, data] of entries) {
-      const readings = data.charts.flatMap((c) => c.readings);
-      for (const r of readings) {
-        const fields = [
-          r.contrast10S,
-          r.contrast10M,
-          r.resolution30S,
-          r.resolution30M,
-        ];
-        for (const val of fields) {
-          expect(
-            val,
-            `${slug} pos ${r.position}: out of range`,
-          ).toBeGreaterThanOrEqual(0);
-          expect(
-            val,
-            `${slug} pos ${r.position}: out of range`,
-          ).toBeLessThanOrEqual(1);
-        }
-      }
+  it("all non-null values are in 0-1 range", () => {
+    // Flatten to (slug, position, value) triples so the assertion loop
+    // stays at one level — keeps cognitive complexity under the lint cap.
+    type Sample = { slug: string; position: number; value: number };
+    const samples: Sample[] = entries.flatMap(([slug, data]) =>
+      data.charts.flatMap((c) =>
+        c.readings.flatMap((r) =>
+          [r.contrast10S, r.contrast10M, r.resolution30S, r.resolution30M]
+            .filter((v): v is number => v != null)
+            .map((value) => ({ slug, position: r.position, value })),
+        ),
+      ),
+    );
+
+    for (const s of samples) {
+      expect(
+        s.value,
+        `${s.slug} pos ${s.position}: out of range`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        s.value,
+        `${s.slug} pos ${s.position}: out of range`,
+      ).toBeLessThanOrEqual(1);
     }
   });
 
@@ -87,24 +89,43 @@ describe("mtf-readings data integrity", () => {
   // emitted as 0 by the old extractor (the B2 zero-artifact found in the #726
   // verify pass). Edge readings may legitimately approach 0, so this guard is
   // scoped to position 0 only.
+  //
+  // null is allowed: the digitizer (B2 contract) returns null when no curve
+  // was found at a sample position. That's honest absence-of-data; only an
+  // emitted 0 indicates a buggy "found curve at MTF=0" reading.
   it("centre (position 0) MTF is never zero", () => {
-    for (const [slug, data] of entries) {
-      for (const chart of data.charts) {
+    type CentreField = {
+      slug: string;
+      aperture: string;
+      field: string;
+      value: number;
+    };
+    const centreFields: CentreField[] = entries.flatMap(([slug, data]) =>
+      data.charts.flatMap((chart) => {
         const centre = chart.readings.find((r) => r.position === 0);
-        if (!centre) continue;
-        const fields = {
+        if (!centre) return [];
+        const raw = {
           contrast10S: centre.contrast10S,
           contrast10M: centre.contrast10M,
           resolution30S: centre.resolution30S,
           resolution30M: centre.resolution30M,
         };
-        for (const [field, val] of Object.entries(fields)) {
-          expect(
-            val,
-            `${slug} ${chart.aperture}: centre ${field} is 0 (undetected curve?)`,
-          ).toBeGreaterThan(0);
-        }
-      }
+        return Object.entries(raw)
+          .filter((entry): entry is [string, number] => entry[1] != null)
+          .map(([field, value]) => ({
+            slug,
+            aperture: chart.aperture,
+            field,
+            value,
+          }));
+      }),
+    );
+
+    for (const c of centreFields) {
+      expect(
+        c.value,
+        `${c.slug} ${c.aperture}: centre ${c.field} is 0 (undetected curve?)`,
+      ).toBeGreaterThan(0);
     }
   });
 });

--- a/src/data/mtf-readings.ts
+++ b/src/data/mtf-readings.ts
@@ -2247,6 +2247,94 @@ const mtfReadings: Record<string, MtfData> = {
       },
     ],
   },
+  "viltrox-af-75mm-f1-2-pro": {
+    source: "https://viltrox.com/products/75mm-f12-xf-lens",
+    mtfType: "measured",
+    charts: [
+      {
+        aperture: "f/1.2",
+        readings: [
+          {
+            position: 0,
+            contrast10S: 0.99,
+            contrast10M: 0.94,
+            resolution30S: null,
+            resolution30M: null,
+          },
+          {
+            position: 1.4,
+            contrast10S: 0.99,
+            contrast10M: 0.94,
+            resolution30S: null,
+            resolution30M: null,
+          },
+          {
+            position: 2.8,
+            contrast10S: 0.99,
+            contrast10M: 0.95,
+            resolution30S: null,
+            resolution30M: null,
+          },
+          {
+            position: 4.2,
+            contrast10S: 0.99,
+            contrast10M: null,
+            resolution30S: 0.93,
+            resolution30M: null,
+          },
+          {
+            position: 5.6,
+            contrast10S: 0.99,
+            contrast10M: 0.94,
+            resolution30S: 0.9,
+            resolution30M: null,
+          },
+          {
+            position: 7,
+            contrast10S: 0.98,
+            contrast10M: 0.9,
+            resolution30S: null,
+            resolution30M: null,
+          },
+          {
+            position: 8.4,
+            contrast10S: 0.98,
+            contrast10M: null,
+            resolution30S: 0.88,
+            resolution30M: 0.84,
+          },
+          {
+            position: 9.8,
+            contrast10S: 0.97,
+            contrast10M: null,
+            resolution30S: 0.88,
+            resolution30M: 0.82,
+          },
+          {
+            position: 11.2,
+            contrast10S: 0.98,
+            contrast10M: null,
+            resolution30S: 0.88,
+            resolution30M: null,
+          },
+          {
+            position: 12.6,
+            contrast10S: 0.97,
+            contrast10M: null,
+            resolution30S: 0.87,
+            resolution30M: 0.81,
+          },
+          {
+            position: 14,
+            contrast10S: 1,
+            contrast10M: null,
+            resolution30S: 0.85,
+            resolution30M: null,
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export { mtfReadings };

--- a/src/pages/lenses/[slug].astro
+++ b/src/pages/lenses/[slug].astro
@@ -404,10 +404,10 @@ const jsonLd = {
                         <td>
                           {r.position === 0 ? "Center" : `${r.position}mm`}
                         </td>
-                        <td>{r.contrast10S.toFixed(2)}</td>
-                        <td>{r.contrast10M.toFixed(2)}</td>
-                        <td>{r.resolution30S.toFixed(2)}</td>
-                        <td>{r.resolution30M.toFixed(2)}</td>
+                        <td>{r.contrast10S?.toFixed(2) ?? DASH}</td>
+                        <td>{r.contrast10M?.toFixed(2) ?? DASH}</td>
+                        <td>{r.resolution30S?.toFixed(2) ?? DASH}</td>
+                        <td>{r.resolution30M?.toFixed(2) ?? DASH}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/types/mtf.ts
+++ b/src/types/mtf.ts
@@ -1,9 +1,15 @@
 interface MtfReading {
   position: number; // image height in mm (0 = center)
-  contrast10S: number; // 10 lp/mm sagittal
-  contrast10M: number; // 10 lp/mm meridional
-  resolution30S: number; // 30 lp/mm sagittal
-  resolution30M: number; // 30 lp/mm meridional
+  // Per-field values may be null when the chart extractor (or hand
+  // curator) has no usable data for that frequency / orientation at
+  // this position. Renderers break the polyline at nulls; tables show
+  // a dash. Hand-curated entries from official manufacturer charts
+  // typically have all four populated; digitizer-emitted entries may
+  // not (per the ADR-038 B2 contract — never fabricate).
+  contrast10S: number | null; // 10 lp/mm sagittal
+  contrast10M: number | null; // 10 lp/mm meridional
+  resolution30S: number | null; // 30 lp/mm sagittal
+  resolution30M: number | null; // 30 lp/mm meridional
 }
 
 interface MtfChart {

--- a/tools/mtfdigitizer/emit.py
+++ b/tools/mtfdigitizer/emit.py
@@ -1,0 +1,270 @@
+"""Emit extractor readings as a TypeScript literal for src/data/mtf-readings.ts.
+
+The mtfdigitizer pipeline returns `ExtractedChart` Python objects; the
+Astro lens page consumes the same data as TypeScript records keyed by
+lens slug. This module bridges the two: it serializes one or more
+`ExtractedChart` results into a TS `MtfData` object literal that can be
+pasted into `src/data/mtf-readings.ts`.
+
+Closes the loop the ADR-038 design called for: digitized readings
+become the site's display source of truth, while the committed SVG
+under `docs/optical-specs/<slug>/` remains a provenance artifact.
+
+## Null readings
+
+`MtfReading` in `src/types/mtf.ts` declares each OTF field as
+`number | null`. The digitizer's `SampledReading` returns `None` for
+fields where no usable curve data exists at that column (B2 contract
+— never fabricate). The emitter passes those through as TypeScript
+`null` literals; the chart renderer breaks its polyline at nulls and
+the lens-page table shows an em-dash for null cells.
+
+A position with all four fields null is dropped entirely (no row to
+emit). Per-field null counts are reported on stderr so the operator
+can see chart-coverage gaps without staring at the diff.
+
+## Usage
+
+    cd tools
+    py -m mtfdigitizer.emit <slug>                 # one slug, print to stdout
+    py -m mtfdigitizer.emit <slug> <slug> ...      # multiple slugs
+
+Each slug must be present in `referenceset/charts.py` with a populated
+`plot_box`. The output prints the lens entry in `mtf-readings.ts` order
+— copy-paste into the file, then `npm run check && npm run build` to
+verify.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from .pipeline import PlotBox, extract_chart
+from .pipeline.types import ExtractedChart, SampledReading
+from .profiles import (
+    SAMYANG_4COLOR_ALL_SOLID,
+    SEVENARTISANS_2COLOR_SAMECOLOR_DASHED,
+    SIGMA_2COLOR_SOLID_DASHED,
+    TOKINA_2COLOR_FREQUENCY,
+    VILTROX_BW_DASHED_F12,
+)
+from .profiles.types import MtfProfile
+from .referenceset.charts import REFERENCE_CHARTS, PlotBoxCoords, ReferenceChart
+
+
+# Map style_family declared on each reference chart to the runtime
+# profile. Centralised so we don't sprinkle per-family lookups across
+# the codebase. Kept here rather than `referenceset/` because the
+# binding is profile-side, not reference-side.
+_FAMILY_TO_PROFILE: dict[str, MtfProfile] = {
+    "mainstream-2color-solid-dashed": SIGMA_2COLOR_SOLID_DASHED,
+    "mainstream-4color-all-solid": SAMYANG_4COLOR_ALL_SOLID,
+    "idealized-flat": SAMYANG_4COLOR_ALL_SOLID,
+    "samecolor-dashed-sm": SEVENARTISANS_2COLOR_SAMECOLOR_DASHED,
+    "2color-frequency": TOKINA_2COLOR_FREQUENCY,
+    "bw-dashed-promo": VILTROX_BW_DASHED_F12,
+}
+
+
+def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
+    return PlotBox(
+        x_left=coords.x_left,
+        x_right=coords.x_right,
+        y_top=coords.y_top,
+        y_bottom=coords.y_bottom,
+    )
+
+
+@dataclass(frozen=True)
+class EmitResult:
+    """What `emit_lens()` produced for one slug."""
+
+    slug: str
+    ts_literal: str
+    positions_emitted: int
+    null_counts: dict[str, int]
+
+
+_FIELDS: tuple[str, ...] = (
+    "contrast10S",
+    "contrast10M",
+    "resolution30S",
+    "resolution30M",
+)
+
+
+def _has_any_data(r: SampledReading) -> bool:
+    return any(getattr(r, field) is not None for field in _FIELDS)
+
+
+def _format_value(value: float | None) -> str:
+    """Render `0.92` not `0.92000000000001`, or `null` for None."""
+    if value is None:
+        return "null"
+    return f"{round(value, 2):.2f}"
+
+
+def _format_reading(r: SampledReading) -> str:
+    return (
+        "          {\n"
+        f"            position: {r.position_mm:g},\n"
+        f"            contrast10S: {_format_value(r.contrast10S)},\n"
+        f"            contrast10M: {_format_value(r.contrast10M)},\n"
+        f"            resolution30S: {_format_value(r.resolution30S)},\n"
+        f"            resolution30M: {_format_value(r.resolution30M)},\n"
+        "          },"
+    )
+
+
+def _format_chart(
+    aperture: str, paired: tuple[SampledReading, ...]
+) -> str:
+    readings_block = "\n".join(_format_reading(r) for r in paired)
+    return (
+        "      {\n"
+        f"        aperture: \"{aperture}\",\n"
+        "        readings: [\n"
+        f"{readings_block}\n"
+        "        ],\n"
+        "      },"
+    )
+
+
+def _format_entry(
+    slug: str,
+    source: str,
+    aperture: str,
+    paired: tuple[SampledReading, ...],
+) -> str:
+    chart_block = _format_chart(aperture, paired)
+    return (
+        f"  \"{slug}\": {{\n"
+        f"    source: \"{source}\",\n"
+        "    mtfType: \"measured\",\n"
+        "    charts: [\n"
+        f"{chart_block}\n"
+        "    ],\n"
+        "  },"
+    )
+
+
+def emit_lens(
+    chart: ReferenceChart,
+    source_url: str,
+    aperture: str | None = None,
+    repo_root: Path | None = None,
+) -> EmitResult:
+    """Extract one reference chart and serialize to a TS object literal.
+
+    `source_url` becomes the `source` field on the emitted entry — the
+    canonical attribution URL that the lens page renders below the chart.
+    `aperture` overrides the chart's first declared aperture (useful when
+    the reference chart declares multiple panels but only the first is
+    extracted by the current pipeline).
+    """
+    if chart.plot_box is None or chart.ground_truth is None:
+        raise ValueError(
+            f"reference chart {chart.slug!r} has no plot_box or ground_truth — "
+            f"emit only supports charts that calibrate"
+        )
+    profile = _FAMILY_TO_PROFILE.get(chart.style_family)
+    if profile is None:
+        raise ValueError(
+            f"no runtime profile mapped for style_family {chart.style_family!r}"
+        )
+
+    root = repo_root or Path(__file__).resolve().parents[2]
+    extracted: ExtractedChart = extract_chart(
+        root / chart.chart_path,
+        profile,
+        _to_plotbox(chart.plot_box),
+        image_height_mm=chart.image_height_mm,
+    )
+
+    rows = tuple(r for r in extracted.readings if _has_any_data(r))
+    null_counts = {
+        field: sum(1 for r in extracted.readings if getattr(r, field) is None)
+        for field in _FIELDS
+    }
+
+    return EmitResult(
+        slug=chart.slug,
+        ts_literal=_format_entry(
+            slug=chart.slug,
+            source=source_url,
+            aperture=aperture or chart.apertures[0],
+            paired=rows,
+        ),
+        positions_emitted=len(rows),
+        null_counts=null_counts,
+    )
+
+
+# Mapping from reference chart slug to the source URL the lens page
+# should cite. Kept here rather than on ReferenceChart because
+# attribution is an emit-step concern, not a calibration concern.
+_DEFAULT_SOURCES: dict[str, str] = {
+    "sigma-56mm-f1-4-dc-dn-c": (
+        "https://www.sigma-global.com/en/lenses/c018_56_14/"
+    ),
+    "samyang-85mm-f1-4-as-if-umc": (
+        "https://www.lksamyang.com/en/product/product-view.php?seq=311"
+    ),
+    "samyang-300mm-f6-3-ed-umc-cs-reflex": (
+        "https://www.lksamyang.com/en/product/product-view.php?seq=355"
+    ),
+    "viltrox-af-75mm-f1-2-pro": (
+        "https://viltrox.com/products/75mm-f12-xf-lens"
+    ),
+    "tokina-atx-m-23mm-f1-4-x": (
+        "https://www.lenstip.com/665.1-Lens_review-Tokina_atx-m_23_mm_f_1.4_X-Introduction.html"
+    ),
+    "7artisans-50mm-f1-2-mark-ii": (
+        "https://7artisans.store/products/7artisans-50mm-f-1-2-mark-ii-prime-lens"
+    ),
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "slugs",
+        nargs="+",
+        help="reference-set lens slug(s) to emit",
+    )
+    args = parser.parse_args(argv)
+
+    chart_by_slug = {c.slug: c for c in REFERENCE_CHARTS}
+
+    for slug in args.slugs:
+        chart = chart_by_slug.get(slug)
+        if chart is None:
+            print(f"ERROR: unknown slug {slug!r}", file=sys.stderr)
+            return 1
+        source = _DEFAULT_SOURCES.get(slug)
+        if source is None:
+            print(
+                f"ERROR: no default source URL for {slug!r}; "
+                f"add to _DEFAULT_SOURCES",
+                file=sys.stderr,
+            )
+            return 1
+        result = emit_lens(chart, source_url=source)
+        print(result.ts_literal)
+        nulls = ", ".join(
+            f"{field}={count}" for field, count in result.null_counts.items()
+        )
+        print(
+            f"\n# {slug}: emitted {result.positions_emitted}/11 positions; "
+            f"nulls per field: {nulls}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mtfdigitizer/tests/test_emit.py
+++ b/tools/mtfdigitizer/tests/test_emit.py
@@ -1,0 +1,114 @@
+"""Tests for emit.py: ExtractedChart → TypeScript object literal."""
+
+from __future__ import annotations
+
+from mtfdigitizer.emit import (
+    _FIELDS,
+    _format_entry,
+    _format_reading,
+    _format_value,
+    _has_any_data,
+)
+from mtfdigitizer.pipeline.types import SampledReading
+
+
+def _r(
+    pos: float = 0.0,
+    c10s: float | None = 0.9,
+    c10m: float | None = 0.9,
+    r30s: float | None = 0.7,
+    r30m: float | None = 0.7,
+) -> SampledReading:
+    return SampledReading(
+        position_mm=pos,
+        contrast10S=c10s,
+        contrast10M=c10m,
+        resolution30S=r30s,
+        resolution30M=r30m,
+    )
+
+
+# --- _format_value -------------------------------------------------------
+
+
+def test_format_value_renders_two_decimals() -> None:
+    assert _format_value(0.92) == "0.92"
+
+
+def test_format_value_strips_floating_point_noise() -> None:
+    assert _format_value(0.92000000001) == "0.92"
+
+
+def test_format_value_renders_none_as_null() -> None:
+    assert _format_value(None) == "null"
+
+
+def test_format_value_renders_one_as_one_decimal_two_digits() -> None:
+    # The lens-page table calls .toFixed(2) on the JS side; the emitted
+    # TS literal should be a valid number, not "1" or "1.0" specifically.
+    assert _format_value(1.0) == "1.00"
+
+
+# --- _has_any_data -------------------------------------------------------
+
+
+def test_has_any_data_true_when_one_field_present() -> None:
+    r = _r(c10s=0.9, c10m=None, r30s=None, r30m=None)
+    assert _has_any_data(r) is True
+
+
+def test_has_any_data_false_when_all_fields_none() -> None:
+    r = _r(c10s=None, c10m=None, r30s=None, r30m=None)
+    assert _has_any_data(r) is False
+
+
+# --- _format_reading -----------------------------------------------------
+
+
+def test_format_reading_includes_all_four_fields() -> None:
+    out = _format_reading(_r(pos=5.0, c10s=0.95, c10m=0.94, r30s=0.85, r30m=0.84))
+    for field in _FIELDS:
+        assert field in out
+
+
+def test_format_reading_emits_null_for_none_fields() -> None:
+    out = _format_reading(_r(c10m=None, r30m=None))
+    assert "contrast10M: null," in out
+    assert "resolution30M: null," in out
+    assert "null: null" not in out  # only field values become null
+
+
+def test_format_reading_position_renders_without_trailing_zero() -> None:
+    out = _format_reading(_r(pos=14.0))
+    assert "position: 14," in out
+
+
+def test_format_reading_position_renders_float() -> None:
+    out = _format_reading(_r(pos=1.4))
+    assert "position: 1.4," in out
+
+
+# --- _format_entry -------------------------------------------------------
+
+
+def test_format_entry_wraps_a_lens_block() -> None:
+    rows = (_r(pos=0), _r(pos=5.0))
+    out = _format_entry(
+        slug="test-lens",
+        source="https://example.com/lens",
+        aperture="f/2.8",
+        paired=rows,
+    )
+    assert '"test-lens":' in out
+    assert 'source: "https://example.com/lens",' in out
+    assert 'mtfType: "measured",' in out
+    assert 'aperture: "f/2.8",' in out
+    # Both rows appear
+    assert out.count("position:") == 2
+
+
+def test_format_entry_empty_readings_block_is_valid_ts() -> None:
+    out = _format_entry(
+        slug="test-lens", source="https://x", aperture="f/2", paired=()
+    )
+    assert "readings: [\n\n        ]," in out


### PR DESCRIPTION
## Summary
- New `tools/mtfdigitizer/emit.py` — converts `ExtractedChart` Python output to a TypeScript `MtfData` object literal that drops straight into `src/data/mtf-readings.ts`
- First emitted lens: **Viltrox AF 75mm f/1.2 Pro** (the #994 ridge-tracking test case) — Viltrox lens page now shows a real MTF chart where there was none before
- `MtfReading` fields made nullable (`number | null`) so the digitizer's B2 contract (None where no curve data) can flow through to the site without fabricated values; chart polylines break at nulls, table cells show em-dash
- Closes the loop epic #932 was heading toward: digitized readings → site display

Part of epic #932.

## Pipeline (now end-to-end)

```
chart PNG → mtfdigitizer.extract_chart() → ExtractedChart
         → mtfdigitizer.emit (py -m) → TS literal
         → paste into src/data/mtf-readings.ts
         → lens page renders MtfChart.astro (themed inline SVG + table)
```

## Honest scope

Only one lens lands today: `viltrox-af-75mm-f1-2-pro`. The other 3 digitizer reference-set lenses (sigma-56, samyang-85, samyang-300) already have hand-curated entries in `mtf-readings.ts` that I deliberately did not overwrite — manufacturer-published readings beat the digitizer's ±0.02-0.05 calibration band. The script is ready for future lenses where no hand-curated source exists.

## Test plan
- [x] 213/213 vitest tests pass (data-integrity tests updated to admit null cells)
- [x] 12 new Python tests for `emit.py` (170/170 mtfdigitizer tests pass total)
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` — 461 pages built clean
- [x] Dev server: Viltrox lens page renders 6 polylines (with 2 broken-segment cases where nulls split a curve), 26 data dots, MTF table with em-dashes for nulls
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)