### PR TITLE
fix(mtf): 7artisans dispatch -> FREQUENCY_PER_HUE_RIDGE (#1045)

### DIFF
--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -79,7 +79,16 @@ SEVENARTISANS_2COLOR_SAMECOLOR_DASHED: MtfProfile = MtfProfile(
         HueRange(name="green", h_lo=35, h_hi=60, s_min=60, v_min=70),
     ),
     style_axis="SPLIT_BY_DASH",
-    hue_meaning="FREQUENCY",
+    # FREQUENCY_PER_HUE_RIDGE (not FREQUENCY) — same shape as TTartisan
+    # max-aperture (ADR-045). The 7Artisans chart's morphological close
+    # (7 px horizontal) cannot bridge the wider dash gaps in this brand's
+    # dashed-line rendering, so split_sm_by_cc_width returns one
+    # spatially-confined left-half CC as S and ~30 right-half fragments
+    # lumped as M — neither curve covers the field end-to-end. Per-column
+    # ridge tracking handles fragmented dashed lines naturally: 7artisans-
+    # 50mm-f1-2-mark-ii anchor goes from 5/11 paired (freq10M) to 10/11,
+    # p95|Δ| on freq30S from 0.184 to 0.053 (closes #1045).
+    hue_meaning="FREQUENCY_PER_HUE_RIDGE",
     frequencies_lpmm=(10, 30),
     dashed_is_sagittal=True,
     notes="7Artisans/Chinese convention: blue=10, green=30; T1/T2 (blue) = M pair, S1/S2 (green) = S pair; dashed=S within hue",


### PR DESCRIPTION
## Summary

Closes **#1045**. The spike asked for a decision between three options for the 7Artisans coverage gap (Y_BAND_IS_FREQUENCY variant, port to GEODESIC_DP, or accept the limitation). The ADR-045 work landed yesterday gave us a **fourth option** that turns out to fit this exact bug shape: `FREQUENCY_PER_HUE_RIDGE` — per-hue ridge tracking handles fragmented dashed lines naturally.

## Diagnosis (from #1045)

7Artisans chart's dashed lines have wider gaps than the morphological close (7px horizontal) can bridge. `split_sm_by_cc_width` returns:
- the **longest single CC** as S — but it's spatially confined to the left half (a fragment, not the whole curve)
- ~30 right-half fragments lumped as M — but they include pieces of BOTH curves

End result: neither S nor M covers the field end-to-end; calibration shows 4-6 ext-None per curve out of 11 samples.

## Fix

One-character literal swap: `hue_meaning="FREQUENCY"` → `"FREQUENCY_PER_HUE_RIDGE"`. The dispatch I built for TTartisan max-aperture (ADR-045, #1082) walks per-column ridge centroids and picks 2 tracks (higher coverage = solid). Fragmented dashes are bridged by the greedy `_RIDGE_TRACK_MAX_DX=40` clustering window.

## Calibration impact (7artisans-50mm-f1-2-mark-ii Tier 1 anchor)

| curve   | paired (before → after) | p95 \|Δ\| (before → after) |
|---------|------------------------|----------------------------|
| freq10M | 5/11 → **10/11**       | 0.069 → 0.049              |
| freq10S | 7/11 → 6/11            | 0.095 → 0.055              |
| freq30M | 6/11 → 8/11            | 0.033 → 0.060              |
| freq30S | 7/11 → 6/11            | 0.184 → **0.053 (3.5×)**   |

Two curves (10S, 30S) regress by 1 sample on paired count — but **p95 |Δ| drops on 3 of 4 curves**, especially freq30S which was the cohort's worst offender. The dispatch is built for this exact failure mode (coincident-curve dispatch where dashed fragments confuse CC-width split).

**Aggregate calibration: 481/523 (92.0%) → 492/528 (93.2%)** within ±0.05 tolerance band (+1.2 pp, +11 paired comparisons captured).

## Test plan

- [x] 289 pytest pass (no test changes — covered by existing ridge dispatch tests from #1082)
- [x] `npm run validate` green
- [x] Full anchor-set calibration: 7artisans-50 substantially improved, no other anchor regresses

Closes #1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)