### PR TITLE
feat(mtfdigitizer): scaffold 4 Sigma zoom ReferenceChart entries (#793)

### DIFF
--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -341,6 +341,55 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         notes="Tier 2 (ADR-041) — #1018. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
     ),
+    # Sigma zooms — #793. Same chart family as the DC DN C primes; the
+    # canonical chart per folder is the wide-end diffraction MTF per
+    # ADR-033, taken from the Fujifilm X mount edition where the source
+    # publishes a separate X-mount chart set (only the 100-400mm does).
+    # Plot box transferred from the 56mm template — verified by
+    # detect_sigma_plot_box() returning (309, 2980, 83, 1700) on every
+    # entry below. The 17-40mm Art is intentionally omitted: its image
+    # dimensions are 2988x1953 and detect_sigma_plot_box() finds only
+    # one axis-frame cluster instead of two — handle in a follow-up.
+    ReferenceChart(
+        slug="sigma-10-18mm-f2-8-dc-dn-c",
+        chart_path="docs/optical-specs/sigma-10-18mm-f2-8-dc-dn-c/sigma-10-18mm-f2-8-dc-dn-c-mtf-diffraction-wide.png",
+        style_family="mainstream-2color-solid-dashed",
+        apertures=("f/2.8",),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.0,
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (10mm).",
+        plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+    ),
+    ReferenceChart(
+        slug="sigma-16-300mm-f3-5-6-7-dc-os-c",
+        chart_path="docs/optical-specs/sigma-16-300mm-f3-5-6-7-dc-os-c/sigma-16-300mm-f3-5-6-7-dc-os-c-mtf-diffraction-wide.png",
+        style_family="mainstream-2color-solid-dashed",
+        apertures=("f/3.5",),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.0,
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (16mm).",
+        plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+    ),
+    ReferenceChart(
+        slug="sigma-18-50mm-f2-8-dc-dn-c",
+        chart_path="docs/optical-specs/sigma-18-50mm-f2-8-dc-dn-c/sigma-18-50mm-f2-8-dc-dn-c-mtf-diffraction-wide.png",
+        style_family="mainstream-2color-solid-dashed",
+        apertures=("f/2.8",),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.0,
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (18mm).",
+        plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+    ),
+    ReferenceChart(
+        slug="sigma-100-400mm-f5-6-3-dg-dn-os-c",
+        chart_path="docs/optical-specs/sigma-100-400mm-f5-6-3-dg-dn-os-c/sigma-100-400mm-f5-6-3-dg-dn-os-c-mtf-diffraction-wide.png",
+        style_family="mainstream-2color-solid-dashed",
+        apertures=("f/5",),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.0,
+        notes="Tier 2 (ADR-041) — #793. Fujifilm X mount edition; source publishes parallel L/Sony FF and TC chart sets (deleted per #1032). Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (100mm).",
+        plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+    ),
     ReferenceChart(
         slug="samyang-85mm-f1-4-as-if-umc",
         chart_path="docs/optical-specs/samyang-85mm-f1-4-as-if-umc/samyang-85mm-f1-4-as-if-umc-mtf.png",


### PR DESCRIPTION
## Summary

Adds four Sigma zoom slugs to the Tier 2 reference set so the production extractor can run on each folder's canonical wide-end diffraction MTF chart, advancing #793 (Sigma per-brand digitization, part of epic #790).

| Slug | Aperture | Plot box source |
|---|---|---|
| sigma-10-18mm-f2-8-dc-dn-c | f/2.8 | transferred from 56mm template (auto-detected match) |
| sigma-16-300mm-f3-5-6-7-dc-os-c | f/3.5 | transferred from 56mm template (auto-detected match) |
| sigma-18-50mm-f2-8-dc-dn-c | f/2.8 | transferred from 56mm template (auto-detected match) |
| sigma-100-400mm-f5-6-3-dg-dn-os-c (Fujifilm X) | f/5 | transferred from 56mm template (auto-detected match) |

The **sigma-17-40mm-f1-8-dc-art** is intentionally omitted — its image dimensions are 2988×1953 (vs the 2991×1964 template the other four match), and `detect_sigma_plot_box()` finds only one axis-frame cluster instead of two. Track in a follow-up.

## Smoke test results

Ran \`py -m mtfdigitizer.extract <slug>\` end-to-end on all four:

| Slug | Verdict | Precision | IoU | Prior violations |
|---|---|---|---|---|
| sigma-10-18mm | LOW | 0.626 | 0.491 | 1 |
| sigma-16-300mm | LOW | 0.626 | 0.491 | 0 |
| sigma-18-50mm | LOW | 0.711 | 0.580 | 0 |
| sigma-100-400mm | HIGH | 0.849 | 0.747 | 0 |

All four extract without errors and HOLD per the ADR-041 gate protocol — preview artifacts (svg/overlay/review.html) are deferred to maintainer \`--accept\` runs and not in this PR.

## Test plan

- [x] \`py -m pytest tools/mtfdigitizer/tests/\` — 230 passed (up from 226; the 4 new \`test_detect_matches_known_box\` cases all pass within the 2 px tolerance)
- [x] \`npm run validate\` clean
- [x] \`py -m mtfdigitizer.extract <slug>\` runs end-to-end on each new slug

## What this PR does NOT do

- Does not commit any digitization logs — those land per-slug via \`--accept\` after maintainer eye-glance per ADR-041.
- Does not address sigma-17-40mm Art (detector mismatch, follow-up).
- Does not extend digitization to tele-end charts (canonical-only per ADR-033; tele-end is supplementary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)