### PR TITLE
feat(mtfdigitizer): support N chart views per lens for zoom wide+tele (#793)

### DIFF
--- a/tools/mtfdigitizer/extract.py
+++ b/tools/mtfdigitizer/extract.py
@@ -51,7 +51,12 @@ from .pipeline.rendermatch import DEFAULT_DILATION_RADIUS_PX
 from .pipeline.types import ExtractedChart
 from .priors import check_all
 from .production_log import ProductionPanel, render_production_log
-from .referenceset.charts import REFERENCE_CHARTS, PlotBoxCoords, ReferenceChart
+from .referenceset.charts import (
+    REFERENCE_CHARTS,
+    ChartView,
+    PlotBoxCoords,
+    ReferenceChart,
+)
 from .review import write_review
 from .svg import render_svg
 from .triage import ChartVerdict, triage
@@ -97,28 +102,28 @@ def _chart_by_slug(slug: str) -> ReferenceChart | None:
 # --- Canonical chart path with legacy fallback ----------------------------
 
 
-def _resolve_chart_image(chart: ReferenceChart) -> Path:
-    """Return the absolute path to the chart raster.
+def _resolve_view_image(chart: ReferenceChart, view: ChartView) -> Path:
+    """Return the absolute path to a view's chart raster.
 
     Honors ADR-033's canonical `-mtf-diffraction.png` (or
     `-mtf-diffraction-<focal>.png` for zooms) if present; otherwise
-    falls back to the path the `ReferenceChart` declares. As of #1017
-    the Sigma DC DN C primes are renamed and their `chart_path` already
-    points at the canonical name, so both branches resolve to the same
-    file. The fallback remains for the multi-chart zooms still on the
-    numeric scheme (tokina-atx-m-11-18, sigma zooms) and drops in the
-    follow-up PR that renames them.
+    falls back to the path the view declares. The canonical-name probe
+    only fires on the primary view (the slug-bare name), so additional
+    zoom views — whose `chart_path` is already the focal-suffixed
+    canonical (`...-wide.png`, `...-tele.png`) — resolve via fallback.
 
     Resolution order:
 
-    1. `<slug>-mtf-diffraction.png` in the same folder as the declared path
-    2. `chart.chart_path` (legacy `-mtf-1.png` for the remaining zooms)
+    1. `<slug>-mtf-diffraction.png` in the same folder (primary view only)
+    2. `view.chart_path` (always exists for additional views)
     """
-    declared = REPO_ROOT / chart.chart_path
-    canonical_name = f"{chart.slug}-mtf-diffraction.png"
-    canonical = declared.parent / canonical_name
-    if canonical.exists():
-        return canonical
+    declared = REPO_ROOT / view.chart_path
+    is_primary = view.chart_path == chart.chart_path
+    if is_primary:
+        canonical_name = f"{chart.slug}-mtf-diffraction.png"
+        canonical = declared.parent / canonical_name
+        if canonical.exists():
+            return canonical
     return declared
 
 
@@ -136,23 +141,28 @@ def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
 
 @dataclass(frozen=True)
 class ExtractRun:
-    """The full output of one chart's extraction pass."""
+    """The full output of one chart view's extraction pass."""
 
     chart: ReferenceChart
+    view: ChartView
     image_path: Path
     plot_box: PlotBox
     extracted: ExtractedChart
     verdict: ChartVerdict
 
 
-def _run_one(chart: ReferenceChart) -> ExtractRun:
-    """extract → score → priors → triage. No I/O beyond reading the chart."""
-    assert chart.plot_box is not None, (
-        f"chart {chart.slug!r} has no plot_box — cannot run extractor"
+def _run_view(chart: ReferenceChart, view: ChartView) -> ExtractRun:
+    """Run one chart view through extract → score → priors → triage.
+
+    No I/O beyond reading the chart raster.
+    """
+    assert view.plot_box is not None, (
+        f"chart {chart.slug!r} view {view.chart_path!r} has no plot_box — "
+        "cannot run extractor"
     )
     profile = profile_for_chart(chart)
-    image_path = _resolve_chart_image(chart)
-    plot_box = _to_plotbox(chart.plot_box)
+    image_path = _resolve_view_image(chart, view)
+    plot_box = _to_plotbox(view.plot_box)
 
     extracted = extract_chart(
         image_path, profile, plot_box, image_height_mm=chart.image_height_mm
@@ -169,6 +179,7 @@ def _run_one(chart: ReferenceChart) -> ExtractRun:
     verdict = triage(score, violations)
     return ExtractRun(
         chart=chart,
+        view=view,
         image_path=image_path,
         plot_box=plot_box,
         extracted=extracted,
@@ -176,31 +187,38 @@ def _run_one(chart: ReferenceChart) -> ExtractRun:
     )
 
 
+def _run_all_views(chart: ReferenceChart) -> list[ExtractRun]:
+    """Run every view this lens publishes. Each view contributes one
+    panel to the lens's single digitization-log.md.
+    """
+    return [_run_view(chart, view) for view in chart.views]
+
+
 # --- Acceptance decision --------------------------------------------------
 
 
 def _should_write_log(
-    verdict: ChartVerdict, *, accept_override: bool
+    verdicts: list[ChartVerdict], *, accept_override: bool
 ) -> tuple[bool, str]:
-    """The gate-at-commit decision.
+    """The gate-at-commit decision over every view of a lens.
 
     Returns (write: bool, reason: str). When the maintainer passed
     `--accept`, the log is written regardless of verdict — the reason
     is recorded as 'accept-override' so the run output is honest about
     bypassing the gate.
 
-    With overlay-glance mandatory (the current default), a HIGH verdict
-    on its own is not enough — the operator must run with `--accept`
-    after eyeballing the overlay. This is intentional; the toggle to
-    let HIGH auto-write lives in `OVERLAY_GLANCE_REQUIRED` above.
+    A multi-view lens (zoom: wide + tele) holds if **any** view is
+    LOW; HIGH-pending-glance fires only when every view is HIGH. The
+    log writer emits one log per lens regardless, so partial accepts
+    are not a meaningful state.
     """
     if accept_override:
         return True, "accept-override"
-    if verdict.verdict == "HIGH" and not OVERLAY_GLANCE_REQUIRED:
+    if not all(v.verdict == "HIGH" for v in verdicts):
+        return False, "gate-low"
+    if not OVERLAY_GLANCE_REQUIRED:
         return True, "gate-high-auto"
-    if verdict.verdict == "HIGH":
-        return False, "gate-high-pending-glance"
-    return False, "gate-low"
+    return False, "gate-high-pending-glance"
 
 
 # --- Artifact writers -----------------------------------------------------
@@ -213,8 +231,11 @@ def _lens_dir_for(chart: ReferenceChart) -> Path:
 
 
 def _write_inspection_artifacts(run: ExtractRun) -> tuple[Path, Path, Path]:
-    """Write SVG + overlay PNG + review HTML. Always written; the
-    maintainer needs them whether the gate accepted or held.
+    """Write one view's SVG + overlay PNG + review HTML.
+
+    Always written, regardless of the gate decision — the maintainer
+    needs them to eye-glance a HOLD. Artifacts are named by the chart
+    image stem so multiple views in the same folder do not collide.
     """
     lens_dir = _lens_dir_for(run.chart)
     lens_dir.mkdir(parents=True, exist_ok=True)
@@ -233,23 +254,31 @@ def _write_inspection_artifacts(run: ExtractRun) -> tuple[Path, Path, Path]:
     return svg_path, outputs.overlay_path, outputs.html_path
 
 
-def _render_log_for(run: ExtractRun) -> str:
+def _panel_for(run: ExtractRun) -> ProductionPanel:
+    """Build the one log panel for a single view of a lens."""
     plot_box_tuple = (
         run.plot_box.x_left,
         run.plot_box.x_right,
         run.plot_box.y_top,
         run.plot_box.y_bottom,
     )
-    panel = ProductionPanel(
+    return ProductionPanel(
         chart_slug=run.chart.slug,
-        chart_path=run.chart.chart_path,
+        chart_path=run.view.chart_path,
         style_family=run.chart.style_family,
         plot_box=plot_box_tuple,
         image_height_mm=run.chart.image_height_mm,
         extracted=run.extracted,
         verdict=run.verdict,
     )
-    return render_production_log(run.chart.slug, [panel])
+
+
+def _render_log_for(runs: list[ExtractRun]) -> str:
+    """Render the lens's full digitization-log.md — one panel per view."""
+    assert runs, "cannot render a log with zero panels"
+    slug = runs[0].chart.slug
+    panels = [_panel_for(r) for r in runs]
+    return render_production_log(slug, panels)
 
 
 def _log_path_for(chart: ReferenceChart) -> Path:
@@ -260,7 +289,12 @@ def _log_path_for(chart: ReferenceChart) -> Path:
 
 
 def extract_lens(slug: str, *, accept_override: bool) -> int:
-    """Extract one lens. Returns 0 on success, non-zero on error."""
+    """Extract one lens. Returns 0 on success, non-zero on error.
+
+    A lens with N views produces N × (SVG + overlay + review.html) plus
+    one digitization-log.md with N panels. The gate aggregates verdicts
+    across views — a single LOW holds the entire lens.
+    """
     chart = _chart_by_slug(slug)
     if chart is None:
         print(f"ERROR: unknown lens slug {slug!r}", file=sys.stderr)
@@ -275,37 +309,41 @@ def extract_lens(slug: str, *, accept_override: bool) -> int:
         )
         return 1
 
-    print(f"Extracting {slug} ({chart.style_family})...")
-    run = _run_one(chart)
+    n_views = len(chart.views)
+    suffix = "" if n_views == 1 else f" — {n_views} views"
+    print(f"Extracting {slug} ({chart.style_family}){suffix}...")
+    runs = _run_all_views(chart)
 
-    svg_path, overlay_path, html_path = _write_inspection_artifacts(run)
     rel = lambda p: p.relative_to(REPO_ROOT)
-    print(f"  wrote {rel(svg_path)}")
-    print(f"  wrote {rel(overlay_path)}")
-    print(f"  wrote {rel(html_path)}")
+    for run in runs:
+        svg_path, overlay_path, html_path = _write_inspection_artifacts(run)
+        print(f"  wrote {rel(svg_path)}")
+        print(f"  wrote {rel(overlay_path)}")
+        print(f"  wrote {rel(html_path)}")
 
-    precision = run.verdict.render_match_precision
-    iou = run.verdict.render_match_iou
-    p_str = f"{precision:.3f}" if precision is not None else "—"
-    i_str = f"{iou:.3f}" if iou is not None else "—"
-    print(
-        f"  verdict: {run.verdict.verdict}  "
-        f"(precision={p_str}, IoU={i_str}, "
-        f"prior_violations={len(run.verdict.prior_violations)})"
-    )
+        precision = run.verdict.render_match_precision
+        iou = run.verdict.render_match_iou
+        p_str = f"{precision:.3f}" if precision is not None else "—"
+        i_str = f"{iou:.3f}" if iou is not None else "—"
+        view_label = run.image_path.stem
+        print(
+            f"  verdict ({view_label}): {run.verdict.verdict}  "
+            f"(precision={p_str}, IoU={i_str}, "
+            f"prior_violations={len(run.verdict.prior_violations)})"
+        )
 
     write, reason = _should_write_log(
-        run.verdict, accept_override=accept_override
+        [r.verdict for r in runs], accept_override=accept_override
     )
     if not write:
         print(
-            f"  HOLD ({reason}): overlay PNG written for maintainer glance; "
+            f"  HOLD ({reason}): overlay PNG(s) written for maintainer glance; "
             f"re-run with --accept to commit the production log."
         )
         return 0
 
     log_path = _log_path_for(chart)
-    log_path.write_text(_render_log_for(run), encoding="utf-8")
+    log_path.write_text(_render_log_for(runs), encoding="utf-8")
     print(f"  wrote {rel(log_path)}  ({reason})")
     return 0
 
@@ -353,8 +391,8 @@ def check_logs(charts: Iterable[ReferenceChart] | None = None) -> int:
 
     failures: list[str] = []
     for chart in target:
-        run = _run_one(chart)
-        expected = _render_log_for(run)
+        runs = _run_all_views(chart)
+        expected = _render_log_for(runs)
         path = _log_path_for(chart)
         rel = path.relative_to(REPO_ROOT)
         actual = path.read_text(encoding="utf-8")

--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -66,8 +66,35 @@ GroundTruthCurves = dict[str, dict[str, tuple[float | None, ...]]]
 
 
 @dataclass(frozen=True)
+class ChartView:
+    """One MTF chart for a lens.
+
+    A prime publishes one chart, a zoom publishes wide + tele. Each view
+    owns its own pixel raster and its own plot box (the auto-detector
+    returns slightly different boxes per chart even within the same
+    lens). All other lens-level attributes — style family, apertures,
+    image-height extent — live on `ReferenceChart` and are shared
+    across views.
+    """
+
+    chart_path: str
+    plot_box: PlotBoxCoords | None = None
+
+
+@dataclass(frozen=True)
 class ReferenceChart:
-    """One eye-verified reference chart entry."""
+    """One eye-verified reference chart entry.
+
+    A lens has at least one primary chart (`chart_path` + `plot_box`)
+    and zero or more additional views (`additional_views` — used by
+    zooms to publish the tele-end chart alongside the canonical
+    wide-end chart per ADR-033). Calibration-tier callers (calibrate,
+    log, emit, scorer, plausibility, autotriage) read only the primary
+    chart — they were written before multi-view zooms existed and never
+    walk `additional_views`. Only the production extractor
+    (`extract.py`) fans out over every view to emit per-view artifacts
+    and a single multi-panel digitization-log.md per lens (#793).
+    """
 
     slug: str
     chart_path: str
@@ -81,6 +108,16 @@ class ReferenceChart:
     # plot-box hasn't been declared yet.
     plot_box: PlotBoxCoords | None = None
     ground_truth: GroundTruthCurves | None = None
+    # Additional chart views beyond the primary. Empty for primes; a
+    # zoom lists its tele-end chart here so the production extractor
+    # emits one log per lens with one panel per chart.
+    additional_views: tuple[ChartView, ...] = ()
+
+    @property
+    def views(self) -> tuple[ChartView, ...]:
+        """Every chart this lens publishes — primary first, then any extras."""
+        primary = ChartView(chart_path=self.chart_path, plot_box=self.plot_box)
+        return (primary, *self.additional_views)
 
 
 # Eye-read ground truth tables for the runnable subset. Each tuple holds
@@ -357,8 +394,14 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("f/2.8",),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (10mm).",
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Wide + tele panels share one digitization-log.md.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/sigma-10-18mm-f2-8-dc-dn-c/sigma-10-18mm-f2-8-dc-dn-c-mtf-diffraction-tele.png",
+                plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+            ),
+        ),
     ),
     ReferenceChart(
         slug="sigma-16-300mm-f3-5-6-7-dc-os-c",
@@ -367,8 +410,14 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("f/3.5",),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (16mm).",
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Wide + tele panels share one digitization-log.md.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/sigma-16-300mm-f3-5-6-7-dc-os-c/sigma-16-300mm-f3-5-6-7-dc-os-c-mtf-diffraction-tele.png",
+                plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+            ),
+        ),
     ),
     ReferenceChart(
         slug="sigma-18-50mm-f2-8-dc-dn-c",
@@ -377,8 +426,14 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("f/2.8",),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (18mm).",
+        notes="Tier 2 (ADR-041) — #793. Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Wide + tele panels share one digitization-log.md.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/sigma-18-50mm-f2-8-dc-dn-c/sigma-18-50mm-f2-8-dc-dn-c-mtf-diffraction-tele.png",
+                plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+            ),
+        ),
     ),
     ReferenceChart(
         slug="sigma-100-400mm-f5-6-3-dg-dn-os-c",
@@ -387,8 +442,14 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("f/5",),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="Tier 2 (ADR-041) — #793. Fujifilm X mount edition; source publishes parallel L/Sony FF and TC chart sets (deleted per #1032). Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Canonical chart is wide-end (100mm).",
+        notes="Tier 2 (ADR-041) — #793. Fujifilm X mount edition; source publishes parallel L/Sony FF and TC chart sets (deleted per #1032). Image 2991x1964 matches 56mm template; 56mm plot box transferred unchanged. Wide + tele panels share one digitization-log.md.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/sigma-100-400mm-f5-6-3-dg-dn-os-c/sigma-100-400mm-f5-6-3-dg-dn-os-c-mtf-diffraction-tele.png",
+                plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=83, y_bottom=1700),
+            ),
+        ),
     ),
     ReferenceChart(
         slug="sigma-17-40mm-f1-8-dc-art",
@@ -397,8 +458,14 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("f/1.8",),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="Tier 2 (ADR-041) — #793. Image 2988x1953 with the wide-end 30 lp/mm curves crossing the right axis frame; required the #1036 detector fix (total ink fraction instead of longest contiguous run). Plot box auto-detected via detect_sigma_plot_box().",
+        notes="Tier 2 (ADR-041) — #793. Image 2988x1953 with the wide-end 30 lp/mm curves crossing the right axis frame; required the #1036 detector fix (total ink fraction instead of longest contiguous run). Plot box auto-detected via detect_sigma_plot_box(). Wide + tele panels share one digitization-log.md.",
         plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=75, y_bottom=1693),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/sigma-17-40mm-f1-8-dc-art/sigma-17-40mm-f1-8-dc-art-mtf-diffraction-tele.png",
+                plot_box=PlotBoxCoords(x_left=309, x_right=2980, y_top=77, y_bottom=1694),
+            ),
+        ),
     ),
     ReferenceChart(
         slug="samyang-85mm-f1-4-as-if-umc",

--- a/tools/mtfdigitizer/tests/test_extract.py
+++ b/tools/mtfdigitizer/tests/test_extract.py
@@ -21,7 +21,7 @@ import pytest
 from mtfdigitizer import extract
 from mtfdigitizer.extract import (
     _is_tier2,
-    _resolve_chart_image,
+    _resolve_view_image,
     _should_write_log,
     check_logs,
     extract_lens,
@@ -32,6 +32,7 @@ from mtfdigitizer.pipeline.sampling import SAMPLE_FRACTIONS
 from mtfdigitizer.priors import PriorViolation
 from mtfdigitizer.production_log import ProductionPanel, render_production_log
 from mtfdigitizer.referenceset.charts import (
+    ChartView,
     PlotBoxCoords,
     REFERENCE_CHARTS,
     ReferenceChart,
@@ -73,27 +74,27 @@ def _low_verdict(reason: LowReason = LowReason.PRECISION_BELOW_THRESHOLD) -> Cha
 
 
 def test_gate_low_verdict_holds_without_accept():
-    write, reason = _should_write_log(_low_verdict(), accept_override=False)
+    write, reason = _should_write_log([_low_verdict()], accept_override=False)
     assert not write
     assert reason == "gate-low"
 
 
 def test_gate_low_verdict_writes_with_accept():
-    write, reason = _should_write_log(_low_verdict(), accept_override=True)
+    write, reason = _should_write_log([_low_verdict()], accept_override=True)
     assert write
     assert reason == "accept-override"
 
 
 def test_gate_high_verdict_holds_when_overlay_glance_required(monkeypatch):
     monkeypatch.setattr(extract, "OVERLAY_GLANCE_REQUIRED", True)
-    write, reason = _should_write_log(_high_verdict(), accept_override=False)
+    write, reason = _should_write_log([_high_verdict()], accept_override=False)
     assert not write
     assert reason == "gate-high-pending-glance"
 
 
 def test_gate_high_verdict_auto_writes_when_glance_not_required(monkeypatch):
     monkeypatch.setattr(extract, "OVERLAY_GLANCE_REQUIRED", False)
-    write, reason = _should_write_log(_high_verdict(), accept_override=False)
+    write, reason = _should_write_log([_high_verdict()], accept_override=False)
     assert write
     assert reason == "gate-high-auto"
 
@@ -104,9 +105,38 @@ def test_gate_accept_always_writes_even_on_low(monkeypatch):
     dashed-M charts that classify LOW but extract cleanly."""
     monkeypatch.setattr(extract, "OVERLAY_GLANCE_REQUIRED", True)
     write, _ = _should_write_log(
-        _low_verdict(LowReason.PRIOR_FAILED_IN_RANGE), accept_override=True
+        [_low_verdict(LowReason.PRIOR_FAILED_IN_RANGE)], accept_override=True
     )
     assert write
+
+
+def test_gate_multi_view_one_low_holds_the_lens(monkeypatch):
+    """A zoom (wide + tele) holds if any view is LOW — the log writer
+    emits one log per lens, so a partial commit is meaningless."""
+    monkeypatch.setattr(extract, "OVERLAY_GLANCE_REQUIRED", True)
+    write, reason = _should_write_log(
+        [_high_verdict(), _low_verdict()], accept_override=False
+    )
+    assert not write
+    assert reason == "gate-low"
+
+
+def test_gate_multi_view_all_high_pending_glance(monkeypatch):
+    monkeypatch.setattr(extract, "OVERLAY_GLANCE_REQUIRED", True)
+    write, reason = _should_write_log(
+        [_high_verdict(), _high_verdict()], accept_override=False
+    )
+    assert not write
+    assert reason == "gate-high-pending-glance"
+
+
+def test_gate_multi_view_accept_override_writes_anyway():
+    """The escape hatch overrides the gate for multi-view lenses too."""
+    write, reason = _should_write_log(
+        [_low_verdict(), _low_verdict()], accept_override=True
+    )
+    assert write
+    assert reason == "accept-override"
 
 
 # --- Tier 2 filter --------------------------------------------------------
@@ -142,11 +172,13 @@ def test_is_tier2_requires_plot_box_and_no_ground_truth():
 # --- Canonical chart selection -------------------------------------------
 
 
-def test_resolve_chart_image_prefers_diffraction_when_present(tmp_path):
+def test_resolve_view_image_prefers_diffraction_when_present(tmp_path):
     """ADR-033 names the canonical chart `-mtf-diffraction.png`. When
     present, the extractor picks it up even if the registry still
     declares the legacy `-mtf-1.png` path (transitional behaviour
-    during #1017 rename)."""
+    during #1017 rename). The probe runs on the primary view only —
+    additional views (zoom tele) already use their canonical
+    focal-suffixed name."""
     legacy_dir = tmp_path / "docs" / "optical-specs" / "fake-slug"
     legacy_dir.mkdir(parents=True)
     legacy = legacy_dir / "fake-slug-mtf-1.png"
@@ -161,20 +193,21 @@ def test_resolve_chart_image_prefers_diffraction_when_present(tmp_path):
         image_height_mm=14.0, notes="",
         plot_box=PlotBoxCoords(x_left=0, x_right=10, y_top=0, y_bottom=10),
     )
+    primary_view = chart.views[0]
 
     import mtfdigitizer.extract as ext_mod
     monkey_root = tmp_path
     original = ext_mod.REPO_ROOT
     ext_mod.REPO_ROOT = monkey_root
     try:
-        resolved = _resolve_chart_image(chart)
+        resolved = _resolve_view_image(chart, primary_view)
     finally:
         ext_mod.REPO_ROOT = original
 
     assert resolved.name == "fake-slug-mtf-diffraction.png"
 
 
-def test_resolve_chart_image_falls_back_to_legacy(tmp_path):
+def test_resolve_view_image_falls_back_to_legacy(tmp_path):
     legacy_dir = tmp_path / "docs" / "optical-specs" / "fake-slug"
     legacy_dir.mkdir(parents=True)
     legacy = legacy_dir / "fake-slug-mtf-1.png"
@@ -187,16 +220,62 @@ def test_resolve_chart_image_falls_back_to_legacy(tmp_path):
         image_height_mm=14.0, notes="",
         plot_box=PlotBoxCoords(x_left=0, x_right=10, y_top=0, y_bottom=10),
     )
+    primary_view = chart.views[0]
 
     import mtfdigitizer.extract as ext_mod
     original = ext_mod.REPO_ROOT
     ext_mod.REPO_ROOT = tmp_path
     try:
-        resolved = _resolve_chart_image(chart)
+        resolved = _resolve_view_image(chart, primary_view)
     finally:
         ext_mod.REPO_ROOT = original
 
     assert resolved.name == "fake-slug-mtf-1.png"
+
+
+def test_resolve_view_image_additional_view_skips_canonical_probe(tmp_path):
+    """The canonical `-mtf-diffraction.png` probe only fires on the
+    primary view. Additional views (zoom tele) declare their full
+    focal-suffixed canonical path and must resolve via fallback —
+    otherwise both wide and tele would collapse to the same file."""
+    lens_dir = tmp_path / "docs" / "optical-specs" / "fake-slug"
+    lens_dir.mkdir(parents=True)
+    primary = lens_dir / "fake-slug-mtf-diffraction-wide.png"
+    primary.write_bytes(b"wide")
+    tele = lens_dir / "fake-slug-mtf-diffraction-tele.png"
+    tele.write_bytes(b"tele")
+    # The bare-canonical lure that would clobber the tele if the probe
+    # ran on additional views.
+    bare = lens_dir / "fake-slug-mtf-diffraction.png"
+    bare.write_bytes(b"bare-lure")
+
+    chart = ReferenceChart(
+        slug="fake-slug",
+        chart_path=str(primary.relative_to(tmp_path)).replace("\\", "/"),
+        style_family="x", apertures=("MAX",), frequencies_lpmm=(10, 30),
+        image_height_mm=14.0, notes="",
+        plot_box=PlotBoxCoords(x_left=0, x_right=10, y_top=0, y_bottom=10),
+        additional_views=(
+            ChartView(
+                chart_path=str(tele.relative_to(tmp_path)).replace("\\", "/"),
+                plot_box=PlotBoxCoords(x_left=0, x_right=10, y_top=0, y_bottom=10),
+            ),
+        ),
+    )
+
+    import mtfdigitizer.extract as ext_mod
+    original = ext_mod.REPO_ROOT
+    ext_mod.REPO_ROOT = tmp_path
+    try:
+        primary_resolved = _resolve_view_image(chart, chart.views[0])
+        tele_resolved = _resolve_view_image(chart, chart.views[1])
+    finally:
+        ext_mod.REPO_ROOT = original
+
+    # Primary's diffraction probe finds the bare lure.
+    assert primary_resolved.name == "fake-slug-mtf-diffraction.png"
+    # Tele's path is preserved untouched — no probe on additional views.
+    assert tele_resolved.name == "fake-slug-mtf-diffraction-tele.png"
 
 
 # --- production_log.render_production_log() ------------------------------


### PR DESCRIPTION
## Summary

The production extractor accepted one chart per lens slug. Sigma zooms publish a wide-end **and** a tele-end MTF chart per focal range, and we want both digitised under one \`digitization-log.md\` per lens — two \`## Panel\` sections in the renderer's already-list-based shape.

## Data shape

\`\`\`python
@dataclass(frozen=True)
class ChartView:
    chart_path: str
    plot_box: PlotBoxCoords | None = None

@dataclass(frozen=True)
class ReferenceChart:
    # ...existing fields unchanged...
    additional_views: tuple[ChartView, ...] = ()

    @property
    def views(self) -> tuple[ChartView, ...]:
        primary = ChartView(chart_path=self.chart_path, plot_box=self.plot_box)
        return (primary, *self.additional_views)
\`\`\`

Primes set nothing (default empty); zooms list their tele chart there. The \`views\` property returns \`(primary, *additional)\` so the extractor iterates either way.

## extract.py changes

- \`_run_view(chart, view)\` runs one view through extract → score → priors → triage
- \`_run_all_views(chart)\` runs every view this lens publishes
- \`_should_write_log(verdicts: list[ChartVerdict])\` aggregates the gate: LOW on **any** view holds the lens; HIGH-pending-glance only when every view passes
- \`_render_log_for(runs: list[ExtractRun])\` builds N \`ProductionPanel\`s and lets \`render_production_log\` emit a single multi-panel log
- \`_resolve_view_image(chart, view)\` only probes the ADR-033 canonical bare \`-mtf-diffraction.png\` on the **primary** view; additional views (already focal-suffixed canonical, e.g. \`-mtf-diffraction-tele.png\`) resolve via fallback so two views in the same folder never collapse to the same file

## Calibration tier unchanged

\`calibrate.py\`, \`log.py\`, \`emit.py\`, \`scorer.py\`, \`plausibility.py\`, \`autotriage.py\` all read \`chart.chart_path\` / \`chart.plot_box\` directly — the primary chart. They never see zooms (which have no \`ground_truth\` and are Tier 2 only).

## Tele entries added

5 tele \`ChartView\`s on the existing zoom \`ReferenceChart\` entries:

| Slug | Tele plot box (auto-detected) |
|---|---|
| sigma-10-18mm-f2-8-dc-dn-c | (309, 2980, 83, 1700) |
| sigma-16-300mm-f3-5-6-7-dc-os-c | (309, 2980, 83, 1700) |
| sigma-18-50mm-f2-8-dc-dn-c | (309, 2980, 83, 1700) |
| sigma-100-400mm-f5-6-3-dg-dn-os-c | (309, 2980, 83, 1700) |
| sigma-17-40mm-f1-8-dc-art | (309, 2980, 77, 1694) |

All 5 detect cleanly via the #1036 total-ink-fraction rule.

## Smoke test

\`\`\`
$ py -m mtfdigitizer.extract sigma-10-18mm-f2-8-dc-dn-c
Extracting sigma-10-18mm-f2-8-dc-dn-c (mainstream-2color-solid-dashed) — 2 views...
  wrote ...-mtf-diffraction-wide.svg
  wrote ...-mtf-diffraction-wide-overlay.png
  wrote ...-mtf-diffraction-wide-review.html
  verdict (...-mtf-diffraction-wide): LOW
  wrote ...-mtf-diffraction-tele.svg
  wrote ...-mtf-diffraction-tele-overlay.png
  wrote ...-mtf-diffraction-tele-review.html
  verdict (...-mtf-diffraction-tele): LOW
  HOLD (gate-low): re-run with --accept to commit the production log.
\`\`\`

## Test plan

- [x] \`py -m pytest tools/mtfdigitizer/tests/\` — 235 passed (was 231; +3 multi-view gate cases, +1 additional-view path resolution)
- [x] \`npm run validate\` clean
- [x] Smoke test extracts wide + tele per zoom; gate aggregates verdicts correctly

## Follow-up data PR

After this merges, a separate data PR runs \`py -m mtfdigitizer.extract <slug> --accept\` on all 5 zooms — produces 10× (SVG + overlay + review.html) plus 5 \`digitization-log.md\` files with two panels each. That artifact set is separate from this PR by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)