### PR TITLE
docs(adr-033): narrow analysis.md remit when digitization-log.md exists

### DIFF
--- a/docs/decisions/033-optical-specs-folder-structure.md
+++ b/docs/decisions/033-optical-specs-folder-structure.md
@@ -3,17 +3,9 @@
 **Status:** Accepted
 **Date:** 2026-05-20
 
-> **Pending amendment (2026-06-01, tracked in #1015).** ADR-040 introduced
-> the generated `digitization-log.md`, which now carries the MTF readings
-> tables, center/edge summary, and shape metrics — data the hand-written
-> `analysis.md` "Readings" section duplicated in older folders. Before the
-> `analysis.md` backfill (#1015) authors new files, this ADR will be amended
-> so that, where a `digitization-log.md` exists, `analysis.md` **references**
-> the digitized readings rather than re-tabulating them, and its remit
-> narrows to the interpretive layer (astigmatism/field-curvature assessment,
-> construction-based predictions, the bridge from numbers to OQ scoring
-> fields). Do not author new inline-readings `analysis.md` files for lenses
-> that already have a digitization-log until this is resolved.
+**Amended 2026-06-05 (session 120):** Narrowed `analysis.md`'s remit when
+a `digitization-log.md` exists in the same folder. See **File
+responsibilities** below.
 
 ## Context
 
@@ -152,9 +144,23 @@ sources. No other formats (JPG, WebP, GIF) are allowed.
 
 ### File responsibilities
 
-- **analysis.md** — deterministic: given the construction and MTF data,
-  what can we predict about optical quality? Contains MTF readings
-  tables, astigmatism assessments, and construction-based predictions.
+- **analysis.md** — deterministic interpretation: given the construction
+  and MTF data, what can we predict about optical quality? Required for
+  every folder. Two formats depending on whether a `digitization-log.md`
+  exists in the same folder:
+  - **With a digitization-log** (ADR-040): `analysis.md` MUST reference
+    the digitized readings (`see digitization-log.md` plus a one-line
+    pointer to the relevant section) rather than re-tabulating them.
+    Its remit is the interpretive layer the generated log deliberately
+    lacks: astigmatism / field-curvature assessment, construction-based
+    predictions, and the bridge from numbers to OQ scoring fields
+    (ADR-014).
+  - **Without a digitization-log**: `analysis.md` MAY include an inline
+    Readings section (legacy format) alongside the interpretive
+    sections. New folders SHOULD prefer to digitize first when the
+    chart is in scope for the digitizer (Sigma today; other vendors as
+    style families are added under ADR-038); the inline-readings
+    format remains valid until then.
 - **scoring-log.md** — justification: why was each optical field scored
   the way it was? Links sources, applies the rubric (ADR-014), records
   the trust level. Same field format as the monolithic scoring log

--- a/docs/optical-specs/tokina-atx-m-11-18mm-f2-8-x/analysis.md
+++ b/docs/optical-specs/tokina-atx-m-11-18mm-f2-8-x/analysis.md
@@ -4,8 +4,8 @@ Source: [Official Tokina product page](https://tokinalens.com/product/atx_m_11_1
 
 MTF charts:
 
-- [tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png) — MTF (11mm)
-- [tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png) — MTF (18mm)
+- [tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png) — MTF (11mm, f/2.8)
+- [tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png) — MTF (18mm, f/2.8)
 
 ## Chart legend
 
@@ -15,6 +15,88 @@ MTF charts:
 - Red = 10 lp/mm, blue = 30 lp/mm
 - Aperture: wide-open (f/2.8) at each focal length
 
-> Interpretive sections (readings, astigmatism, construction-based
-> predictions) intentionally deferred — added under epic #1015.
-> Per-panel digitized readings live in `digitization-log.md`.
+## Readings
+
+Numerical readings are not duplicated here. See
+[digitization-log.md](digitization-log.md) — Panel at 11mm and Panel at 18mm
+each carry the per-field sample grid, center / edge summary, and shape
+metrics. The interpretation below refers back to those tables.
+
+## Astigmatism and field curvature
+
+Both panels show a clean S/M separation that grows from center to corner —
+characteristic of a wide-angle zoom with field-curvature contributions
+rather than a free-standing astigmatic defect.
+
+**11mm panel.** At the 90% field position, resolution-30 S = 0.55 and
+M = 0.45 (digitization-log center/edge summary). The S-vs-M gap of
+~18% sits at the upper boundary of ADR-014's astigmatism "10–18%" band
+(score 1.0). Contrast-10 stays tight (S 0.89 vs M 0.86 at 0.9), so the
+divergence is concentrated at high spatial frequencies, not low.
+
+**18mm panel.** The gap widens at the long end: at 0.9 field, res30 S =
+0.47 vs M = 0.34 (~28%), and at the corner res30 S = 0.44 vs M = 0.28.
+This is the steepest astigmatism in the lens and the reason the scored
+`astigmatism` field sits at 1.0 rather than 1.5 — averaging the two
+panels per ADR-014's zoom rule (per-position mean of divergences) keeps
+the field in the 10–18% band overall, but the tele end on its own would
+fall into the 18–25% band (score 0.5).
+
+The shape — S consistently higher than M, with the gap accelerating past
+the 70% field marker — points to **field curvature** as the primary
+contributor: meridional structures fall off faster as the focal plane
+bends away from the sensor toward the corners. Stopping down brings both
+curves up together, which Abbott (2025-02) confirms in the f/5.6–f/8
+range.
+
+## Construction-based predictions
+
+The 13/11 optical formula carries **two aspherical + two SD elements**
+(specs-log.md). Predictions consistent with that formula and validated
+against the digitized readings:
+
+- **Distortion** — UWA zooms in this class without aspherical correction
+  at the wide end show 3–5% barrel; two aspherical elements typically
+  pull that into the 1–2% range with profile correction handling the
+  residual. Stored `distortion = 1.0` (ADR-014's "1.0–2.0%" band) is
+  consistent. The vendor MTF carries no distortion signal directly —
+  this prediction is rubric-applied from review measurements, not
+  inferred from the chart.
+- **Lateral CA** — two SD elements at the wide end of a UWA zoom is a
+  standard countermeasure for lateral colour at the corners. Abbott
+  reports it as well controlled out of camera; stored `lateralCA = 2.0`
+  is consistent with the "negligible" band.
+- **Longitudinal CA** — UWA primes and zooms rarely show significant
+  longCA because the long-focal failure modes (purple/green fringing on
+  out-of-focus highlights) are minimal at f/2.8 with this short focal
+  range. Stored `longitudinalCA = 1.5` is consistent.
+- **Vignetting** — fast UWA zooms ship with strong wide-open vignetting;
+  the published MTF does not measure it. Stored `vignettingWideOpen = 0`
+  reflects the lab measurement that this lens is at the harsher end of
+  the "> 2.0 EV" band. Stopping down to f/5.6–f/8 recovers most of it
+  (`vignettingStopped = 1.0`).
+
+## Bridge to OQ scoring fields
+
+The MTF readings drive the resolution and astigmatism scores; the other
+fields are filled from Abbott's review per ADR-014's trust hierarchy.
+Detailed per-field rubric application lives in `scoring-log.md` (to be
+authored when this lens is re-scored). Summary of how the digitized
+readings map to the scored values currently in `lenses.ts`:
+
+| Field              | Score | Driver                                              |
+| ------------------ | ----- | --------------------------------------------------- |
+| centerWideOpen     | 1.5   | res30 center ~0.97 (11mm) / 0.91 (18mm) on chart    |
+| cornerWideOpen     | 1.0   | res30 corner 0.45 (11mm) / 0.44 (18mm) on chart     |
+| centerStopped      | 1.5   | Abbott f/5.6–f/8 lab measurement                    |
+| cornerStopped      | 1.0   | Abbott f/8 corner; chart only published at f/2.8    |
+| astigmatism        | 1.0   | S-vs-M divergence per ADR-014 zoom-mean rule        |
+| distortion         | 1.0   | Construction prediction + Abbott confirms ~1.5%     |
+| lateralCA          | 2.0   | 2 SD elements + Abbott "well controlled"            |
+| longitudinalCA     | 1.5   | UWA at f/2.8 — minimal longCA expected and observed |
+| vignettingWideOpen | 0.0   | Abbott — strong wide-open fall-off                  |
+| vignettingStopped  | 1.0   | Abbott — recovers at f/5.6–f/8                      |
+
+> The Tokina chart is published at f/2.8 (wide-open) only. Stopped-down
+> scores rely on the Abbott review measurements rather than on the
+> vendor chart.

--- a/docs/optical-specs/tokina-atx-m-11-18mm-f2-8-x/analysis.md
+++ b/docs/optical-specs/tokina-atx-m-11-18mm-f2-8-x/analysis.md
@@ -4,8 +4,8 @@ Source: [Official Tokina product page](https://tokinalens.com/product/atx_m_11_1
 
 MTF charts:
 
-- [tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png) — MTF (11mm, f/2.8)
-- [tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png) — MTF (18mm, f/2.8)
+- [tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-11mm.png) — MTF (11mm)
+- [tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png](tokina-atx-m-11-18mm-f2-8-x-mtf-18mm.png) — MTF (18mm)
 
 ## Chart legend
 
@@ -15,88 +15,6 @@ MTF charts:
 - Red = 10 lp/mm, blue = 30 lp/mm
 - Aperture: wide-open (f/2.8) at each focal length
 
-## Readings
-
-Numerical readings are not duplicated here. See
-[digitization-log.md](digitization-log.md) — Panel at 11mm and Panel at 18mm
-each carry the per-field sample grid, center / edge summary, and shape
-metrics. The interpretation below refers back to those tables.
-
-## Astigmatism and field curvature
-
-Both panels show a clean S/M separation that grows from center to corner —
-characteristic of a wide-angle zoom with field-curvature contributions
-rather than a free-standing astigmatic defect.
-
-**11mm panel.** At the 90% field position, resolution-30 S = 0.55 and
-M = 0.45 (digitization-log center/edge summary). The S-vs-M gap of
-~18% sits at the upper boundary of ADR-014's astigmatism "10–18%" band
-(score 1.0). Contrast-10 stays tight (S 0.89 vs M 0.86 at 0.9), so the
-divergence is concentrated at high spatial frequencies, not low.
-
-**18mm panel.** The gap widens at the long end: at 0.9 field, res30 S =
-0.47 vs M = 0.34 (~28%), and at the corner res30 S = 0.44 vs M = 0.28.
-This is the steepest astigmatism in the lens and the reason the scored
-`astigmatism` field sits at 1.0 rather than 1.5 — averaging the two
-panels per ADR-014's zoom rule (per-position mean of divergences) keeps
-the field in the 10–18% band overall, but the tele end on its own would
-fall into the 18–25% band (score 0.5).
-
-The shape — S consistently higher than M, with the gap accelerating past
-the 70% field marker — points to **field curvature** as the primary
-contributor: meridional structures fall off faster as the focal plane
-bends away from the sensor toward the corners. Stopping down brings both
-curves up together, which Abbott (2025-02) confirms in the f/5.6–f/8
-range.
-
-## Construction-based predictions
-
-The 13/11 optical formula carries **two aspherical + two SD elements**
-(specs-log.md). Predictions consistent with that formula and validated
-against the digitized readings:
-
-- **Distortion** — UWA zooms in this class without aspherical correction
-  at the wide end show 3–5% barrel; two aspherical elements typically
-  pull that into the 1–2% range with profile correction handling the
-  residual. Stored `distortion = 1.0` (ADR-014's "1.0–2.0%" band) is
-  consistent. The vendor MTF carries no distortion signal directly —
-  this prediction is rubric-applied from review measurements, not
-  inferred from the chart.
-- **Lateral CA** — two SD elements at the wide end of a UWA zoom is a
-  standard countermeasure for lateral colour at the corners. Abbott
-  reports it as well controlled out of camera; stored `lateralCA = 2.0`
-  is consistent with the "negligible" band.
-- **Longitudinal CA** — UWA primes and zooms rarely show significant
-  longCA because the long-focal failure modes (purple/green fringing on
-  out-of-focus highlights) are minimal at f/2.8 with this short focal
-  range. Stored `longitudinalCA = 1.5` is consistent.
-- **Vignetting** — fast UWA zooms ship with strong wide-open vignetting;
-  the published MTF does not measure it. Stored `vignettingWideOpen = 0`
-  reflects the lab measurement that this lens is at the harsher end of
-  the "> 2.0 EV" band. Stopping down to f/5.6–f/8 recovers most of it
-  (`vignettingStopped = 1.0`).
-
-## Bridge to OQ scoring fields
-
-The MTF readings drive the resolution and astigmatism scores; the other
-fields are filled from Abbott's review per ADR-014's trust hierarchy.
-Detailed per-field rubric application lives in `scoring-log.md` (to be
-authored when this lens is re-scored). Summary of how the digitized
-readings map to the scored values currently in `lenses.ts`:
-
-| Field              | Score | Driver                                              |
-| ------------------ | ----- | --------------------------------------------------- |
-| centerWideOpen     | 1.5   | res30 center ~0.97 (11mm) / 0.91 (18mm) on chart    |
-| cornerWideOpen     | 1.0   | res30 corner 0.45 (11mm) / 0.44 (18mm) on chart     |
-| centerStopped      | 1.5   | Abbott f/5.6–f/8 lab measurement                    |
-| cornerStopped      | 1.0   | Abbott f/8 corner; chart only published at f/2.8    |
-| astigmatism        | 1.0   | S-vs-M divergence per ADR-014 zoom-mean rule        |
-| distortion         | 1.0   | Construction prediction + Abbott confirms ~1.5%     |
-| lateralCA          | 2.0   | 2 SD elements + Abbott "well controlled"            |
-| longitudinalCA     | 1.5   | UWA at f/2.8 — minimal longCA expected and observed |
-| vignettingWideOpen | 0.0   | Abbott — strong wide-open fall-off                  |
-| vignettingStopped  | 1.0   | Abbott — recovers at f/5.6–f/8                      |
-
-> The Tokina chart is published at f/2.8 (wide-open) only. Stopped-down
-> scores rely on the Abbott review measurements rather than on the
-> vendor chart.
+> Interpretive sections (readings, astigmatism, construction-based
+> predictions) intentionally deferred — added under epic #1015.
+> Per-panel digitized readings live in `digitization-log.md`.


### PR DESCRIPTION
## Summary

- Amends **ADR-033** so that when a \`digitization-log.md\` exists in the
  same folder, \`analysis.md\` references the digitized readings instead
  of re-tabulating them; its remit narrows to the interpretive layer
  (astigmatism / field-curvature assessment, construction-based
  predictions, bridge to OQ scoring fields).
- Folders without a digitization-log MAY keep the legacy inline-readings
  format.

## Why

ADR-033 already flagged this question as pending (the callout block
referenced #1015 and ADR-040). Lifting the answer into the body settles
the spec so the next session that picks up #1015 starts from a clear
rule.

The Tokina pilot \`analysis.md\` originally in this PR has been reverted
(0129660) — that piece was the first slice of #1015 (P3 / Backlog) and
out of scope while v0.8.0 is the active milestone.

## Test plan

- [x] \`npm run validate\` — green on the original commit (lint, format,
      check, 215 vitest, 461-page build, link check). Revert only
      restored a file already on \`main\`.
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)