### PR TITLE
feat(mtf): TTartisan emit script + calibrate per-aperture fan-out (#1074)

### DIFF
--- a/tools/mtfdigitizer/calibrate.py
+++ b/tools/mtfdigitizer/calibrate.py
@@ -49,6 +49,17 @@ _PER_FREQUENCY_STYLE_FAMILIES: frozenset[str] = frozenset({"fujifilm-permfreq"})
 _FUJI_FREQ_RE = re.compile(r"-(?P<freq>\d+)lp\.png$", re.IGNORECASE)
 
 
+# Per-aperture result type for multi-aperture charts (ADR-044). When a
+# chart's profile declares `apertures_per_chart=(...)`, the calibrator
+# runs the extractor once per aperture and returns a dict keyed by the
+# orchestrator's aperture label (`"max"` / `"stopped"` for TTartisan).
+# Ground-truth lookups are then keyed by the SAME label — the chart's
+# `ground_truth` dict for a multi-aperture chart MUST use the
+# orchestrator's aperture labels, not f-numbers. Single-aperture charts
+# continue to return a single `ExtractedChart` and ground-truth uses
+# the lens's f-number label as it always has.
+
+
 @dataclass(frozen=True)
 class FieldDelta:
     """One field's Δ stats across the 11 sample positions of one chart."""
@@ -176,28 +187,98 @@ def _extract_per_frequency_chart(chart: ReferenceChart):
     return dataclasses.replace(last_result, readings=merged_readings)
 
 
+def _extract_multi_aperture_chart(chart: ReferenceChart) -> dict[str, "object"]:
+    """Run the extractor once per declared aperture and return a per-
+    aperture result dict (ADR-044).
+
+    The profile's `apertures_per_chart` lists the orchestrator-side
+    aperture labels (`"max"` / `"stopped"` for TTartisan). For each
+    label, the profile's hues are filtered to only those whose name
+    starts with `f"{label}-"`, then the extractor runs against the
+    full chart raster using that filtered profile. The result is
+    aperture-tagged so downstream code can compare against
+    `chart.ground_truth[label]`.
+
+    Returns ``{aperture_label: ExtractedChart}``. Single-aperture
+    charts use the existing single-result path in `_calibrate_chart`
+    and never call this.
+    """
+    from .extract import _hue_filtered_profile  # noqa: PLC0415 — avoid cycle at import
+
+    assert chart.plot_box is not None
+    base_profile = profile_for_chart(chart)
+    assert base_profile.apertures_per_chart is not None, (
+        f"{chart.slug}: _extract_multi_aperture_chart called on a profile "
+        f"without apertures_per_chart declared"
+    )
+    image_path = REPO_ROOT / chart.chart_path
+    plot_box = _to_plotbox(chart.plot_box)
+
+    results: dict[str, object] = {}
+    for aperture in base_profile.apertures_per_chart:
+        filtered = _hue_filtered_profile(base_profile, aperture)
+        results[aperture] = extract_chart(
+            image_path,
+            filtered,
+            plot_box,
+            image_height_mm=chart.image_height_mm,
+        )
+    return results
+
+
 def _calibrate_chart(chart: ReferenceChart):
     """Run extract_chart on one reference chart and return per-field stats.
 
     The chart must carry both `plot_box` and `ground_truth`; the caller
     filters runnable charts.
 
-    For per-frequency style families (Fujifilm; ADR-043) the runner
-    walks every chart view, substitutes the filename frequency into
-    the profile per call, and merges per-position readings into one
-    tuple before the GT comparison. Other style families run a single
-    `extract_chart` on the primary view.
+    Three dispatch shapes:
 
-    Returns ``(field_deltas, extracted)`` so callers can both summarize
-    the Δ distribution and write the per-chart readings log.
+    - **Per-frequency** (Fujifilm; ADR-043): walk every chart view,
+      substitute the filename frequency into the profile per call, and
+      merge per-position readings into one tuple before the GT
+      comparison. Result is a single `ExtractedChart`.
+    - **Multi-aperture** (TTartisan; ADR-044): run the extractor once
+      per declared aperture with the profile's hues filtered to that
+      aperture's bucket. Result is a `dict[aperture_label, ExtractedChart]`
+      so GT comparison can index per aperture without colliding
+      `freq{N}S/M` field names across passes.
+    - **Standard** (everything else): single `extract_chart` call on
+      the primary view.
+
+    Returns ``(field_deltas, result)`` where ``result`` is the shape
+    appropriate to the chart — single `ExtractedChart` for standard +
+    per-frequency dispatches, dict for multi-aperture.
     """
     assert chart.plot_box is not None
     assert chart.ground_truth is not None
 
+    base_profile = profile_for_chart(chart)
+    if base_profile.apertures_per_chart is not None:
+        results_by_aperture = _extract_multi_aperture_chart(chart)
+        out: list[FieldDelta] = []
+        for aperture, gt_by_field in chart.ground_truth.items():
+            if aperture not in results_by_aperture:
+                # GT carries an aperture key the profile didn't declare.
+                # Fail-loud: a typo here masks a missing extractor pass.
+                raise KeyError(
+                    f"{chart.slug}: ground_truth aperture {aperture!r} not "
+                    f"in profile.apertures_per_chart "
+                    f"{base_profile.apertures_per_chart!r}"
+                )
+            result = results_by_aperture[aperture]
+            for field, gt_values in gt_by_field.items():
+                out.append(
+                    _compare_field(
+                        chart, aperture, field, result.readings, gt_values
+                    )
+                )
+        return out, results_by_aperture
+
     if chart.style_family in _PER_FREQUENCY_STYLE_FAMILIES:
         result = _extract_per_frequency_chart(chart)
     else:
-        profile = profile_for_chart(chart)
+        profile = base_profile
         image_path = REPO_ROOT / chart.chart_path
         plot_box = _to_plotbox(chart.plot_box)
         result = extract_chart(
@@ -205,7 +286,7 @@ def _calibrate_chart(chart: ReferenceChart):
             image_height_mm=chart.image_height_mm,
         )
 
-    out: list[FieldDelta] = []
+    out = []
     # The ground truth dict may carry multiple apertures; the extractor
     # was given a single plot box (MAX panel today), so only compare the
     # apertures that match. In practice a single key today.
@@ -230,6 +311,20 @@ def _format_field_row(delta: FieldDelta) -> str:
 READINGS_DIR = REPO_ROOT / "tools" / "mtfdigitizer" / "referenceset" / "readings"
 
 
+def _readings_for_aperture(result, aperture: str):
+    """Resolve the readings tuple to use when comparing one aperture.
+
+    For multi-aperture charts (ADR-044) the result is a
+    ``dict[aperture_label, ExtractedChart]`` and we pick the matching
+    entry. For single-aperture charts the result is a single
+    ``ExtractedChart`` and we use its readings regardless of aperture
+    — the chart's `ground_truth` carries one aperture key.
+    """
+    if isinstance(result, dict):
+        return result[aperture].readings
+    return result.readings
+
+
 def _write_readings_log(chart: ReferenceChart, result, field_deltas: list[FieldDelta]) -> Path:
     """Write a markdown grid of GT vs extracted vs Δ for one chart.
 
@@ -237,6 +332,10 @@ def _write_readings_log(chart: ReferenceChart, result, field_deltas: list[FieldD
     to be diffed across algorithm changes — every row is a single
     sample fraction, every column is a curve/field, and the Δ column
     shows the per-position error against the eye-read ground truth.
+
+    For multi-aperture charts the result is a per-aperture dict; this
+    function picks the matching aperture's readings when filling each
+    section's grid (per ADR-044).
     """
     READINGS_DIR.mkdir(parents=True, exist_ok=True)
     path = READINGS_DIR / f"{chart.slug}.md"
@@ -253,9 +352,11 @@ def _write_readings_log(chart: ReferenceChart, result, field_deltas: list[FieldD
     lines.append(f"- **Image height:** {chart.image_height_mm} mm")
     lines.append("")
 
-    # Per-aperture grids. In practice charts carry one aperture today,
-    # but the format generalises.
+    # Per-aperture grids. Single-aperture charts hit this loop once;
+    # multi-aperture charts (ADR-044) hit it once per declared aperture
+    # and index `result` per aperture to pull the right pass's readings.
     for aperture, gt_by_field in chart.ground_truth.items():
+        readings = _readings_for_aperture(result, aperture)
         lines.append(f"## Aperture {aperture}")
         lines.append("")
         # Per-field stats table
@@ -290,7 +391,7 @@ def _write_readings_log(chart: ReferenceChart, result, field_deltas: list[FieldD
             for f in fields:
                 gt_vals = gt_by_field.get(f, (None,) * 11)
                 gt = gt_vals[i] if i < len(gt_vals) else None
-                ex = _extracted_value(result.readings[i], f)
+                ex = _extracted_value(readings[i], f)
                 if gt is not None and ex is not None:
                     delta = f"{abs(ex - gt):.3f}"
                 else:

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -1,0 +1,324 @@
+"""Emit TTartisan Tier 2 MTF readings as TS literals for `mtf-readings.ts`.
+
+Walks the 19 TTartisan ReferenceChart entries (style family
+`ttartisan-4color-dual-aperture`) and produces one `MtfData` literal
+per lens. Each chart packs two apertures by color encoding (ADR-044),
+so every emitted literal carries **two** `MtfChart` panels — one per
+aperture pass — with the actual f-numbers (read from
+`chart.apertures[i]`, NOT the orchestrator's `"max"`/`"stopped"` labels).
+
+This is the bridge from "extracted to disk" (the production
+digitization-log.md artifacts) to "visible on the lens detail page"
+(src/data/mtf-readings.ts).
+
+Usage::
+
+    cd tools
+    py -m mtfdigitizer.scripts.emit_ttartisan_tier2          # preview to stdout
+    py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --write   # patch mtf-readings.ts
+
+Without `--write` the literals print to stdout for review. With it, the
+script splices each entry into `src/data/mtf-readings.ts` using the
+same shape as `emit_fuji_tier2._splice_entries`.
+
+`source` URL comes from each lens's `officialUrl` field in
+`src/data/lenses.ts` — never re-derived from the slug (per #1062 the
+TTartisan brand URL pattern is not slug-mangle-recoverable).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from mtfdigitizer.calibrate import _extract_multi_aperture_chart
+from mtfdigitizer.pipeline.types import SampledReading
+from mtfdigitizer.referenceset.charts import REFERENCE_CHARTS, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MTF_READINGS_PATH = REPO_ROOT / "src" / "data" / "mtf-readings.ts"
+LENSES_PATH = REPO_ROOT / "src" / "data" / "lenses.ts"
+
+
+# Match a single top-level lens entry: from `^  {` to the matching `^  },`.
+_LENS_BLOCK_RE = re.compile(r"^  \{$.*?^  \},?$", re.DOTALL | re.MULTILINE)
+_BRAND_RE = re.compile(r'^\s*brand:\s*"([^"]+)"', re.MULTILINE)
+_MODEL_RE = re.compile(r'^\s*model:\s*"([^"]+)"', re.MULTILINE)
+_OFFICIAL_URL_RE = re.compile(
+    r'^\s*officialUrl:\s*(?:\n\s*)?"([^"]+)"', re.MULTILINE
+)
+
+
+def _format_value(v: float | None) -> str:
+    if v is None:
+        return "null"
+    rounded = round(v, 2)
+    text = f"{rounded:.2f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _format_reading(r: SampledReading) -> str:
+    inner_lines: list[str] = []
+    # Frequencies in the reading's sample keys: freq10S/M, freq30S/M, ...
+    freqs: set[int] = set()
+    for field in r.samples:
+        m = re.match(r"freq(\d+)[SM]$", field)
+        if m:
+            freqs.add(int(m.group(1)))
+    for freq in sorted(freqs):
+        s_val = r.samples.get(f"freq{freq}S")
+        m_val = r.samples.get(f"freq{freq}M")
+        inner_lines.append(
+            f"              {freq}: {{ S: {_format_value(s_val)}, "
+            f"M: {_format_value(m_val)} }},"
+        )
+    samples_block = "\n".join(inner_lines)
+    return (
+        "          {\n"
+        f"            position: {r.position_mm:g},\n"
+        "            samples: {\n"
+        f"{samples_block}\n"
+        "            },\n"
+        "          },"
+    )
+
+
+def _has_any_data(r: SampledReading) -> bool:
+    return any(v is not None for v in r.samples.values())
+
+
+def _format_chart_block(
+    aperture: str, readings: tuple[SampledReading, ...]
+) -> str:
+    """Emit one MtfChart panel — aperture string + readings array.
+
+    Mirrors the prime-shape emit in `emit_fuji_tier2._format_chart_block`
+    but without focalLength (TTartisan does not publish per-focal-length
+    charts; even the 500mm super-tele ships one chart per lens).
+    """
+    rendered: list[str] = []
+    for r in readings:
+        if _has_any_data(r) or r.position_mm == 0.0:
+            rendered.append(_format_reading(r))
+    rows = "\n".join(rendered)
+    return (
+        "      {\n"
+        f'        aperture: "{aperture}",\n'
+        "        readings: [\n"
+        f"{rows}\n"
+        "        ],\n"
+        "      },"
+    )
+
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _to_slug(brand_model: str) -> str:
+    """Port of src/utils/slug.ts:toSlug — must stay byte-equivalent."""
+    lowered = brand_model.lower().replace("/", "")
+    return _NON_ALNUM_RE.sub("-", lowered).strip("-")
+
+
+def _load_official_urls() -> dict[str, str]:
+    """Parse `src/data/lenses.ts` into a slug → officialUrl mapping."""
+    text = LENSES_PATH.read_text(encoding="utf-8")
+    mapping: dict[str, str] = {}
+    for block_match in _LENS_BLOCK_RE.finditer(text):
+        block = block_match.group(0)
+        brand_match = _BRAND_RE.search(block)
+        model_match = _MODEL_RE.search(block)
+        url_match = _OFFICIAL_URL_RE.search(block)
+        if not (brand_match and model_match and url_match):
+            continue
+        slug = _to_slug(f"{brand_match.group(1)} {model_match.group(1)}")
+        mapping[slug] = url_match.group(1)
+    return mapping
+
+
+def _source_url(slug: str, official_urls: dict[str, str]) -> str:
+    """Return the verified TTartisan product URL for `slug`.
+
+    Reads from `lenses.ts`'s `officialUrl` field rather than deriving
+    from the slug — TTartisan's URL pattern is not slug-mangle-
+    recoverable (different paths for AF / Tilt / GFX product lines).
+    """
+    if slug not in official_urls:
+        raise KeyError(
+            f"No officialUrl found in lenses.ts for {slug!r}. Add the "
+            f"field to the lens entry before re-running this script."
+        )
+    return official_urls[slug]
+
+
+def _emit_one_lens(
+    chart: ReferenceChart, official_urls: dict[str, str]
+) -> tuple[str, int, int]:
+    """Build the TS object literal for one TTartisan lens.
+
+    Returns ``(literal, panel_count, total_positions)``. Every TTartisan
+    chart produces exactly two panels — one per aperture in the
+    profile's `apertures_per_chart`. The aperture in each panel is the
+    actual f-number (from `chart.apertures[i]`), aligned positionally
+    with the profile's aperture labels.
+    """
+    results_by_aperture = _extract_multi_aperture_chart(chart)
+    blocks: list[str] = []
+    total_positions = 0
+
+    # Profile aperture labels and chart.apertures positions must align —
+    # the scaffolder enforces this; assert here to catch any later drift.
+    from mtfdigitizer.family_profile import profile_for_chart  # noqa: PLC0415
+
+    profile = profile_for_chart(chart)
+    assert profile.apertures_per_chart is not None
+    assert len(profile.apertures_per_chart) == len(chart.apertures), (
+        f"{chart.slug}: profile.apertures_per_chart "
+        f"({profile.apertures_per_chart!r}) length != "
+        f"chart.apertures ({chart.apertures!r}) length"
+    )
+
+    for label, f_number in zip(profile.apertures_per_chart, chart.apertures):
+        result = results_by_aperture[label]
+        blocks.append(_format_chart_block(f_number, result.readings))
+        total_positions += len(result.readings)
+
+    chart_blocks = "\n".join(blocks)
+    literal = (
+        f'  "{chart.slug}": {{\n'
+        f'    source: "{_source_url(chart.slug, official_urls)}",\n'
+        '    mtfType: "computed",\n'
+        "    charts: [\n"
+        f"{chart_blocks}\n"
+        "    ],\n"
+        "  },"
+    )
+    return literal, len(blocks), total_positions
+
+
+def _ttartisan_lenses() -> list[ReferenceChart]:
+    """Every TTartisan multi-aperture chart in the reference set."""
+    return [
+        c for c in REFERENCE_CHARTS
+        if c.style_family == "ttartisan-4color-dual-aperture"
+    ]
+
+
+# --- mtf-readings.ts patching ---------------------------------------------
+# Direct port of emit_fuji_tier2._splice_entries — single-source-of-truth
+# patching keyed by lens slug. Existing entries are replaced in place;
+# new entries are appended just before the record's closing `};`.
+
+_ENTRY_OPEN_RE = re.compile(r'^\s*"(?P<slug>[^"]+)":\s*\{\s*$')
+
+
+def _splice_entries(source: str, new_entries: dict[str, str]) -> str:
+    lines = source.splitlines(keepends=True)
+    out: list[str] = []
+    replaced: set[str] = set()
+
+    i = 0
+    n = len(lines)
+    inside_record = False
+    while i < n:
+        line = lines[i]
+        if not inside_record:
+            out.append(line)
+            if "const mtfReadings" in line:
+                inside_record = True
+            i += 1
+            continue
+
+        m = _ENTRY_OPEN_RE.match(line)
+        if m and m.group("slug") in new_entries:
+            slug = m.group("slug")
+            brace_depth = 0
+            while i < n:
+                cur = lines[i]
+                brace_depth += cur.count("{") - cur.count("}")
+                i += 1
+                if brace_depth <= 0:
+                    break
+            out.append(new_entries[slug] + "\n")
+            replaced.add(slug)
+            continue
+
+        if line.startswith("};"):
+            for slug, literal in new_entries.items():
+                if slug not in replaced:
+                    out.append(literal + "\n")
+                    replaced.add(slug)
+            out.append(line)
+            inside_record = False
+            i += 1
+            continue
+
+        out.append(line)
+        i += 1
+
+    return "".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Patch src/data/mtf-readings.ts with the emitted entries. "
+        "Without this flag the literals print to stdout for review.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit emission to the first N lenses (smoke-test).",
+    )
+    args = parser.parse_args(argv)
+
+    lenses = _ttartisan_lenses()
+    if args.limit is not None:
+        lenses = lenses[: args.limit]
+    if not lenses:
+        print("No TTartisan multi-aperture lenses found.", file=sys.stderr)
+        return 1
+
+    official_urls = _load_official_urls()
+    entries: dict[str, str] = {}
+    total_positions = 0
+    total_panels = 0
+    for chart in lenses:
+        literal, panels, positions = _emit_one_lens(chart, official_urls)
+        entries[chart.slug] = literal
+        total_panels += panels
+        total_positions += positions
+        print(
+            f"emitted {chart.slug}: {panels} panel(s), "
+            f"{positions} position(s)",
+            file=sys.stderr,
+        )
+
+    if args.write:
+        source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        patched = _splice_entries(source, entries)
+        MTF_READINGS_PATH.write_text(patched, encoding="utf-8")
+        print(
+            f"\npatched {MTF_READINGS_PATH.relative_to(REPO_ROOT)}: "
+            f"{len(entries)} entries, {total_panels} panels, "
+            f"{total_positions} positions.",
+            file=sys.stderr,
+        )
+    else:
+        print("\n".join(entries.values()))
+        print(
+            f"\n# Preview only — pass --write to patch "
+            f"{MTF_READINGS_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mtfdigitizer/tests/test_calibrate.py
+++ b/tools/mtfdigitizer/tests/test_calibrate.py
@@ -1,0 +1,203 @@
+"""Tests for the calibration runner's dispatch shapes (ADR-043, ADR-044).
+
+The calibrator handles three dispatch shapes:
+
+- Standard single-aperture single-image (Sigma, Samyang, Tokina,
+  7Artisans, Viltrox)
+- Per-frequency single-aperture multi-image (Fujifilm; ADR-043)
+- Multi-aperture single-image (TTartisan; ADR-044)
+
+This module focuses on the multi-aperture path that landed with #1074
+items 3+4 — the other two paths are exercised by the live
+`calibrate.py` runner on the actual reference set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mtfdigitizer import calibrate as calibrate_mod
+from mtfdigitizer.pipeline.types import ExtractedChart, PlotBox, SampledReading
+from mtfdigitizer.profiles.types import HueRange, MtfProfile
+from mtfdigitizer.referenceset.charts import PlotBoxCoords, ReferenceChart
+
+
+@pytest.fixture
+def multi_aperture_chart():
+    """A minimal multi-aperture chart with two-aperture ground truth.
+
+    Profile declares ``apertures_per_chart=("max", "stopped")``; ground
+    truth carries one tuple per (aperture, field) at the 11 sample
+    fractions. The plot_box and chart_path are real-looking but the
+    extractor is monkeypatched so the chart raster is never read.
+    """
+    return ReferenceChart(
+        slug="probe-ttartisan",
+        chart_path="docs/optical-specs/probe-ttartisan/probe-ttartisan-mtf.png",
+        style_family="ttartisan-4color-dual-aperture",
+        apertures=("f/1.2", "f/5.6"),
+        frequencies_lpmm=(10, 30),
+        image_height_mm=14.0,
+        notes="probe",
+        plot_box=PlotBoxCoords(x_left=87, x_right=607, y_top=116, y_bottom=461),
+        ground_truth={
+            "max": {
+                "freq10S": (0.9,) * 11,
+                "freq30S": (0.5,) * 11,
+            },
+            "stopped": {
+                "freq10S": (0.95,) * 11,
+                "freq30S": (0.7,) * 11,
+            },
+        },
+    )
+
+
+@pytest.fixture
+def probe_profile():
+    return MtfProfile(
+        name="probe-dual",
+        hues=(
+            HueRange(name="max-10-black", h_lo=0, h_hi=179, s_min=0, v_max=80),
+            HueRange(name="max-30-grey", h_lo=0, h_hi=179, s_min=0, v_min=90, v_max=160),
+            HueRange(name="stopped-10-red", h_lo=0, h_hi=5, s_min=80, v_min=80),
+            HueRange(name="stopped-30-orange", h_lo=12, h_hi=22, s_min=80, v_min=80),
+        ),
+        style_axis="SPLIT_BY_DASH",
+        hue_meaning="FREQUENCY",
+        frequencies_lpmm=(10, 30),
+        apertures_per_chart=("max", "stopped"),
+    )
+
+
+def _make_readings(value_by_field: dict[str, float]) -> tuple[SampledReading, ...]:
+    """11 SampledReadings with the same value across every position."""
+    from mtfdigitizer.pipeline.sampling import SAMPLE_FRACTIONS
+
+    return tuple(
+        SampledReading(
+            position_mm=frac * 14.0,
+            samples=dict(value_by_field),
+        )
+        for frac in SAMPLE_FRACTIONS
+    )
+
+
+def test_multi_aperture_dispatch_runs_one_pass_per_aperture(
+    monkeypatch, multi_aperture_chart, probe_profile
+):
+    """`_calibrate_chart` for a multi-aperture chart calls the
+    extractor once per declared aperture, each with a hue-filtered
+    profile, and returns a dict keyed by aperture label."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake_extract_chart(image_path, profile, plot_box, *, image_height_mm):
+        # Tag the call by which hue names the filtered profile carries.
+        calls.append(tuple(h.name for h in profile.hues))
+        # Synthesize readings whose value matches the aperture so the
+        # test can verify the right pass's readings go into the right
+        # GT-vs-EX comparison.
+        if any(h.name.startswith("max-") for h in profile.hues):
+            readings = _make_readings({"freq10S": 0.9, "freq30S": 0.5})
+        else:
+            readings = _make_readings({"freq10S": 0.95, "freq30S": 0.7})
+        return ExtractedChart(
+            source_path=str(image_path),
+            profile_name=profile.name,
+            plot_box=plot_box,
+            image_height_mm=image_height_mm,
+            readings=readings,
+        )
+
+    monkeypatch.setattr(calibrate_mod, "extract_chart", fake_extract_chart)
+    monkeypatch.setattr(
+        calibrate_mod, "profile_for_chart", lambda chart: probe_profile
+    )
+
+    field_deltas, result = calibrate_mod._calibrate_chart(multi_aperture_chart)
+
+    # Two passes: one per aperture, each with only its own hues.
+    assert len(calls) == 2
+    assert calls[0] == ("max-10-black", "max-30-grey")
+    assert calls[1] == ("stopped-10-red", "stopped-30-orange")
+
+    # Result is a per-aperture dict.
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"max", "stopped"}
+
+    # GT-vs-EX paired correctly: max pass returned exactly GT values
+    # (every Δ = 0), stopped pass also returned exactly GT values.
+    by_key = {(fd.aperture, fd.field): fd for fd in field_deltas}
+    assert by_key[("max", "freq10S")].deltas == (0.0,) * 11
+    assert by_key[("max", "freq30S")].deltas == (0.0,) * 11
+    assert by_key[("stopped", "freq10S")].deltas == (0.0,) * 11
+    assert by_key[("stopped", "freq30S")].deltas == (0.0,) * 11
+
+
+def test_multi_aperture_dispatch_rejects_unknown_gt_aperture(
+    monkeypatch, multi_aperture_chart, probe_profile
+):
+    """A GT aperture key that the profile didn't declare is a fail-loud
+    event — masks a missing extractor pass otherwise."""
+    monkeypatch.setattr(
+        calibrate_mod, "extract_chart",
+        lambda *a, **kw: ExtractedChart(
+            source_path="", profile_name="probe",
+            plot_box=PlotBox(x_left=0, x_right=10, y_top=0, y_bottom=10),
+            image_height_mm=14.0, readings=_make_readings({"freq10S": 0.9}),
+        ),
+    )
+    monkeypatch.setattr(
+        calibrate_mod, "profile_for_chart", lambda chart: probe_profile
+    )
+
+    # Inject a stray aperture key into ground truth — same shape as a
+    # maintainer mis-typing the aperture label.
+    chart_with_bad_gt = ReferenceChart(
+        slug=multi_aperture_chart.slug,
+        chart_path=multi_aperture_chart.chart_path,
+        style_family=multi_aperture_chart.style_family,
+        apertures=multi_aperture_chart.apertures,
+        frequencies_lpmm=multi_aperture_chart.frequencies_lpmm,
+        image_height_mm=multi_aperture_chart.image_height_mm,
+        notes=multi_aperture_chart.notes,
+        plot_box=multi_aperture_chart.plot_box,
+        ground_truth={
+            "max": multi_aperture_chart.ground_truth["max"],
+            "MAX": multi_aperture_chart.ground_truth["max"],  # the typo
+        },
+    )
+
+    with pytest.raises(KeyError, match="apertures_per_chart"):
+        calibrate_mod._calibrate_chart(chart_with_bad_gt)
+
+
+def test_readings_for_aperture_handles_dict_and_single(multi_aperture_chart):
+    """`_readings_for_aperture` returns the right readings tuple for
+    either result shape."""
+    single = ExtractedChart(
+        source_path="x", profile_name="p",
+        plot_box=PlotBox(x_left=0, x_right=10, y_top=0, y_bottom=10),
+        image_height_mm=14.0, readings=_make_readings({"freq10S": 0.5}),
+    )
+    # Single-aperture: ignores aperture, returns the one readings tuple.
+    assert calibrate_mod._readings_for_aperture(single, "any") is single.readings
+    assert calibrate_mod._readings_for_aperture(single, "max") is single.readings
+
+    # Multi-aperture: picks the matching aperture's readings.
+    by_ap = {
+        "max": ExtractedChart(
+            source_path="x", profile_name="p",
+            plot_box=PlotBox(x_left=0, x_right=10, y_top=0, y_bottom=10),
+            image_height_mm=14.0, readings=_make_readings({"freq10S": 0.9}),
+        ),
+        "stopped": ExtractedChart(
+            source_path="x", profile_name="p",
+            plot_box=PlotBox(x_left=0, x_right=10, y_top=0, y_bottom=10),
+            image_height_mm=14.0, readings=_make_readings({"freq10S": 0.95}),
+        ),
+    }
+    assert calibrate_mod._readings_for_aperture(by_ap, "max") is by_ap["max"].readings
+    assert calibrate_mod._readings_for_aperture(by_ap, "stopped") is by_ap["stopped"].readings

--- a/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
@@ -1,0 +1,157 @@
+"""Unit tests for `emit_ttartisan_tier2` (ADR-044 emit pipeline).
+
+Targets the pure formatting helpers — string emission, lens-tuple
+shape, slug-to-URL resolution. The end-to-end extractor pipeline
+(extract_chart → SampledReading) is exercised by the live runner;
+this module verifies that the TS-literal output shape is correct.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from mtfdigitizer.pipeline.types import SampledReading
+from mtfdigitizer.scripts.emit_ttartisan_tier2 import (
+    _format_chart_block,
+    _format_reading,
+    _format_value,
+    _source_url,
+    _to_slug,
+    _ttartisan_lenses,
+)
+
+
+def test_format_value_strips_trailing_zeros():
+    assert _format_value(0.5) == "0.5"
+    assert _format_value(0.95) == "0.95"
+    assert _format_value(0.90) == "0.9"  # no trailing zero
+    assert _format_value(0.0) == "0"
+    assert _format_value(None) == "null"
+
+
+def test_format_reading_emits_per_frequency_pairs():
+    """One SampledReading → one TS object with `position` + `samples` of
+    `{freq: { S, M }}` pairs, sorted by frequency."""
+    reading = SampledReading(
+        position_mm=5.6,
+        samples={
+            "freq10S": 0.95,
+            "freq10M": 0.94,
+            "freq30S": 0.80,
+            "freq30M": None,
+        },
+    )
+    out = _format_reading(reading)
+    # Position appears as plain number, sample keys in frequency order.
+    assert "position: 5.6," in out
+    assert "10: { S: 0.95, M: 0.94 }" in out
+    assert "30: { S: 0.8, M: null }" in out
+    # Frequencies sorted (10 then 30 — not order of dict insertion)
+    assert out.index("10:") < out.index("30:")
+
+
+def test_format_chart_block_carries_aperture_and_readings():
+    """A chart block carries the f-number (NOT the orchestrator label)
+    and the readings array."""
+    readings = (
+        SampledReading(
+            position_mm=0.0,
+            samples={"freq10S": 0.9, "freq10M": 0.9, "freq30S": 0.5, "freq30M": 0.5},
+        ),
+    )
+    out = _format_chart_block("f/1.2", readings)
+    assert 'aperture: "f/1.2",' in out
+    assert "readings: [" in out
+    assert "position: 0," in out
+
+
+def test_format_chart_block_keeps_position_0_even_when_all_null():
+    """The mtf-readings data-integrity test asserts position 0 is always
+    present. Mirror the Fuji emit's null-row preservation."""
+    readings = (
+        SampledReading(
+            position_mm=0.0,
+            samples={"freq10S": None, "freq10M": None, "freq30S": None, "freq30M": None},
+        ),
+        SampledReading(
+            position_mm=14.0,
+            samples={"freq10S": 0.6, "freq10M": 0.6, "freq30S": 0.3, "freq30M": 0.3},
+        ),
+    )
+    out = _format_chart_block("f/1.2", readings)
+    assert "position: 0," in out  # kept despite all-null samples
+
+
+def test_format_chart_block_drops_intermediate_all_null_rows():
+    """A middle row where every sample is None drops out (the renderer
+    doesn't need it — `position: 0` is the only forced-keep)."""
+    readings = (
+        SampledReading(
+            position_mm=0.0,
+            samples={"freq10S": 0.9, "freq30S": 0.5},
+        ),
+        SampledReading(
+            position_mm=5.0,
+            samples={"freq10S": None, "freq30S": None},  # drop
+        ),
+        SampledReading(
+            position_mm=14.0,
+            samples={"freq10S": 0.6, "freq30S": 0.3},
+        ),
+    )
+    out = _format_chart_block("f/1.2", readings)
+    assert "position: 0," in out
+    assert "position: 14," in out
+    assert "position: 5," not in out
+
+
+def test_to_slug_matches_typescript_port():
+    """Port of src/utils/slug.ts:toSlug must be byte-equivalent."""
+    assert _to_slug("TTartisan 50mm f/1.2") == "ttartisan-50mm-f1-2"
+    assert _to_slug("TTartisan 11mm f/2.8 Fisheye GFX") == "ttartisan-11mm-f2-8-fisheye-gfx"
+    assert _to_slug("TTartisan AF 75mm f/2") == "ttartisan-af-75mm-f2"
+
+
+def test_source_url_fails_loud_on_missing_official_url():
+    """A slug not in the lenses.ts officialUrl mapping is a fail-loud
+    event — masks a missing field otherwise (per #1062)."""
+    with pytest.raises(KeyError, match="officialUrl"):
+        _source_url("ttartisan-nonexistent-1mm-f0", {})
+
+
+def test_ttartisan_lenses_returns_19_entries():
+    """The Tier 2 scaffolder added 19 TTartisan ReferenceCharts; the
+    emit walker must find all of them."""
+    lenses = _ttartisan_lenses()
+    assert len(lenses) == 19
+    for lens in lenses:
+        assert lens.style_family == "ttartisan-4color-dual-aperture"
+        assert len(lens.apertures) == 2  # max + stopped
+
+
+def test_ttartisan_aperture_tuple_aligns_with_profile():
+    """Every TTartisan ReferenceChart's `apertures` tuple must align
+    positionally with the profile's `apertures_per_chart`. The emit
+    script's _emit_one_lens zip-aligns them — if they ever drift, the
+    f-number on the panel would mis-label the wrong aperture pass."""
+    from mtfdigitizer.family_profile import profile_for_chart
+
+    for lens in _ttartisan_lenses():
+        profile = profile_for_chart(lens)
+        assert profile.apertures_per_chart is not None
+        assert len(profile.apertures_per_chart) == len(lens.apertures), lens.slug
+        # First position is always max-aperture lens stop; second is stopped.
+        assert profile.apertures_per_chart == ("max", "stopped"), profile.name
+
+
+def test_format_reading_uses_compact_position_repr():
+    """Position values are emitted with `:g` — no trailing zeros or
+    decimal point for integers. The mtf-readings data-integrity tests
+    expect this representation (e.g. `position: 0,` not
+    `position: 0.0,`)."""
+    integer_pos = SampledReading(position_mm=14.0, samples={"freq10S": 0.5})
+    decimal_pos = SampledReading(position_mm=5.6, samples={"freq10S": 0.5})
+    assert "position: 14," in _format_reading(integer_pos)
+    assert "position: 5.6," in _format_reading(decimal_pos)


### PR DESCRIPTION
## Summary

Closes the remaining two items from #1074:

- **Item 3** — `emit_ttartisan_tier2.py` writes per-lens TS literals to `src/data/mtf-readings.ts`. Each TTartisan literal carries two MtfChart panels (one per aperture pass) with the actual f-numbers.
- **Item 4** — `calibrate.py` gains a multi-aperture fan-out path. `_extract_multi_aperture_chart` mirrors the per-frequency dispatch shape (returns a `dict[aperture_label, ExtractedChart]`); `_calibrate_chart` routes through it when `profile.apertures_per_chart is not None`.

After #1073 (profile + scaffolder), #1075 (plot-box inset + artifact naming), and this PR, the TTartisan brand has the full pipeline: orchestrator → production extraction → emit → calibration.

## Why no mtf-readings.ts patch in this PR

The emit script is shipped but `src/data/mtf-readings.ts` is **not** patched — same policy that gates Fuji's production extraction. Tier 2 data ships only after maintainer overlay review per lens. The maintainer runs:

```
cd tools
# After reviewing each chart's overlay artifacts:
py -m mtfdigitizer.extract <slug> --accept    # commits digitization-log.md
# When the cohort looks right:
py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --write    # patches mtf-readings.ts
```

Smoke-running `emit_ttartisan_tier2 --write` mid-PR confirmed the output shape is correct: 19 entries, 38 panels, 418 positions, `npm run check` passes against the rendered TS. Reverted before commit.

## What changed

**Item 3 — `tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py`**

- Walks `REFERENCE_CHARTS` for `style_family == \"ttartisan-4color-dual-aperture\"`.
- Per lens: calls `_extract_multi_aperture_chart` (which fans out one extractor pass per aperture), then emits two MtfChart panels — `chart.apertures[i]` (the actual f-number) aligned positionally with `profile.apertures_per_chart[i]`.
- Source URL via `officialUrl` lookup in `src/data/lenses.ts` (per #1062 — TTartisan URLs aren't slug-recoverable).
- Direct port of `emit_fuji_tier2._splice_entries` for in-place patching.

**Item 4 — `tools/mtfdigitizer/calibrate.py`**

- New `_extract_multi_aperture_chart(chart)` returns `dict[aperture_label, ExtractedChart]`.
- `_calibrate_chart` detects multi-aperture via `profile.apertures_per_chart is not None` and indexes GT vs result per aperture. Unknown GT aperture key → `KeyError` naming the profile (fail-loud — masks a missing extractor pass otherwise).
- `_write_readings_log` gains `_readings_for_aperture(result, aperture)` to handle both single-result and dict-result shapes.

## Tests

- 3 new calibrate tests: dispatch fan-out + hue filtering, fail-loud on unknown aperture, helper handles both result shapes.
- 10 new emit tests: value formatting, reading-shape correctness, position-0 preservation, slug port byte-equivalence, fail-loud on missing officialUrl, 19-lens walker count, aperture-tuple alignment with profile.
- 542 → **555 pytest pass** (+13).
- `npm run validate` green.

## Test plan

- [x] `py -m pytest` — 555 passed
- [x] `npm run validate` — full gate green
- [x] `emit_ttartisan_tier2 --write` writes valid TS (smoke-tested mid-PR; output reverted)
- [x] Multi-aperture dispatch verified by monkeypatched extract_chart calls
- [x] Aperture tuple positional alignment asserted for all 19 lenses

Closes #1074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)