### PR TITLE
feat(mtf): per-aperture multipath orchestrator (ADR-044)

### DIFF
--- a/docs/decisions/044-multi-aperture-per-chart-orchestrator.md
+++ b/docs/decisions/044-multi-aperture-per-chart-orchestrator.md
@@ -1,0 +1,240 @@
+# ADR-044: Multi-aperture per-chart orchestrator
+
+**Status:** Accepted
+**Date:** 2026-06-07
+
+## Context
+
+The MTF digitizer's orchestrator (ADR-038, ADR-041) and its
+per-frequency extension for Fujifilm (ADR-043) both assume each chart
+image carries data for exactly **one aperture**. The aperture lives on
+the `ReferenceChart.apertures` tuple (a one-element tuple for every
+profile shipped before this ADR) and is treated as metadata on the lens
+record, not as a per-pixel signal the extractor needs to disambiguate.
+
+Every declared profile to date honors that assumption:
+
+- Sigma, Samyang, 7Artisans, Tokina, Viltrox publish one chart image
+  per lens at maximum aperture only — the chart contains the four
+  curves `{10S, 10M, 30S, 30M}` and nothing else.
+- Fujifilm publishes one chart image per spatial frequency at
+  maximum aperture only — three or six images per lens, all at the
+  same f-stop. ADR-043's multipath orchestrator fans out over images
+  but each image is still single-aperture.
+
+TTartisan breaks the assumption. Their MTF publication convention is
+**one chart image per lens, with two apertures packed into the same
+panel by color encoding**:
+
+- **Black curves** (low V, near-zero S): 10 lp/mm at **maximum** aperture
+- **Grey curves** (mid V, near-zero S): 30 lp/mm at **maximum** aperture
+- **Red curves** (saturated, hue ≈ 1 in OpenCV's 0–179 range): 10 lp/mm
+  at a **stopped** aperture (f/5.6 / f/8 / f/11 depending on the lens)
+- **Orange curves** (saturated, hue ≈ 17): 30 lp/mm at the same
+  stopped aperture
+
+Per color, the solid line is the sagittal (S) curve and the dashed line
+is the tangential (T) curve, mirroring the Sigma convention. Eight
+curves total per chart: four colors × two line styles.
+
+The legend on the right names every curve with its aperture, e.g.
+`S10_F1.2`, `T10_F5.6`, `S30_Fmax`, `T30_F11`. The stopped aperture
+varies per lens — the legend always carries the actual f-number; the
+slug encodes the lens's max aperture only.
+
+The survey of all 19 TTartisan charts in `docs/optical-specs/ttartisan-*`
+confirms the convention is consistent across the brand (prime, macro,
+fisheye, tilt, AF). The two-aperture-per-chart packing is the brand's
+publication standard, not a one-off.
+
+### Why the existing orchestrator does not fit
+
+The single-aperture assumption is baked into the dispatch helper:
+
+```python
+def _profile_for_view(chart, image_path) -> MtfProfile:
+    base = profile_for_chart(chart)
+    if chart.style_family in _FUJI_STYLE_FAMILIES:
+        freq = _parse_filename_frequency(image_path)
+        return dataclasses.replace(base, frequencies_lpmm=(freq,))
+    return base
+```
+
+`_profile_for_view` returns one profile per view. `_run_view` runs the
+extractor once on that profile. `_run_all_views` produces one
+`ExtractRun` per declared view, period.
+
+Two paths considered to accommodate TTartisan-style charts:
+
+1. **Skip the stopped aperture.** Declare the TTartisan profile with
+   only the black + grey hues; emit max-aperture readings only and
+   discard 50% of the published data. Rejected — same shape as the
+   "treat Fujifilm as a Sigma chart with two frequencies dropped"
+   alternative rejected in ADR-042. We ship every published curve or
+   we don't ship the brand.
+2. **Synthesize two virtual `ChartView` objects per chart image, each
+   tagged with its aperture.** Rejected on structural grounds: a
+   `ChartView` already declares `chart_path` + `plot_box`. Two views
+   pointing at the same image with different aperture metadata would
+   require either (a) extending `ChartView` with an aperture field
+   (touches every reference-set entry, every CLI that walks views) or
+   (b) tagging the same view differently on each iteration (mutates a
+   frozen dataclass conceptually). Neither is clean.
+
+The fix is to introduce a third dispatch path at the same layer as
+Fuji's per-frequency substitution: per-aperture fan-out at
+`_aperture_passes_for_view`.
+
+## Decision
+
+### A new profile field: `apertures_per_chart`
+
+`MtfProfile` gains an optional field:
+
+```python
+@dataclass(frozen=True)
+class MtfProfile:
+    ...
+    apertures_per_chart: tuple[str, ...] | None = None
+```
+
+- **None** (default) means the profile follows the single-aperture
+  convention. Every existing profile keeps the default — no behavior
+  change for Sigma, Samyang, 7Artisans, Tokina, Viltrox, Fujifilm.
+- **A tuple of aperture labels** declares that the chart image packs N
+  apertures by color encoding. The orchestrator runs the extractor
+  once per aperture in this tuple, each time with the profile's
+  `hues` filtered to the aperture's bucket.
+
+The labels are opaque strings used as a name prefix on `HueRange.name`
+entries (see "Hue naming convention" below). The orchestrator treats
+them as identifiers, not as f-numbers — the actual numeric f-stop
+lives on the parent `ReferenceChart.apertures`, in the same positions
+as `apertures_per_chart`.
+
+### Hue naming convention
+
+Profiles with `apertures_per_chart=("a", "b", ...)` MUST name every
+`HueRange` with a prefix matching one of the declared apertures plus a
+hyphen. The orchestrator's filter:
+
+```python
+def _hue_filtered_profile(profile, aperture) -> MtfProfile:
+    filtered = tuple(h for h in profile.hues if h.name.startswith(f"{aperture}-"))
+    return dataclasses.replace(profile, hues=filtered)
+```
+
+A hue whose name does not match any aperture prefix is silently
+dropped across all passes — by design, so a typo fails loud at
+extraction time (the extractor sees a profile with zero hues and
+refuses).
+
+### Orchestrator change: `_aperture_passes_for_view`
+
+The single-aperture `_profile_for_view` helper becomes the
+multi-aperture fan-out `_aperture_passes_for_view`:
+
+```python
+def _aperture_passes_for_view(
+    chart: ReferenceChart, image_path: Path
+) -> list[tuple[str, MtfProfile]]:
+    base = profile_for_chart(chart)
+    if chart.style_family in _FUJI_STYLE_FAMILIES:
+        freq = _parse_filename_frequency(image_path)
+        substituted = dataclasses.replace(base, frequencies_lpmm=(freq,))
+        return [(chart.apertures[0], substituted)]
+    if base.apertures_per_chart is not None:
+        return [
+            (ap, _hue_filtered_profile(base, ap)) for ap in base.apertures_per_chart
+        ]
+    return [(chart.apertures[0] if chart.apertures else "", base)]
+```
+
+`_profile_for_view` survives as a thin back-compat shim returning the
+first pass's profile, so existing callers (and tests) that predate the
+fan-out keep working without modification.
+
+`_run_view` becomes `_run_view_passes` returning `list[ExtractRun]`
+(one per pass). `_run_all_views` flattens.
+
+### A new field on `ExtractRun`: `aperture`
+
+```python
+@dataclass(frozen=True)
+class ExtractRun:
+    ...
+    aperture: str = ""
+```
+
+The default empty string preserves back-compat for callers that
+construct `ExtractRun` without populating the field (mostly tests).
+Production paths through `_run_view_passes` always populate it.
+
+The downstream `ProductionPanel` does NOT grow an aperture field —
+the aperture label flows from the orchestrator to the log renderer
+through the surrounding `ExtractRun` list, not through the panel
+dataclass. This keeps the panel shape stable for existing single-
+aperture brands.
+
+### What this ADR does NOT do
+
+- Does NOT declare the TTartisan profile. That lands in a follow-up PR
+  (and a follow-up ADR if the profile's dispatch needs anything beyond
+  what the four declared `hue_meaning` dispatch paths already cover).
+- Does NOT change the schema for `ReferenceChart`, `ChartView`,
+  `ProductionPanel`, or any pipeline type.
+- Does NOT modify the existing five declared profiles or the
+  Fujifilm profile. They retain `apertures_per_chart=None` and route
+  through the unchanged single-pass path.
+- Does NOT modify the `mtf-readings.ts` data shape. The emit pipeline
+  for a multi-aperture brand will produce one TS object literal per
+  aperture pass per lens, mirroring the way Fuji emits one panel per
+  frequency-aware view; the shape on disk is unchanged.
+
+## Alternatives considered
+
+| Alternative                                                                 | Why rejected                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Extend `ChartView` with an `aperture` field; synthesize two views per chart | Same image, different metadata per view. Forces every existing reference-set entry to declare `aperture=None` (or get migrated). Forces every CLI that walks `chart.views` to handle the new field. The fan-out at orchestrator level is more localized — only `extract.py` and the new profile field change.                                                                                                                                                                                                                                    |
+| Extend the schema on `ReferenceChart` with `apertures_per_chart`            | Same fan-out logic, declared on the chart instead of the profile. Rejected because the rule is structural to the chart STYLE (every TTartisan chart packs two apertures) rather than to individual lenses. Putting it on the profile means TTartisan declares it once and every TTartisan `ReferenceChart` inherits the behavior.                                                                                                                                                                                                                |
+| Skip the stopped aperture; emit max-aperture data only                      | Discards 50% of TTartisan's published data. Same shape as ADR-042's rejected "drop the high frequency" alternative. We ship every published curve or not at all.                                                                                                                                                                                                                                                                                                                                                                                 |
+| Composite the chart image into N synthetic images upfront                   | Mask the chart by aperture color bucket, save two synthetic PNGs, feed each to the existing single-pass orchestrator. Rejected as fake input: the synthetic images would carry no maintainer-verifiable provenance and would invalidate the render-match score (which compares against the source PNG). The fan-out happens at the orchestrator, not the image.                                                                                                                                                                                  |
+| Declare two profiles for TTartisan and two `ReferenceChart`s per lens       | One ReferenceChart per (lens, aperture), each pointing at the same chart image. Rejected because two charts per lens doubles the entry count in the reference set (~38 TTartisan entries instead of 19) and the slug uniqueness invariant would need an aperture suffix. The orchestrator-level fan-out keeps the reference set as one-row-per-lens.                                                                                                                                                                                             |
+| Defer TTartisan; pick a brand that fits the single-aperture convention      | Considered. The session-124 memory's next-brand candidates included TTartisan (19 charts) and Voigtländer (0 charts, MTF policy limits publication to APO-LANTHAR). The other un-anchored brands (#800–#814) were not surveyed for chart packing; some may also pack multiple apertures. Picking a smaller brand defers the architectural work, but the work is genuinely needed because the dual-aperture pattern is not TTartisan-specific (some Sigma Art line chart sheets pack `f/wide` + `f/8` similarly, observed but not yet onboarded). |
+
+## Consequences
+
+- **The orchestrator grows a second fan-out axis.** ADR-043 added
+  per-frequency fan-out via Fuji's filename suffix. This ADR adds
+  per-aperture fan-out via profile metadata. The two axes are
+  independent — a future style family could combine both (per-frequency
+  images each packing two apertures by color). The dispatch in
+  `_aperture_passes_for_view` handles them as separate branches and
+  composing them would be a third branch, not a rewrite.
+- **Profile naming convention becomes load-bearing for multi-aperture
+  profiles.** `HueRange.name` was historically free-form documentation
+  (`"red"`, `"10S-saturated-red"`). For multi-aperture profiles the
+  prefix is now a contract the orchestrator parses. Documented in
+  `profiles/types.py` and in this ADR.
+- **`_profile_for_view` is now a back-compat shim.** It returns the
+  first pass's profile, which is correct for single-aperture profiles
+  but lossy for multi-aperture ones. New code calls
+  `_aperture_passes_for_view` directly. The shim is kept so existing
+  tests don't need to migrate; it will be removed in a future cleanup
+  PR once those tests are rewritten.
+- **`ExtractRun` carries an aperture label.** Downstream consumers
+  (the log renderer, the emit pipeline for multi-aperture brands) can
+  read it. Existing consumers ignore it — the default empty string is
+  benign for them.
+- **No PRs ship a multi-aperture profile yet.** This PR ships the
+  plumbing only. The TTartisan profile + Tier 1 anchor + Tier 2 bulk
+  land in a follow-up PR (#798).
+- **Test coverage: 6 new unit tests.** `_hue_filtered_profile`,
+  `_aperture_passes_for_view` for standard / Fuji / multi-aperture
+  shapes, the back-compat shim, and `ExtractRun.aperture` default.
+  All 24 pre-existing extract tests still pass — single-aperture
+  regression coverage.
+- **Future brand reuse.** Any brand that packs N apertures into one
+  chart image by color (TTartisan today; possibly some Sigma Art /
+  Tamron product pages tomorrow) declares `apertures_per_chart` and
+  registers per-aperture hue prefixes. No further orchestrator work.

--- a/tools/mtfdigitizer/extract.py
+++ b/tools/mtfdigitizer/extract.py
@@ -153,7 +153,15 @@ def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
 
 @dataclass(frozen=True)
 class ExtractRun:
-    """The full output of one chart view's extraction pass."""
+    """The full output of one chart view's extraction pass.
+
+    `aperture` labels which f-stop the extracted readings represent.
+    For single-aperture charts (every style family before ADR-044) this
+    is just `chart.apertures[0]`. For multi-aperture charts (TTartisan-
+    style: one image, N apertures encoded by color) the orchestrator
+    runs one pass per aperture and tags each ExtractRun with its own
+    aperture label.
+    """
 
     chart: ReferenceChart
     view: ChartView
@@ -161,6 +169,7 @@ class ExtractRun:
     plot_box: PlotBox
     extracted: ExtractedChart
     verdict: ChartVerdict
+    aperture: str = ""
 
 
 def _parse_filename_frequency(image_path: Path) -> int:
@@ -181,63 +190,112 @@ def _parse_filename_frequency(image_path: Path) -> int:
     return int(m.group("freq"))
 
 
-def _profile_for_view(chart: ReferenceChart, image_path: Path) -> MtfProfile:
-    """Choose the runtime profile for one chart view.
+def _hue_filtered_profile(profile: MtfProfile, aperture: str) -> MtfProfile:
+    """Return a profile copy with `hues` filtered to one aperture.
 
-    For most style families this is just the chart's declared profile.
-    For Fujifilm per-frequency charts (ADR-043), the declared profile
-    carries a sentinel `frequencies_lpmm=(0,)`; this helper parses the
-    real frequency from the filename and returns a profile copy with
-    `frequencies_lpmm=(parsed_freq,)`.
+    Used by multi-aperture dispatch (ADR-044): when a chart packs N
+    apertures per image by color encoding (TTartisan-style), each
+    `HueRange.name` is prefixed `f"{aperture}-..."`. This helper keeps
+    only the hues for the requested aperture so the extractor sees a
+    standard single-aperture profile.
+    """
+    filtered = tuple(h for h in profile.hues if h.name.startswith(f"{aperture}-"))
+    return dataclasses.replace(profile, hues=filtered)
+
+
+def _aperture_passes_for_view(
+    chart: ReferenceChart, image_path: Path
+) -> list[tuple[str, MtfProfile]]:
+    """Resolve a view to one or more (aperture, profile) extraction passes.
+
+    Most style families produce one pass — the chart's declared profile,
+    paired with the chart's primary aperture label. Two style families
+    fan out to multiple passes:
+
+    - Fujifilm per-frequency (ADR-043): one pass, but the profile is
+      copied with `frequencies_lpmm` substituted from the filename.
+      Still single-aperture.
+    - Multi-aperture-per-chart (ADR-044): one chart image packs N
+      apertures by color encoding. The orchestrator returns N passes,
+      each with the profile's hues filtered to one aperture's bucket.
+
+    The default fan-out for back-compat is `[(chart.apertures[0], profile)]`.
     """
     base = profile_for_chart(chart)
     if chart.style_family in _FUJI_STYLE_FAMILIES:
         freq = _parse_filename_frequency(image_path)
-        return dataclasses.replace(base, frequencies_lpmm=(freq,))
-    return base
+        substituted = dataclasses.replace(base, frequencies_lpmm=(freq,))
+        return [(chart.apertures[0], substituted)]
+    if base.apertures_per_chart is not None:
+        return [
+            (ap, _hue_filtered_profile(base, ap)) for ap in base.apertures_per_chart
+        ]
+    return [(chart.apertures[0] if chart.apertures else "", base)]
 
 
-def _run_view(chart: ReferenceChart, view: ChartView) -> ExtractRun:
-    """Run one chart view through extract → score → priors → triage.
+def _profile_for_view(chart: ReferenceChart, image_path: Path) -> MtfProfile:
+    """Back-compat shim: return the first pass's profile.
 
-    No I/O beyond reading the chart raster.
+    Reserved for callers (e.g. tests) that predate the multi-aperture
+    fan-out and only need to inspect the single declared profile. Do
+    not use in new code — call `_aperture_passes_for_view` instead so
+    multi-aperture profiles dispatch correctly.
+    """
+    return _aperture_passes_for_view(chart, image_path)[0][1]
+
+
+def _run_view_passes(
+    chart: ReferenceChart, view: ChartView
+) -> list[ExtractRun]:
+    """Run one chart view through one or more extract → score → priors → triage
+    passes (one per aperture). Returns one ExtractRun per pass.
+
+    No I/O beyond reading the chart raster — even for multi-aperture
+    profiles, the raster is read once and reused across passes.
     """
     assert view.plot_box is not None, (
         f"chart {chart.slug!r} view {view.chart_path!r} has no plot_box — "
         "cannot run extractor"
     )
     image_path = _resolve_view_image(chart, view)
-    profile = _profile_for_view(chart, image_path)
     plot_box = _to_plotbox(view.plot_box)
+    passes = _aperture_passes_for_view(chart, image_path)
 
-    extracted = extract_chart(
-        image_path, profile, plot_box, image_height_mm=chart.image_height_mm
-    )
-    score = score_chart(
-        image_path,
-        profile,
-        plot_box,
-        image_height_mm=chart.image_height_mm,
-        readings=extracted.readings,
-        dilation_radius_px=DEFAULT_DILATION_RADIUS_PX,
-    )
-    violations = check_all(extracted.readings)
-    verdict = triage(score, violations)
-    return ExtractRun(
-        chart=chart,
-        view=view,
-        image_path=image_path,
-        plot_box=plot_box,
-        extracted=extracted,
-        verdict=verdict,
-    )
+    runs: list[ExtractRun] = []
+    for aperture, profile in passes:
+        extracted = extract_chart(
+            image_path, profile, plot_box, image_height_mm=chart.image_height_mm
+        )
+        score = score_chart(
+            image_path,
+            profile,
+            plot_box,
+            image_height_mm=chart.image_height_mm,
+            readings=extracted.readings,
+            dilation_radius_px=DEFAULT_DILATION_RADIUS_PX,
+        )
+        violations = check_all(extracted.readings)
+        verdict = triage(score, violations)
+        runs.append(
+            ExtractRun(
+                chart=chart,
+                view=view,
+                image_path=image_path,
+                plot_box=plot_box,
+                extracted=extracted,
+                verdict=verdict,
+                aperture=aperture,
+            )
+        )
+    return runs
 
 
 def _run_all_views(chart: ReferenceChart) -> list[ExtractRun]:
-    """Run every view this lens publishes. Each view contributes one
-    panel to the lens's single digitization-log.md.
+    """Run every view this lens publishes. Each view contributes one or
+    more panels to the lens's single digitization-log.md — one panel per
+    aperture pass per view (single-aperture charts: one panel per view).
     """
-    return [_run_view(chart, view) for view in chart.views]
+    return [run for view in chart.views for run in _run_view_passes(chart, view)]
 
 
 # --- Acceptance decision --------------------------------------------------

--- a/tools/mtfdigitizer/profiles/types.py
+++ b/tools/mtfdigitizer/profiles/types.py
@@ -173,6 +173,14 @@ class MtfProfile:
     # masks only contain one color and within-color curves don't run
     # parallel for these chart styles).
     close_kernel_width: int | None = None
+    # When set, the chart image packs multiple apertures per panel via
+    # color encoding (TTartisan-style: black+grey curves at max aperture,
+    # red+orange at the stopped aperture). The orchestrator runs the
+    # extractor once per aperture in this tuple, each time with `hues`
+    # filtered to those whose `HueRange.name` starts with `f"{aperture}-"`.
+    # None for single-aperture charts (every profile shipped before this
+    # extension). See ADR-044 (multi-aperture orchestrator).
+    apertures_per_chart: tuple[str, ...] | None = None
 
     @property
     def hue_count(self) -> int:

--- a/tools/mtfdigitizer/tests/test_extract.py
+++ b/tools/mtfdigitizer/tests/test_extract.py
@@ -507,3 +507,158 @@ def test_profile_for_view_passes_through_non_fuji_charts():
     sigma_chart = next(c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c")
     profile = _profile_for_view(sigma_chart, Path(sigma_chart.chart_path))
     assert profile.frequencies_lpmm == (10, 30)
+
+
+# --- Multi-aperture orchestrator (ADR-044) ---------------------------------
+
+
+def test_hue_filtered_profile_keeps_only_matching_prefix():
+    """`_hue_filtered_profile` selects hues whose name starts with the
+    aperture token plus a `-`. Used by the multi-aperture orchestrator
+    to derive a per-aperture profile copy from one declared profile."""
+    from mtfdigitizer.extract import _hue_filtered_profile
+    from mtfdigitizer.profiles.types import HueRange, MtfProfile
+
+    profile = MtfProfile(
+        name="probe",
+        hues=(
+            HueRange(name="max-10S-black", h_lo=0, h_hi=179, s_min=0, v_max=80),
+            HueRange(name="max-30S-grey", h_lo=0, h_hi=179, s_min=0, v_min=90, v_max=160),
+            HueRange(name="stopped-10S-red", h_lo=0, h_hi=10, s_min=80, v_min=60),
+            HueRange(name="stopped-30S-orange", h_lo=11, h_hi=25, s_min=80, v_min=60),
+        ),
+        style_axis="SPLIT_BY_DASH",
+        hue_meaning="FREQUENCY",
+        frequencies_lpmm=(10, 30),
+        apertures_per_chart=("max", "stopped"),
+    )
+
+    max_only = _hue_filtered_profile(profile, "max")
+    assert tuple(h.name for h in max_only.hues) == (
+        "max-10S-black",
+        "max-30S-grey",
+    )
+
+    stopped_only = _hue_filtered_profile(profile, "stopped")
+    assert tuple(h.name for h in stopped_only.hues) == (
+        "stopped-10S-red",
+        "stopped-30S-orange",
+    )
+
+
+def test_aperture_passes_for_view_default_single_pass():
+    """Standard single-aperture charts still produce one pass after the
+    multi-aperture refactor — no regression for Sigma, Samyang, etc."""
+    from mtfdigitizer.extract import _aperture_passes_for_view
+
+    sigma_chart = next(c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c")
+    passes = _aperture_passes_for_view(sigma_chart, Path(sigma_chart.chart_path))
+    assert len(passes) == 1
+    aperture, profile = passes[0]
+    assert aperture == sigma_chart.apertures[0]
+    assert profile.frequencies_lpmm == (10, 30)
+
+
+def test_aperture_passes_for_view_fuji_single_pass():
+    """Fuji per-frequency charts still produce one pass per filename,
+    not one-per-aperture. The Fuji frequency substitution and the
+    multi-aperture fan-out are independent dispatches."""
+    from mtfdigitizer.extract import _aperture_passes_for_view
+
+    fuji_chart = ReferenceChart(
+        slug="probe-fuji",
+        chart_path="docs/optical-specs/probe-fuji/probe-fuji-15lp.png",
+        style_family="fujifilm-permfreq",
+        apertures=("f/4",),
+        frequencies_lpmm=(15, 20, 40),
+        image_height_mm=25.0,
+        notes="probe",
+    )
+    passes = _aperture_passes_for_view(
+        fuji_chart, Path("docs/optical-specs/probe-fuji/probe-fuji-20lp.png")
+    )
+    assert len(passes) == 1
+    aperture, profile = passes[0]
+    assert aperture == "f/4"
+    assert profile.frequencies_lpmm == (20,)
+
+
+def test_aperture_passes_for_view_multi_aperture_fan_out(monkeypatch):
+    """A profile with `apertures_per_chart=(...)` produces N passes, one
+    per aperture, each carrying a hue-filtered profile copy."""
+    from mtfdigitizer import extract as extract_mod
+    from mtfdigitizer.extract import _aperture_passes_for_view
+    from mtfdigitizer.profiles.types import HueRange, MtfProfile
+
+    probe_profile = MtfProfile(
+        name="probe-dual-aperture",
+        hues=(
+            HueRange(name="max-10S", h_lo=0, h_hi=179, s_min=0, v_max=80),
+            HueRange(name="max-30S", h_lo=0, h_hi=179, s_min=0, v_min=90, v_max=160),
+            HueRange(name="stopped-10S", h_lo=0, h_hi=10, s_min=80, v_min=60),
+            HueRange(name="stopped-30S", h_lo=11, h_hi=25, s_min=80, v_min=60),
+        ),
+        style_axis="SPLIT_BY_DASH",
+        hue_meaning="FREQUENCY",
+        frequencies_lpmm=(10, 30),
+        apertures_per_chart=("max", "stopped"),
+    )
+
+    def fake_profile_for_chart(chart):
+        return probe_profile
+
+    monkeypatch.setattr(extract_mod, "profile_for_chart", fake_profile_for_chart)
+
+    probe_chart = ReferenceChart(
+        slug="probe-dual",
+        chart_path="docs/optical-specs/probe-dual/probe-dual-mtf.png",
+        style_family="probe-dual-aperture",  # not in _FUJI_STYLE_FAMILIES
+        apertures=("max", "stopped"),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.2,
+        notes="probe",
+    )
+    passes = _aperture_passes_for_view(
+        probe_chart, Path(probe_chart.chart_path)
+    )
+    assert len(passes) == 2
+    assert passes[0][0] == "max"
+    assert tuple(h.name for h in passes[0][1].hues) == ("max-10S", "max-30S")
+    assert passes[1][0] == "stopped"
+    assert tuple(h.name for h in passes[1][1].hues) == ("stopped-10S", "stopped-30S")
+
+
+def test_profile_for_view_shim_returns_first_pass():
+    """Back-compat: `_profile_for_view` still returns one profile (the
+    first pass's), matching its pre-ADR-044 signature."""
+    from mtfdigitizer.extract import _profile_for_view
+
+    sigma_chart = next(c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c")
+    profile = _profile_for_view(sigma_chart, Path(sigma_chart.chart_path))
+    assert profile.frequencies_lpmm == (10, 30)
+
+
+def test_extract_run_default_aperture_empty_string():
+    """Existing ExtractRun constructors that omit `aperture` keep the
+    default empty string — no surprises for code that doesn't yet
+    populate the field."""
+    from mtfdigitizer.extract import ExtractRun
+    from mtfdigitizer.pipeline.types import ExtractedChart, PlotBox
+
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c")
+    plot_box = PlotBox(x_left=0, x_right=10, y_top=0, y_bottom=10)
+    run = ExtractRun(
+        chart=chart,
+        view=chart.views[0],
+        image_path=Path(chart.chart_path),
+        plot_box=plot_box,
+        extracted=ExtractedChart(
+            source_path=chart.chart_path,
+            profile_name="probe",
+            plot_box=plot_box,
+            image_height_mm=14.2,
+            readings=(),
+        ),
+        verdict=None,  # type: ignore[arg-type]
+    )
+    assert run.aperture == ""


### PR DESCRIPTION
## Summary

Architectural prep for TTartisan onboarding (#798). The MTF orchestrator assumed one aperture per chart image; TTartisan packs two apertures into one image via color encoding (black+grey at max, red+orange at a stopped aperture). This PR adds the plumbing for multi-aperture-per-chart dispatch **without declaring a TTartisan profile** — the TTartisan profile + Tier 1 anchor + Tier 2 bulk land in a follow-up PR (#798).

ADR-044 captures the decision and the rejected alternatives.

## Changes

- **`MtfProfile`** gains optional `apertures_per_chart: tuple[str, ...] | None`. `None` preserves the single-aperture path for every existing profile (Sigma, Samyang, 7Artisans, Tokina, Viltrox, Fujifilm).
- New helper **`_aperture_passes_for_view(chart, image_path)`** returns `list[tuple[str, MtfProfile]]` — one entry per aperture pass.
  - Default (most profiles): one pass with `(chart.apertures[0], base)`.
  - Fuji per-frequency: one pass with frequency-substituted profile (unchanged behavior).
  - Multi-aperture: N passes, each with hue-filtered profile copy (new).
- New helper **`_hue_filtered_profile(profile, aperture)`** drops hues whose name doesn't start with `f\"{aperture}-\"`.
- **`_run_view` → `_run_view_passes`** returns `list[ExtractRun]`. `_run_all_views` flattens.
- **`ExtractRun`** gains `aperture: str = \"\"` for tagging.
- **`_profile_for_view`** survives as a back-compat shim (returns the first pass's profile).

No changes to:

- `ReferenceChart`, `ChartView`, `ProductionPanel`, or any pipeline type.
- Any of the seven existing declared profiles.
- The `mtf-readings.ts` data shape.
- CLI surface (`py -m mtfdigitizer.extract <slug>` still works for every style family).

## Test plan

- [x] Full mtfdigitizer pytest suite — **269 pass** (was 263 before; +6 = new multi-aperture tests).
  - `test_hue_filtered_profile_keeps_only_matching_prefix`
  - `test_aperture_passes_for_view_default_single_pass`
  - `test_aperture_passes_for_view_fuji_single_pass`
  - `test_aperture_passes_for_view_multi_aperture_fan_out` (with synthetic profile)
  - `test_profile_for_view_shim_returns_first_pass`
  - `test_extract_run_default_aperture_empty_string`
- [x] All 24 pre-existing `test_extract.py` tests pass — single-aperture regression coverage.
- [x] `npm run validate` green.
- [x] `py -m mtfdigitizer.extract --check` behavior unchanged from main: Sigma 10-18mm reports STALE on both branches identically (pre-existing tech debt; not introduced by this PR).

## Out of scope

- TTartisan profile declaration → follow-up PR closing #798.
- Sigma 10-18mm digitization-log staleness → pre-existing on main; tracked separately if not already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)