### PR TITLE
fix(mtf): y-band coherence anchor for ridge DP (closes #1104)

### DIFF
--- a/docs/decisions/051-ridge-dp-y-anchor.md
+++ b/docs/decisions/051-ridge-dp-y-anchor.md
@@ -124,12 +124,12 @@ regress.
 | freq30S | 0.087          | 0.087          | unchanged                       |
 | freq30M | 0.069          | 0.052          | improved                        |
 
-Corner samples (pos 1.0):
+Corner samples (pos 1.0), absolute delta vs ground truth:
 
-| Field   | Pre-fix | Δ         |     | Post-fix | Δ   |     |
-| ------- | ------- | --------- | --- | -------- | --- | --- |
-| freq10S | 0.100   | **0.029** |
-| freq10M | 0.109   | **0.020** |
+| Field   | Pre-fix \|Δ\| | Post-fix \|Δ\| |
+| ------- | ------------- | -------------- |
+| freq10S | 0.100         | **0.029**      |
+| freq10M | 0.109         | **0.020**      |
 
 freq10S meets the issue's target ≤ 0.064. freq10M misses target — the
 new dominant outlier is at pos 0.6 (|Δ|=0.087), a pre-existing

--- a/docs/decisions/051-ridge-dp-y-anchor.md
+++ b/docs/decisions/051-ridge-dp-y-anchor.md
@@ -1,0 +1,187 @@
+# ADR-051: Y-band coherence anchor for ridge DP
+
+**Status:** Accepted
+**Date:** 2026-06-10
+
+## Context
+
+ADR-049 introduced per-column ridge DP in
+`ridge_tracks_for_hue_freq_split` and closed the TTartisan freq30
+corner identity-swap (#1100). Its "Known limitation: 7artisans corner
+crossing" documented a regression on the 7artisans 50mm f/1.2 Mark II
+calibration anchor:
+
+| Field             | Pre-#1100 p95 | Post-#1100 p95 |
+| ----------------- | ------------- | -------------- |
+| 7artisans freq10S | 0.054         | 0.124          |
+| 7artisans freq10M | 0.064         | 0.119          |
+
+A probe on the 7artisans blue (freq10) hue confirmed the failure shape:
+the two physical curves do NOT cross at the corner — they run parallel
+about 28 px apart (upper at y≈115-127, lower at y≈140-160). But the
+DP smoothness prior alone cannot distinguish them: when a dash gap
+leaves only one ridge centroid at a column, the DP is forced to land on
+it. If that centroid belongs to the OTHER curve, pass 1's identity
+swaps. ADR-049's smoothness term penalises the swap but the global
+optimum still routes pass 1 through the lower band at the corner.
+
+The issue's proposed fix (Option 1: dash-vs-solid identity from column
+run lengths) does not work here — both 7artisans curves render with
+similar run-length distributions (p50=2, p95=4), so column run length
+cannot separate them.
+
+Probe also revealed that the TTartisan grey-30 case has fundamentally
+different geometry: 54% of columns carry three-or-more ridges from
+antialiased echoes of adjacent curves. The same fix that helps
+7artisans would drag pass 1 off the legitimate TTartisan freq30 dive.
+The two scenes need different DP costs.
+
+## Decision
+
+Add an opt-in **y-band coherence anchor** to
+`_ridge_dp_one_pass` and `_ridge_dp_two_paths`. Each pass receives a
+per-column anchor; the DP cost adds
+`gamma * |y - anchor[col]|` to every candidate, and (only when an
+anchor is supplied) lets the path **coast** past a column instead of
+landing on a ridge, paying a small fixed penalty
+`_RIDGE_DP_OFF_RIDGE_PENALTY` plus its own anchor cost.
+
+Coasting is only cheaper than landing when the available ridges all sit
+far from this path's anchor — exactly the 7artisans dash-gap case where
+the only remaining ridge belongs to the other curve.
+
+```
++-------------------+   +---------------------+
+| ridges_by_col     |   |  compute anchors    |
+| (sparse per col)  |-->|  upper = ridges[0]  |
+|                   |   |  lower = ridges[1]  |
+|                   |   |  (2-ridge cols only,|
+|                   |   |   carry-fill else)  |
++-------------------+   +---------------------+
+                                  |
+                                  v
+                +-------------------------------+
+                |  DP pass 1 with upper anchor  |
+                |  - land cost: alpha*|dy| +    |
+                |               gamma*|y - up|  |
+                |  - coast cost: penalty +      |
+                |                gamma*|y' - up||
+                +-------------------------------+
+                                  |
+                                  v
+                +-------------------------------+
+                |  DP pass 2 with lower anchor  |
+                |  (pass 1 ridges erased)       |
+                +-------------------------------+
+```
+
+### Anchor construction
+
+Anchors come from columns with exactly two ridge centroids: the smaller
+y seeds the upper anchor, the larger seeds the lower. Columns with one
+ridge (dash gap, coincidence) or three-plus ridges (gridline / halo
+contamination) contribute no seed. Missing values carry forward
+(forward-fill, with a leading backward-fill from the first known seed).
+
+The anchor is intentionally NOT box-smoothed: a smoothing window
+flattens legitimate local features (e.g. the TTartisan freq30 corner
+dive over ~30 columns) as easily as it cancels noise. The inner DP
+already supplies smoothness via the `alpha * |dy|` term; the anchor's
+job is identity, not smoothness.
+
+### Per-profile opt-in
+
+A new `MtfProfile.ridge_dp_y_anchor: bool` field controls activation
+per profile. Defaults False — the default DP behaviour is the same
+identity-free Viterbi pass that ADR-049 settled. The 7Artisans
+`samecolor-dashed-sm` profile sets the flag True; TTartisan and every
+other profile keeps the flag False.
+
+Anchor activation is a per-profile property because chart geometry
+varies meaningfully: 7Artisans has clean two-ridge columns, TTartisan
+grey-30 has noisy three-plus-ridge columns from antialiased halos. A
+single global threshold cannot capture which charts benefit and which
+regress.
+
+### Tuning
+
+- `_RIDGE_DP_GAMMA = 0.20` — anchor cost weight; a 30 px swap costs
+  6.0, enough to dominate the 0.30\*|dy| smoothness cost (max 3.0 for
+  a 10 px jump) and reject swaps, while picking the closer candidate
+  on single-ridge / coincidence columns (anchor cost ≈ 0)
+- `_RIDGE_DP_OFF_RIDGE_PENALTY = 4.0` — fixed coast cost; sized so a
+  single-column coast beats landing on a ridge ≥30 px from this path's
+  anchor, but never beats landing on a ridge that matches the anchor
+
+## Consequences
+
+### 7artisans 50mm f/1.2 Mark II (closes #1104)
+
+| Field   | Post-#1100 p95 | Post-#1104 p95 | Change                          |
+| ------- | -------------- | -------------- | ------------------------------- |
+| freq10S | 0.124          | **0.052**      | corner swap fixed               |
+| freq10M | 0.119          | **0.098**      | corner fixed; pos-0.6 unrelated |
+| freq30S | 0.087          | 0.087          | unchanged                       |
+| freq30M | 0.069          | 0.052          | improved                        |
+
+Corner samples (pos 1.0):
+
+| Field   | Pre-fix | Δ         |     | Post-fix | Δ   |     |
+| ------- | ------- | --------- | --- | -------- | --- | --- |
+| freq10S | 0.100   | **0.029** |
+| freq10M | 0.109   | **0.020** |
+
+freq10S meets the issue's target ≤ 0.064. freq10M misses target — the
+new dominant outlier is at pos 0.6 (|Δ|=0.087), a pre-existing
+curve-coincidence resolution issue present in both pre-#1100 and
+post-#1100 calibrations. Tracked separately.
+
+### TTartisan and other profiles
+
+`ridge_dp_y_anchor` defaults False; TTartisan and every non-7Artisans
+profile keep the ADR-049 unanchored DP. Calibration confirms zero
+delta:
+
+| Field                       | Post-#1100 | Post-#1104 |
+| --------------------------- | ---------- | ---------- |
+| TTartisan max-f/1.2 freq30S | 0.012      | 0.012      |
+| TTartisan max-f/1.2 freq30M | 0.095      | 0.095      |
+| TTartisan stopped freq30S   | 0.192      | 0.192      |
+| TTartisan stopped freq30M   | 0.199      | 0.199      |
+
+### Aggregate (14-anchor calibration set)
+
+- paired comparisons: 627 (unchanged)
+- median |Δ|: 0.0112 → 0.0111
+- p95 |Δ|: 0.0640 → 0.0638
+- in band ±0.05: 92.5% → **93.0%**
+
+### Approaches ruled out
+
+- **Option 1 (dash-vs-solid identity from column run lengths).** The
+  issue's proposed fix. Probe showed 7Artisans solid and dashed
+  curves render with the same run-length distribution (p50=2, p95=4
+  for both), so the signal does not separate them.
+- **Box-smoothed anchors.** A 30-col smoothing window flattened the
+  TTartisan freq30 dive (a 67 px legitimate jump) into noise and
+  forced the DP to coast through it. Removing the smoothing fixed
+  the regression — the anchor's job is identity, not smoothness.
+- **Auto-detect anchor applicability from ridge distribution.** An
+  initial implementation enabled anchors when 3+-ridge columns were
+  rare (<10% of non-empty). It misclassified TTartisan grey-30 as
+  clean after halo exclusion (post-halo 3+-ridge fraction ≈ 2%) and
+  regressed the corner dive anyway. Per-profile declaration captures
+  the chart-geometry signal that ridge-count heuristics miss.
+
+### Known limitation: 7artisans pos-0.6 mid-field
+
+freq10M p95 = 0.098 does not meet the issue's ≤ 0.064 target. The
+dominant outlier shifted from the corner (now fixed) to pos 0.6
+(|Δ| = 0.087). At that position the chart resolution merges the
+solid and dashed curves into a single ridge centroid; the extractor
+reads 0.813 OTF while GT says S = 0.860, M = 0.900. Both fields share
+the single-ridge value via coincidence fill, but neither matches GT
+because the actual physical curves diverge by 0.04 OTF at that
+position. This is a chart-resolution limit, not a DP identity issue —
+no anchor tuning can recover sub-pixel separation that the source
+raster does not encode. Tracked as follow-up.

--- a/tools/mtfdigitizer/pipeline/dispatch.py
+++ b/tools/mtfdigitizer/pipeline/dispatch.py
@@ -440,6 +440,7 @@ def field_skeletons(
             hue_fields = ridge_tracks_for_hue_freq_split(
                 cleaned_mask, plot_box, freq=freq,
                 dashed_is_sagittal=profile.dashed_is_sagittal,
+                use_y_anchor=profile.ridge_dp_y_anchor,
             )
             out.update(hue_fields)
     elif (

--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -774,17 +774,15 @@ def ridge_tracks_for_hue(
 # over from `dp_extract._ALPHA` (Tokina reference-set calibration).
 _RIDGE_DP_ALPHA: float = 0.30
 
-# Penalty cost when a path's y at a column doesn't sit on any ridge
-# centroid AND is more than `_RIDGE_DP_SNAP_TOLERANCE` away from the
-# nearest one. Picked large enough to discourage paths that drift
-# through empty columns but small enough to allow brief excursions
-# across dash gaps.
-_RIDGE_DP_OFF_RIDGE_PENALTY: float = 50.0
-
-# A path may carry forward its previous y across columns with no ridges
-# (dash gaps). When ridges DO exist, snap the path to the nearest ridge
-# if within this many pixels; otherwise charge the off-ridge penalty.
-_RIDGE_DP_SNAP_TOLERANCE: float = 3.0
+# Fixed cost added when a path coasts past a column whose ridges are
+# all far from its anchor (#1104). Lets pass 1 skip a lone lower-band
+# ridge instead of being forced to land on it. Picked small enough that
+# coasting beats jumping across a ~30 px gap (the 7artisans corner mode)
+# but large enough that coasting NEVER beats landing on a ridge that
+# matches the path's anchor (anchor cost ≈ 0 on a clean landing). Only
+# affects passes that supply an `anchor`; without one the coast option
+# is never cheaper than landing on a candidate.
+_RIDGE_DP_OFF_RIDGE_PENALTY: float = 4.0
 
 # After pass 1 finds the best path, pass 2 erases ridges within this
 # vertical half-window of pass 1's path at each column (so pass 2 finds
@@ -792,6 +790,20 @@ _RIDGE_DP_SNAP_TOLERANCE: float = 3.0
 # apart for part of the field (the second curve's ridge falls outside
 # the erase window even at near-coincidence).
 _RIDGE_DP_ERASE_HALF: int = 2
+
+# Y-band coherence weight (#1104). Per-column cost adds
+# `_RIDGE_DP_GAMMA * |y - anchor[col]|` when the path has an anchor.
+# Each anchor is a smoothed approximation of where one curve sits;
+# the cost pulls the DP toward its own anchor and away from the
+# other path's band when both have valid candidates at a column.
+#
+# Sized so a 30px swap (the 7artisans freq10 corner mode) costs
+# ~6.0 in anchor deviation per column — enough to dominate the
+# 0.30*|dy| smoothness cost (max 3.0 for a 10px jump) so the DP
+# rejects swaps but still picks the closer candidate when both
+# anchors agree (single-ridge / coincidence columns).
+_RIDGE_DP_GAMMA: float = 0.20
+
 
 
 def _ridges_by_column(
@@ -814,11 +826,64 @@ def _ridges_by_column(
     return by_x
 
 
+def _compute_y_anchors(
+    ridges_by_col: list[list[float]],
+) -> tuple[list[float | None], list[float | None]]:
+    """Compute per-column y anchors for the upper and lower curves (#1104).
+
+    For each column with exactly two ridges, the smaller y is taken as
+    the upper-curve seed and the larger y as the lower-curve seed
+    (image-y grows downward, so smaller y = higher MTF). Columns with
+    1 ridge (dash gaps, coincidence) or 3+ ridges (contaminated by
+    gridline echoes or other-curve halos) contribute no seed — they
+    inherit the most recent known anchor via forward/backward fill.
+
+    The anchor is intentionally NOT box-smoothed: a smoothing window
+    flattens legitimate local features (e.g. the TTartisan freq30
+    corner dive that spans ~30 columns) just as easily as it cancels
+    noise. The inner DP's smoothness term already supplies the
+    column-to-column smoothness; the anchor's job is to encode curve
+    identity, not to be smooth.
+
+    Returns ``(upper, lower)``, each of length ``len(ridges_by_col)``.
+    Entries are ``None`` only when there are no two-ridge columns
+    anywhere in the input.
+    """
+    n = len(ridges_by_col)
+    upper_raw: list[float | None] = [None] * n
+    lower_raw: list[float | None] = [None] * n
+    for col, ys in enumerate(ridges_by_col):
+        if len(ys) == 2:
+            upper_raw[col] = ys[0]
+            lower_raw[col] = ys[1]
+
+    def _carry_fill(raw: list[float | None]) -> list[float | None]:
+        filled: list[float | None] = list(raw)
+        last: float | None = None
+        for col in range(n):
+            if filled[col] is not None:
+                last = filled[col]
+            elif last is not None:
+                filled[col] = last
+        first = next((v for v in filled if v is not None), None)
+        if first is not None:
+            for col in range(n):
+                if filled[col] is None:
+                    filled[col] = first
+                else:
+                    break
+        return filled
+
+    return _carry_fill(upper_raw), _carry_fill(lower_raw)
+
+
 def _ridge_dp_one_pass(
     ridges_by_col: list[list[float]],
     *,
     alpha: float = _RIDGE_DP_ALPHA,
     erase_window: dict[int, float] | None = None,
+    anchor: list[float | None] | None = None,
+    gamma: float = _RIDGE_DP_GAMMA,
 ) -> tuple[list[float | None], list[bool]]:
     """Single Viterbi pass: pick one y per column to minimise data + smoothness.
 
@@ -837,12 +902,17 @@ def _ridge_dp_one_pass(
 
     Cost model:
       Data cost at column x placing path at y:
-        0       if y == one of column's ridges
-        alpha_off * (|y - nearest_ridge| - snap_tolerance)
-                if column has ridges but path is off-ridge
-        0       if column has NO ridges (carry-forward is free)
-    Smoothness cost transitioning from y' to y across one column:
+        0                              if y == one of column's ridges
+        _RIDGE_DP_OFF_RIDGE_PENALTY    if anchor supplied AND path
+                                       coasts past a column with ridges
+                                       (#1104: see `_ridge_dp_two_paths`)
+        0                              if column has NO ridges (carry
+                                       forward is free)
+      Smoothness cost transitioning from y' to y across one column:
         alpha * |y - y'|
+      Anchor-coherence cost at column x placing path at y (when `anchor`
+      set):
+        gamma * |y - anchor[col]|
     """
     n_cols = len(ridges_by_col)
     if n_cols == 0:
@@ -863,6 +933,14 @@ def _ridge_dp_one_pass(
             kept = list(ys)
         candidates_per_col.append(kept)
 
+    def _anchor_cost(col: int, y: float) -> float:
+        if anchor is None:
+            return 0.0
+        a = anchor[col]
+        if a is None:
+            return 0.0
+        return gamma * abs(y - a)
+
     # DP forward pass. State at each column: best total cost ending at
     # each candidate y, plus the back-pointer (previous y, or None for
     # "start").
@@ -874,7 +952,7 @@ def _ridge_dp_one_pass(
     if first_col is None:
         return [None] * n_cols, [False] * n_cols
     for y in candidates_per_col[first_col]:
-        best[first_col][y] = (0.0, None)
+        best[first_col][y] = (_anchor_cost(first_col, y), None)
 
     # Forward over each subsequent column.
     for col in range(first_col + 1, n_cols):
@@ -890,7 +968,26 @@ def _ridge_dp_one_pass(
                     if cand_cost < best_cost:
                         best_cost = cand_cost
                         best_prev_y = y_prev
-                best[col][y] = (best_cost, best_prev_y)
+                best[col][y] = (best_cost + _anchor_cost(col, y), best_prev_y)
+            # When the path has an anchor, also allow each prior state to
+            # coast through this column WITHOUT landing on a ridge — the
+            # #1104 case where a lone lower-band ridge would drag pass 1
+            # off the upper curve through a dash gap. The anchor cost
+            # still applies, so coasting is only cheaper than landing
+            # when the available ridges are far from this path's anchor.
+            # Without an anchor, coasting is NOT an option — the #1100
+            # TTartisan freq30 dive is a legitimate 67 px jump that the
+            # unanchored DP must take, not coast through.
+            if anchor is not None:
+                for y_prev, (cost_prev, _) in prev.items():
+                    coast_cost = (
+                        cost_prev
+                        + _RIDGE_DP_OFF_RIDGE_PENALTY
+                        + _anchor_cost(col, y_prev)
+                    )
+                    stored = best[col].get(y_prev)
+                    if stored is None or coast_cost < stored[0]:
+                        best[col][y_prev] = (coast_cost, y_prev)
         else:
             # Empty column: carry every state forward at zero cost.
             for y_prev, (cost_prev, _) in prev.items():
@@ -925,13 +1022,29 @@ def _ridge_dp_one_pass(
 
 def _ridge_dp_two_paths(
     ridges_by_col: list[list[float]],
+    *,
+    use_y_anchor: bool = False,
 ) -> tuple[
     tuple[list[float | None], list[bool]],
     tuple[list[float | None], list[bool]],
 ]:
-    """Two complementary passes: pass 1 finds the best path; pass 2 finds
-    the next-best with pass 1's ridges erased per column (so it picks the
-    OTHER curve where two ridges exist).
+    """Two passes: pass 1 finds the best path, pass 2 finds the next-best
+    with pass 1's ridges erased per column.
+
+    When ``use_y_anchor`` is True (#1104), pass 1 is pulled toward the
+    **upper** y-anchor (smaller y = upper in image coordinates = higher
+    MTF) and pass 2 toward the **lower** anchor. The anchor coherence
+    cost lets each pass coast past a column whose ridges sit in the
+    other path's band, instead of being forced to land on a ridge and
+    swap identity. This fixes the identity-swap failure mode described
+    in ADR-049's "Known limitation: 7artisans corner crossing".
+
+    When ``use_y_anchor`` is False (default), the DP runs identity-free
+    — global smoothness optimum across both passes. This is the #1100
+    TTartisan behaviour: the freq30 dive is a legitimate 67 px jump
+    that the unanchored DP takes correctly, but the anchored coast
+    option can mis-attribute it as a swap. Per-profile opt-in via
+    `MtfProfile.ridge_dp_y_anchor`.
 
     When a column has only one ridge (curve coincidence), pass 1 takes
     it; pass 2 then has no ridge at that column and coasts via
@@ -943,12 +1056,18 @@ def _ridge_dp_two_paths(
     columns where DP landed on a real ridge from columns where it
     coasted via carry-forward.
     """
-    pass1 = _ridge_dp_one_pass(ridges_by_col)
+    if use_y_anchor:
+        upper_anchor, lower_anchor = _compute_y_anchors(ridges_by_col)
+    else:
+        upper_anchor = lower_anchor = None
+    pass1 = _ridge_dp_one_pass(ridges_by_col, anchor=upper_anchor)
     pass1_path, _pass1_on_ridge = pass1
     erase: dict[int, float] = {
         col: y for col, y in enumerate(pass1_path) if y is not None
     }
-    pass2 = _ridge_dp_one_pass(ridges_by_col, erase_window=erase)
+    pass2 = _ridge_dp_one_pass(
+        ridges_by_col, erase_window=erase, anchor=lower_anchor
+    )
     return pass1, pass2
 
 
@@ -1043,6 +1162,7 @@ def ridge_tracks_for_hue_freq_split(
     plot_box: PlotBox,
     freq: int,
     dashed_is_sagittal: bool,
+    use_y_anchor: bool = False,
 ) -> dict[str, np.ndarray]:
     """Per-hue, 2-curve variant for SPLIT_BY_DASH families: each hue
     carries one frequency with both S (solid) and T (dashed) curves.
@@ -1091,7 +1211,9 @@ def ridge_tracks_for_hue_freq_split(
     # greedy clusterer + top-N + diversity-picker chain that the
     # frankenstein corner-crossing failure mode came from.
     ridges_by_col = _ridges_by_column(points, plot_box)
-    (p1_path, p1_on_ridge), (p2_path, p2_on_ridge) = _ridge_dp_two_paths(ridges_by_col)
+    (p1_path, p1_on_ridge), (p2_path, p2_on_ridge) = _ridge_dp_two_paths(
+        ridges_by_col, use_y_anchor=use_y_anchor
+    )
     track1 = _path_to_track(p1_path, p1_on_ridge, plot_box)
     track2 = _path_to_track(p2_path, p2_on_ridge, plot_box)
 

--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -91,6 +91,13 @@ SEVENARTISANS_2COLOR_SAMECOLOR_DASHED: MtfProfile = MtfProfile(
     hue_meaning="FREQUENCY_PER_HUE_RIDGE",
     frequencies_lpmm=(10, 30),
     dashed_is_sagittal=True,
+    # Enable y-band coherence prior in the ridge DP (#1104). 7artisans
+    # charts have dashed-line rendering where every column carries at
+    # most two ridge centroids (one per curve) and dash gaps regularly
+    # leave a single centroid behind. The anchor lets the DP coast past
+    # those single-centroid columns instead of swapping curve identity
+    # at the corner crossing. See ADR-049 §"Known limitation".
+    ridge_dp_y_anchor=True,
     notes="7Artisans/Chinese convention: blue=10, green=30; T1/T2 (blue) = M pair, S1/S2 (green) = S pair; dashed=S within hue",
 )
 

--- a/tools/mtfdigitizer/profiles/types.py
+++ b/tools/mtfdigitizer/profiles/types.py
@@ -195,6 +195,15 @@ class MtfProfile:
     # None for single-aperture charts (every profile shipped before this
     # extension). See ADR-044 (multi-aperture orchestrator).
     apertures_per_chart: tuple[str, ...] | None = None
+    # When True, the FREQUENCY_PER_HUE_RIDGE dispatch runs its per-column
+    # ridge DP with a y-band coherence prior (#1104): the upper and lower
+    # paths each follow a precomputed anchor curve so the DP can break
+    # smoothness-cost ties through dash gaps without swapping curve
+    # identity. Only safe on charts where 1- and 2-ridge columns dominate
+    # (7Artisans samecolor-dashed-sm). Defaults False because the option
+    # can drag a path off a legitimate dive on noisier charts (TTartisan
+    # max-aperture grey freq30 — see ADR-049's "Known limitation").
+    ridge_dp_y_anchor: bool = False
 
     @property
     def hue_count(self) -> int:

--- a/tools/mtfdigitizer/tests/test_ridge.py
+++ b/tools/mtfdigitizer/tests/test_ridge.py
@@ -8,6 +8,7 @@ from mtfdigitizer.pipeline.ridge import (
     Track,
     _cluster_into_tracks,
     _column_runs,
+    _compute_y_anchors,
     _extract_ridge_points,
     _merge_near_duplicate_tracks,
     _path_mask_continuity,
@@ -515,3 +516,81 @@ def test_ridge_tracks_for_hue_freq_split_through_dp_crossing() -> None:
     # Each field should have nonzero rasterization
     assert len(s_ys[0]) > 0
     assert len(m_ys[0]) > 0
+
+
+# --- Y-anchor identity prior (#1104) ------------------------------------
+
+
+def test_compute_y_anchors_seeds_from_two_ridge_columns() -> None:
+    """Anchors are seeded only from columns with exactly two ridges. The
+    smaller y becomes the upper anchor; the larger becomes the lower."""
+    ridges_by_col = [[20.0, 40.0], [], [22.0, 42.0]]
+    upper, lower = _compute_y_anchors(ridges_by_col)
+    assert upper[0] == 20.0
+    assert lower[0] == 40.0
+    assert upper[2] == 22.0
+    assert lower[2] == 42.0
+
+
+def test_compute_y_anchors_carry_forward_fills_gaps() -> None:
+    """Empty and single-ridge columns inherit the most recent two-ridge
+    seed; columns before the first seed inherit it via backward fill."""
+    ridges_by_col = [[], [50.0], [20.0, 40.0], [], [25.0], [22.0, 42.0]]
+    upper, lower = _compute_y_anchors(ridges_by_col)
+    # Backward-fill before the first seed at col 2: cols 0-1 inherit 20.0/40.0.
+    assert upper[0] == 20.0
+    assert lower[0] == 40.0
+    assert upper[1] == 20.0
+    # Carry-forward past the seed at col 2: col 3 inherits, col 4 still inherits
+    # (single-ridge doesn't reset the seed), col 5 advances to the new seed.
+    assert upper[3] == 20.0
+    assert upper[4] == 20.0
+    assert upper[5] == 22.0
+
+
+def test_compute_y_anchors_skips_three_or_more_ridge_columns() -> None:
+    """A column with three ridges is treated as noisy (gridline echoes,
+    adjacent-curve halos) — the smallest/largest from it would drag the
+    anchor toward chart chrome. Only exactly-two-ridge columns seed."""
+    ridges_by_col = [[100.0, 105.0, 200.0], [20.0, 40.0]]
+    upper, lower = _compute_y_anchors(ridges_by_col)
+    # The 3-ridge col 0 does NOT seed; carry-fill from col 1's seed instead.
+    assert upper[0] == 20.0
+    assert lower[0] == 40.0
+
+
+def test_ridge_dp_two_paths_with_anchor_resists_corner_swap() -> None:
+    """Two parallel curves with a dash-gap-induced single-ridge column at
+    the end should keep their identities under the y-anchor prior.
+
+    Without the anchor, pass 1's smoothness cost is locally satisfied by
+    landing on the only available ridge — even when that ridge belongs to
+    the other physical curve. The anchor pulls each pass back to its band.
+    """
+    # Upper curve at y=20 for 8 cols. Lower curve at y=50 for 8 cols.
+    # Last 2 cols have ONLY the lower curve's ridge (upper had a dash gap).
+    ridges_by_col = [[20.0, 50.0]] * 8 + [[50.0], [50.0]]
+    (p1, _), (p2, _) = _ridge_dp_two_paths(ridges_by_col, use_y_anchor=True)
+    # Pass 1 (upper) stays at 20.0 across the first 8 cols; for the last
+    # two cols it coasts at 20.0 rather than jumping to 50.0.
+    assert p1[0] == 20.0
+    assert p1[7] == 20.0
+    assert p1[8] == 20.0  # coast, not swap
+    assert p1[9] == 20.0
+    # Pass 2 (lower) sits at 50.0 throughout — pass 1 left it untouched.
+    assert p2[0] == 50.0
+    assert p2[7] == 50.0
+    assert p2[8] == 50.0
+    assert p2[9] == 50.0
+
+
+def test_ridge_dp_two_paths_without_anchor_keeps_dive_intact() -> None:
+    """The default (no anchor) path must still take legitimate large jumps
+    — the #1100 TTartisan freq30 dive. With anchoring off and no coast
+    option, pass 1 lands on every ridge regardless of size."""
+    # A curve that dives 60 px in one column — the #1100 corner-dive shape.
+    ridges_by_col = [[100.0], [100.0], [100.0], [160.0], [160.0]]
+    (p1, p1_on), _ = _ridge_dp_two_paths(ridges_by_col, use_y_anchor=False)
+    assert p1[2] == 100.0
+    assert p1[3] == 160.0  # took the dive, did NOT coast
+    assert p1_on[3] is True


### PR DESCRIPTION
## Summary

- Per-profile opt-in y-band coherence anchor in the ridge DP fixes the 7Artisans freq10 corner identity-swap that landed as a known limitation in ADR-049.
- Pass 1 follows an upper-y anchor, pass 2 follows a lower-y anchor; each pass can coast past a dash-gap column whose lone ridge sits in the other path's band.
- Per-profile flag (`MtfProfile.ridge_dp_y_anchor`) — only 7Artisans `samecolor-dashed-sm` opts in; TTartisan and every other profile keeps the ADR-049 unanchored DP unchanged.

## Calibration impact

**7artisans 50mm f/1.2 Mark II (closes #1104):**

| Field   | Post-#1100 p95 | Post-#1104 p95 |
| ------- | -------------- | -------------- |
| freq10S | 0.124          | **0.052** ✓ meets target ≤0.064 |
| freq10M | 0.119          | **0.098** (corner fixed; remaining outlier at pos 0.6 is chart-resolution, not DP identity) |
| freq30S | 0.087          | 0.087 (unchanged) |
| freq30M | 0.069          | 0.052 (improved) |

**Corner (pos 1.0), absolute |Δ|:**

| Field   | Pre-fix | Post-fix |
| ------- | ------- | -------- |
| freq10S | 0.100   | **0.029** |
| freq10M | 0.109   | **0.020** |

**TTartisan + others (unchanged — flag defaults False):** TTartisan max-f/1.2 freq30 0.012/0.095, stopped 0.192/0.199 — byte-identical to baseline.

**Aggregate (14 charts, 627 paired):** in-band 92.5% → **93.0%**, p95 0.0640 → 0.0638, median 0.0112 → 0.0111.

## Why not the issue's Option 1

Probe showed 7Artisans solid and dashed curves render with the same column run-length distribution (p50=2, p95=4). Run-length-based identity can't separate them. Y-band coherence works on the actual signal: the two physical curves stay parallel ~28 px apart through the corner.

See [ADR-051](docs/decisions/051-ridge-dp-y-anchor.md) for the full design rationale, approaches ruled out, and known limitations.

## Test plan

- [x] 343 mtfdigitizer tests pass (added 5 for y-anchor: seed selection, carry-fill, 3+-ridge skip, anchored corner-swap resistance, unanchored dive preservation)
- [x] `py -m mtfdigitizer.calibrate` — 7artisans freq10S meets target, TTartisan unchanged
- [x] No-op for all profiles except 7Artisans (verified by direct numeric comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)