### PR TITLE
docs(adr-038): flag pending amendment for production digitization rule

### DIFF
--- a/docs/decisions/038-unified-mtf-digitizer.md
+++ b/docs/decisions/038-unified-mtf-digitizer.md
@@ -3,6 +3,35 @@
 **Status:** Accepted
 **Date:** 2026-05-29
 
+> **Pending amendment (2026-06-02, tracked in #1018).** The current text
+> reads as if every digitized lens needs eye-read ground truth, because the
+> reference set was the first work item and #1003/#1016 built the runnable
+> charts through `_<LENS>_GT` tuples. In practice the reference set and the
+> production digitization queue are two different jobs: GT is required for
+> **calibration anchors** (proves the extractor works for a `(brand,
+style_family)` pair), but not for every subsequent lens in that family.
+>
+> The amendment will codify a two-tier rule:
+>
+> - **Calibration anchors** — one per `(brand, style_family)` carries
+>   eye-read GT, sits in `referenceset/charts.py` with `plot_box` and
+>   `ground_truth` populated, and feeds the calibration runner. The
+>   maintainer eye-reads these; the agent does not.
+> - **Production digitizations** — every other lens runs the proven
+>   extractor with no per-lens GT. The acceptance signal is the two-signal
+>   confidence gate this ADR already specifies (render-match score +
+>   plausibility priors) plus a maintainer overlay glance at the generated
+>   review PNG. No `_<LENS>_GT`, no `plot_box`/`ground_truth` on the
+>   `ReferenceChart` entry. Readings emit to `src/data/mtf-readings.ts`
+>   directly.
+>
+> ADR-040's gate ("logs only when `plot_box` and `ground_truth` are
+> populated") narrows in scope to **calibration logs** under the new rule.
+> Production digitizations emit the SVG + readings + lens-folder
+> `digitization-log.md` through a parallel non-calibration path. Until the
+> amendment lands, do not block #1018 (Sigma DC DN C primes 12/15/16/23mm)
+> on eye-read GT — the Sigma 56mm anchor covers them.
+
 ## Context
 
 Digitizing MTF charts into structured readings (`src/data/mtf-readings.ts`)


### PR DESCRIPTION
## Summary

Flags a pending amendment to ADR-038 that splits the digitization workflow into two tiers:

- **Calibration anchors** (one per `(brand, style_family)`) — carry eye-read ground truth, sit in `referenceset/charts.py` with `plot_box` and `ground_truth` populated, feed the calibration runner. Maintainer eye-reads; agent does not.
- **Production digitizations** (every other lens in a proven family) — run the proven extractor with no per-lens GT. Acceptance signal is the two-signal confidence gate ADR-038 already specifies (render-match + plausibility priors) + a maintainer overlay glance. Readings emit to `src/data/mtf-readings.ts` directly; no `_<LENS>_GT`, no `plot_box`/`ground_truth` on the `ReferenceChart` entry.

## Why

Trying to digitize the Sigma DC DN C primes (#1018) surfaced the problem: the current ADR-038 reads as if every lens needs eye-read GT, because the reference set was the first work item and the runnable subset was threaded through `_<LENS>_GT` tuples. In practice that conflates two different jobs — calibration (one anchor per profile family proves the extractor works) and production digitization (just running the proven extractor on more charts). The Sigma 56mm anchor already covers the 12/15/16/23mm primes; demanding eye-read GT on each one is busywork that blocks scaling to hundreds of lenses.

This PR only adds the "Pending amendment" blockquote at the top of ADR-038, matching the convention ADR-033 already uses for #1015. The body amendment lands in a follow-up.

## Consequences (once the amendment body lands)

- #1018 acceptance criteria change: extractor runs cleanly + overlay visually matches + readings emit. No `_SIGMA_NN_GT`, no `plot_box`/`ground_truth` activation on the four primes.
- ADR-040's gate ("logs only when `plot_box` and `ground_truth` are populated") narrows to **calibration logs** under the new rule. Production digitizations get a parallel non-calibration log path.
- The aborted `feat/sigma-16mm-gt-scaffold` branch (deleted earlier this session) is correctly obsolete under the new rule.

## Test plan

- [x] `npm run validate` clean (markdown only; lint-staged ran prettier on the file)
- [ ] No follow-up needed in code until the amendment body lands

Linked to #1018.