### PR TITLE
chore(deps): group react ecosystem in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     labels:
       - chore
       - P3
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Add a \`react\` group to \`.github/dependabot.yml\` so \`react\`, \`react-dom\`, \`@types/react\`, and \`@types/react-dom\` are bundled into a single PR
- Prevents the failure mode seen this week: #1050 (react-dom) and #1053 (react) opened separately, causing the build to fail with \`Incompatible React versions: The "react" and "react-dom" packages must have the exact same version\` until both merged
- Manually combined as #1078; this config makes the combine automatic next time

## Test plan

- [ ] Next weekly Dependabot run opens one PR for the react ecosystem rather than two

🤖 Generated with [Claude Code](https://claude.com/claude-code)