### PR TITLE
feat(mtf): per-pass confidence schema + emit (#1134 schema half)

### DIFF
--- a/docs/decisions/054-per-pass-confidence-schema.md
+++ b/docs/decisions/054-per-pass-confidence-schema.md
@@ -1,0 +1,174 @@
+# ADR-054: Per-pass MTF confidence schema
+
+**Status:** Accepted
+**Date:** 2026-06-13
+
+## Context
+
+ADR-053 (TTartisan cohort strategy) decided that the autotriage LOW
+verdict is honest signal that should reach the user — partial
+coverage with a badge, not suppression. Implementation is issue
+#1134.
+
+The schema question the implementation forces: how does the
+TypeScript type for `mtfReadings[slug]` carry per-pass confidence
+without breaking the existing 100+ hand-curated entries on day one?
+
+Three shapes were considered (full enumeration in #1134's investigation
+notes); this ADR records what was chosen.
+
+## Decision
+
+Add two fields to the existing `MtfChart` interface:
+
+```typescript
+type MtfConfidence = "HIGH" | "LOW";
+
+interface MtfChart {
+  aperture: string;
+  focalLength?: number;
+  confidence: MtfConfidence; // required
+  confidenceReason?: string; // set only when confidence === "LOW"
+  readings: MtfReading[];
+}
+```
+
+**`confidence` is required, not optional.** Every existing entry in
+`src/data/mtf-readings.ts` is migrated to `confidence: "HIGH"`. The
+type system catches a missing field at compile time; an optional field
+would silently default to the renderer's interpretation of `undefined`
+and obscure data-quality regressions.
+
+**`confidenceReason` is a free-form string, not an enum.** The
+authoritative source is `mtfdigitizer.triage.LowReason` (Python
+`Enum.value` strings like `precision_below_threshold`,
+`prior_failed_center_ge_edge`). Mirroring the enum in TS would
+require manual sync on every ADR-052 reason-code change. The
+free-form contract is enforced by:
+
+1. The autotriage gate (ADR-052) is the only producer of LOW
+   passes; it can only emit valid `LowReason` values.
+2. Hand-curated entries never set `confidenceReason` (they are
+   HIGH by construction).
+3. Validation tests assert: LOW charts have non-empty reason; HIGH
+   charts omit reason entirely.
+
+**Multi-reason collapse: emit writes the first reason.** A panel
+that trips multiple priors collapses to `verdict.reasons[0].value`
+in the emit output. The autotriage CLI run remains the
+authoritative full-reason report when the maintainer needs the
+list; the per-pass `confidenceReason` on the lens page is the
+primary failure code, not a full diagnostic dump.
+
+```
++----------------------+   +---------------------+
+| autotriage CLI       |   | mtfReadings.ts       |
+| (full reason list)   |   | (first reason only)  |
++----------------------+   +---------------------+
+        ^                            ^
+        |   ChartVerdict.reasons     |
+        |   tuple[LowReason, ...]    |
+        |                            |
+        +---- triage.triage() -------+
+                  ^                  ^
+                  |                  |
+        +--------------------+       |
+        | score_chart()      |-------+
+        | check_all()        |  reason[0].value
+        +--------------------+
+```
+
+### Hand-curated entries are HIGH
+
+Operator-verified data from official manufacturer charts is treated
+as HIGH. The field models trustworthiness, not provenance lineage —
+a hand-eye-read entry whose values came from a Sigma or Fujifilm
+optical-design chart is at least as trustworthy as an autotriage HIGH
+pass, often more so. A three-way enum (`HIGH | LOW | OPERATOR`) was
+considered and rejected: it would force a UI decision on what
+"OPERATOR" means and create a second axis of meaning the user has
+to reason about. Two states (HIGH / LOW) on a single axis
+(trust the curve / verify before relying on this curve) is
+enough.
+
+### Sample data is kept on LOW passes
+
+Per ADR-053 Q5 evidence: extracted readings on LOW passes are
+predominantly within ±0.05 of ground truth (41/43 on the
+`ttartisan-50mm-f1-2` stopped pass). Nulling samples would discard
+mostly-accurate data because of a plausibility-prior violation. The
+badge surfaces the gate's verdict to the user; the underlying data
+stays available.
+
+## Alternatives considered
+
+### Alt 1 — `confidence?: "HIGH" | "LOW"` (optional)
+
+Rejected. An optional field on day one means hand-curated entries
+leave it undefined; the renderer has to treat undefined as "HIGH" by
+convention. A missing field cannot then be distinguished from a
+forgotten field, and TypeScript's exhaustiveness checks don't fire on
+omission. Migration cost (adding `confidence: "HIGH"` to 182 chart
+literals in `mtf-readings.ts`) was bounded; ran in one mechanical pass.
+
+### Alt 2 — Three-way enum `HIGH | LOW | OPERATOR`
+
+Rejected. Adds a state the user has to interpret without a clear
+behavioural difference from HIGH. The intent of "OPERATOR" is
+provenance, but the field's purpose is trust; an honest
+provenance-tracking field would be a separate `provenance` field with
+its own semantics, not a third confidence value.
+
+### Alt 3 — Mirror `LowReason` as a TS string-literal union
+
+Rejected. Forces manual sync on every reason-code change in ADR-052.
+The cost is paid every time the autotriage gate adds a prior. The
+free-form string + Python-side enum + validation test on the
+TS side captures the contract without the sync burden.
+
+### Alt 4 — Collapse multiple reasons into a `confidenceReasons: string[]`
+
+Rejected. The lens page is a user-facing display surface; the badge
+needs one primary failure mode, not a list. Operators who want the
+full failure-mode list run `py -m mtfdigitizer.autotriage` for the
+authoritative report. Surfacing the list on the page would
+double-encode the same information.
+
+## Consequences
+
+### Immediate
+
+- `MtfChart` carries `confidence: MtfConfidence` (required) and
+  `confidenceReason?: string` (optional).
+- All 182 existing chart literals in `src/data/mtf-readings.ts`
+  migrate to `confidence: "HIGH"`.
+- TTartisan-emit fans out 25 HIGH + 13 LOW per-pass verdicts that
+  match ADR-053's Q2 numbers byte-for-byte.
+- Two validation tests in `src/data/mtf-readings.test.ts` enforce
+  the field contracts (HIGH/LOW, reason present iff LOW).
+- Three pytest cases in `mtfdigitizer/tests/test_emit*.py` enforce
+  the emit-side contract (the formatter accepts confidence + reason,
+  HIGH emits no reason line, LOW emits the reason).
+
+### Schema-evolution
+
+- Adding a new LowReason code requires: add it to
+  `mtfdigitizer/triage.py:LowReason`, no TS-side change.
+- Adding a new confidence level (e.g. `MEDIUM`) is a breaking
+  change requiring a new ADR.
+
+### UI deferred
+
+The lens-page badge and the `/wiki/mtf-confidence` explainer are
+in #1134's scope but **not in this PR**. This ADR commits to the
+schema; the UI is the next layer. The middle scope chosen this
+session (schema + emit) ships the data shape so the next session
+can focus on UI without redesign risk.
+
+### Process
+
+- Autotriage CLI remains the authoritative report for the
+  multi-reason case; the emit step writes the first reason only.
+- Manual edits to `src/data/mtf-readings.ts` that set
+  `confidence: "LOW"` without a `confidenceReason` will fail the
+  validation tests. This is by design.

--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -38,6 +38,36 @@ describe("mtf-readings data integrity", () => {
     }
   });
 
+  // ADR-053 + #1134: per-pass confidence.
+  it("every chart has confidence HIGH or LOW", () => {
+    for (const [slug, data] of entries) {
+      for (const chart of data.charts) {
+        expect(
+          chart.confidence,
+          `${slug} ${chart.aperture}: confidence must be 'HIGH' or 'LOW'`,
+        ).toMatch(/^(HIGH|LOW)$/);
+      }
+    }
+  });
+
+  it("LOW charts carry a non-empty confidenceReason; HIGH charts omit it", () => {
+    for (const [slug, data] of entries) {
+      for (const chart of data.charts) {
+        if (chart.confidence === "LOW") {
+          expect(
+            chart.confidenceReason,
+            `${slug} ${chart.aperture}: LOW must have confidenceReason`,
+          ).toMatch(/\S/);
+        } else {
+          expect(
+            chart.confidenceReason,
+            `${slug} ${chart.aperture}: HIGH must omit confidenceReason`,
+          ).toBeUndefined();
+        }
+      }
+    }
+  });
+
   it("readings are sorted by position (ascending)", () => {
     for (const [slug, data] of entries) {
       for (const chart of data.charts) {

--- a/src/data/mtf-readings.ts
+++ b/src/data/mtf-readings.ts
@@ -7,6 +7,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -95,6 +96,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -183,6 +185,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -243,6 +246,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -331,6 +335,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -392,6 +397,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 10,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -475,6 +481,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 18,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -564,6 +571,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -647,6 +655,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 300,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -736,6 +745,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/1.8",
         focalLength: 17,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -819,6 +829,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/1.8",
         focalLength: 40,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -908,6 +919,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 18,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -991,6 +1003,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 50,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1080,6 +1093,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5",
         focalLength: 100,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1163,6 +1177,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5",
         focalLength: 400,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1252,6 +1267,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1292,6 +1308,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1338,6 +1355,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1399,6 +1417,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1466,6 +1485,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1527,6 +1547,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1594,6 +1615,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1634,6 +1656,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1680,6 +1703,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1720,6 +1744,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1766,6 +1791,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1806,6 +1832,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1852,6 +1879,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1913,6 +1941,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -1980,6 +2009,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2020,6 +2050,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2066,6 +2097,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2127,6 +2159,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2194,6 +2227,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/6.3",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2255,6 +2289,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2322,6 +2357,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2383,6 +2419,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2450,6 +2487,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2490,6 +2528,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2536,6 +2575,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2597,6 +2637,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2664,6 +2705,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2704,6 +2746,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2750,6 +2793,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2790,6 +2834,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2836,6 +2881,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2897,6 +2943,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -2964,6 +3011,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/3.5",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3025,6 +3073,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3092,6 +3141,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3139,6 +3189,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3192,6 +3243,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3239,6 +3291,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3292,6 +3345,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/3.5",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3332,6 +3386,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3378,6 +3433,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8 @ 11mm",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3460,6 +3516,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/2.8 @ 18mm",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3548,6 +3605,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3636,6 +3694,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3724,6 +3783,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3814,6 +3874,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5.6",
         focalLength: 100,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -3908,6 +3969,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5.6",
         focalLength: 200,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4008,6 +4070,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4107,6 +4170,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4207,6 +4271,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4308,6 +4373,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 20,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4402,6 +4468,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 35,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4502,6 +4569,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4601,6 +4669,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/3.5",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4689,6 +4758,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4789,6 +4859,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 32,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4883,6 +4954,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 64,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -4983,6 +5055,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 35,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5077,6 +5150,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 70,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5178,6 +5252,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 45,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5272,6 +5347,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 100,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5372,6 +5448,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5472,6 +5549,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5571,6 +5649,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/3.5",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5670,6 +5749,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.7",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5769,6 +5849,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5868,6 +5949,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.7",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -5969,6 +6051,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 13,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6052,6 +6135,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 33,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6140,6 +6224,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6230,6 +6315,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 50,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6313,6 +6399,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 230,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6403,6 +6490,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 10,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6486,6 +6574,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 24,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6576,6 +6665,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 10,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6659,6 +6749,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 24,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6749,6 +6840,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 100,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6832,6 +6924,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 400,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -6921,6 +7014,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7011,6 +7105,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5.6",
         focalLength: 150,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7094,6 +7189,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/5.6",
         focalLength: 600,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7184,6 +7280,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7267,6 +7364,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 50,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7357,6 +7455,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7440,6 +7539,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 55,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7530,6 +7630,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7613,6 +7714,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 55,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7703,6 +7805,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7779,6 +7882,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 80,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7867,6 +7971,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -7955,6 +8060,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8045,6 +8151,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 18,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8128,6 +8235,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4",
         focalLength: 120,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8218,6 +8326,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 18,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8301,6 +8410,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 135,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8391,6 +8501,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 18,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8474,6 +8585,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 55,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8563,6 +8675,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8651,6 +8764,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8740,6 +8854,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8828,6 +8943,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -8916,6 +9032,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9004,6 +9121,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9069,6 +9187,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9157,6 +9276,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9246,6 +9366,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9335,6 +9456,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9423,6 +9545,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9511,6 +9634,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9601,6 +9725,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 50,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9684,6 +9809,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 140,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9773,6 +9899,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9861,6 +9988,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -9949,6 +10077,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10039,6 +10168,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 55,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10122,6 +10252,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/3.5",
         focalLength: 200,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10211,6 +10342,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10299,6 +10431,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10387,6 +10520,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10475,6 +10609,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10565,6 +10700,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 70,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10648,6 +10784,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/4.5",
         focalLength: 300,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10738,6 +10875,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 8,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10821,6 +10959,7 @@ const mtfReadings: Record<string, MtfData> = {
       {
         aperture: "f/2.8",
         focalLength: 16,
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10910,6 +11049,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -10999,6 +11139,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/3.5",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11034,6 +11175,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.0",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11122,6 +11264,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11221,6 +11364,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11309,6 +11453,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11391,6 +11536,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11479,6 +11625,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11561,6 +11708,8 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "LOW",
+        confidenceReason: "prior_failed_center_ge_edge",
         readings: [
           {
             position: 0,
@@ -11649,6 +11798,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -11731,6 +11882,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11812,6 +11964,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -11894,6 +12048,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -11982,6 +12137,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -12064,6 +12221,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12152,6 +12310,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/6.3",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12227,6 +12386,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/11",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12308,6 +12468,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/6.3",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12383,6 +12544,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/11",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12464,6 +12626,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.2",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12546,6 +12709,8 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "LOW",
+        confidenceReason: "prior_failed_center_ge_edge",
         readings: [
           {
             position: 0,
@@ -12634,6 +12799,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -12716,6 +12883,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12804,6 +12972,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -12886,6 +13056,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -12974,6 +13145,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.25",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13056,6 +13228,8 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "LOW",
+        confidenceReason: "prior_failed_center_ge_edge",
         readings: [
           {
             position: 0,
@@ -13144,6 +13318,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13219,6 +13394,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13300,6 +13476,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.8",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -13375,6 +13553,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13456,6 +13635,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13531,6 +13711,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13612,6 +13793,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -13687,6 +13870,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/5.6",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13768,6 +13952,7 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13850,6 +14035,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -13931,6 +14117,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/1.4",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -14006,6 +14194,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -14087,6 +14276,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -14169,6 +14360,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,
@@ -14257,6 +14449,8 @@ const mtfReadings: Record<string, MtfData> = {
     charts: [
       {
         aperture: "f/2.8",
+        confidence: "LOW",
+        confidenceReason: "precision_below_threshold",
         readings: [
           {
             position: 0,
@@ -14339,6 +14533,7 @@ const mtfReadings: Record<string, MtfData> = {
       },
       {
         aperture: "f/8",
+        confidence: "HIGH",
         readings: [
           {
             position: 0,

--- a/src/types/mtf.ts
+++ b/src/types/mtf.ts
@@ -24,9 +24,20 @@ interface MtfReading {
   samples: Record<number, MtfSampleSM>;
 }
 
+type MtfConfidence = "HIGH" | "LOW";
+
 interface MtfChart {
   aperture: string; // e.g. "f/1.4", "f/8"
   focalLength?: number; // mm; set on zoom panels (wide + tele), omitted on primes
+  // Per-pass confidence (ADR-053, ADR-054). HIGH covers hand-curated
+  // entries and autotriage HIGH verdicts; LOW means autotriage flagged
+  // this pass (render-match precision below threshold or a plausibility
+  // prior violated — see `confidenceReason`). Samples are kept on LOW
+  // passes; the lens page surfaces the verdict with a badge.
+  confidence: MtfConfidence;
+  // ADR-052 reason code on LOW passes (e.g. `precision_below_threshold`,
+  // `prior_failed_center_ge_edge`). Omitted on HIGH passes.
+  confidenceReason?: string;
   readings: MtfReading[];
 }
 
@@ -38,4 +49,11 @@ interface MtfData {
   charts: MtfChart[];
 }
 
-export type { MtfReading, MtfSampleSM, MtfChart, MtfData, MtfType };
+export type {
+  MtfReading,
+  MtfSampleSM,
+  MtfChart,
+  MtfData,
+  MtfType,
+  MtfConfidence,
+};

--- a/tools/mtfdigitizer/emit.py
+++ b/tools/mtfdigitizer/emit.py
@@ -47,11 +47,13 @@ from .per_frequency import (
     PER_FREQUENCY_STYLE_FAMILIES,
     extract_per_frequency_chart,
 )
-from .pipeline import PlotBox, extract_chart
+from .pipeline import PlotBox, extract_chart, score_chart
 from .pipeline.dispatch import parse_field_name
-from .pipeline.rendermatch import fields_in
+from .pipeline.rendermatch import DEFAULT_DILATION_RADIUS_PX, fields_in
 from .pipeline.types import ExtractedChart, SampledReading
+from .priors import check_all
 from .referenceset.charts import REFERENCE_CHARTS, PlotBoxCoords, ReferenceChart
+from .triage import triage
 
 
 def _to_plotbox(coords: PlotBoxCoords) -> PlotBox:
@@ -153,6 +155,8 @@ def _format_chart(
     aperture: str,
     paired: tuple[SampledReading, ...],
     focal_length: int | None = None,
+    confidence: str = "HIGH",
+    confidence_reason: str | None = None,
 ) -> str:
     readings_block = "\n".join(_format_reading(r) for r in paired)
     focal_line = (
@@ -160,10 +164,20 @@ def _format_chart(
         if focal_length is not None
         else ""
     )
+    # ADR-053 + #1134: per-pass confidence. `confidence` is required on
+    # the TS type; `confidenceReason` is set only when LOW (ADR-052
+    # reason code from `ChartVerdict.reasons[0]`).
+    reason_line = (
+        f"        confidenceReason: \"{confidence_reason}\",\n"
+        if confidence == "LOW" and confidence_reason
+        else ""
+    )
     return (
         "      {\n"
         f"        aperture: \"{aperture}\",\n"
         f"{focal_line}"
+        f"        confidence: \"{confidence}\",\n"
+        f"{reason_line}"
         "        readings: [\n"
         f"{readings_block}\n"
         "        ],\n"
@@ -171,9 +185,15 @@ def _format_chart(
     )
 
 
-# One emitted chart panel: aperture string, optional focal length in mm
-# (set on zoom panels, None on primes), and the position-keyed readings.
-ChartPanel = tuple[str, int | None, tuple[SampledReading, ...]]
+# One emitted chart panel: aperture, optional focal length, readings, and
+# per-pass confidence with optional reason code (ADR-053 + #1134).
+ChartPanel = tuple[
+    str,
+    int | None,
+    tuple[SampledReading, ...],
+    str,
+    str | None,
+]
 
 
 def _format_entry(
@@ -183,8 +203,14 @@ def _format_entry(
     panels: tuple[ChartPanel, ...],
 ) -> str:
     chart_blocks = "\n".join(
-        _format_chart(aperture, paired, focal_length=focal)
-        for aperture, focal, paired in panels
+        _format_chart(
+            aperture,
+            paired,
+            focal_length=focal,
+            confidence=confidence,
+            confidence_reason=reason,
+        )
+        for aperture, focal, paired, confidence, reason in panels
     )
     return (
         f"  \"{slug}\": {{\n"
@@ -195,6 +221,40 @@ def _format_entry(
         "    ],\n"
         "  },"
     )
+
+
+def _verdict_for_panel(
+    image_path: Path,
+    profile: object,
+    plot_box: PlotBox,
+    image_height_mm: float,
+    extracted: ExtractedChart,
+) -> tuple[str, str | None]:
+    """Compute (confidence, reason) for one emitted panel via ADR-052.
+
+    Runs the same render-match + priors as `autotriage._run_pipeline` so
+    emit's verdict and the autotriage CLI agree on every panel. Returns
+    `("HIGH", None)` when the panel passes the gate, or
+    `("LOW", "<first_reason_code>")` when it fails. The first reason is
+    the primary one (matches the autotriage CLI display); a panel that
+    trips multiple priors collapses to its first reason for the emit
+    output. The autotriage CLI run remains the authoritative report
+    when the maintainer needs the full reason list.
+    """
+    score = score_chart(
+        image_path,
+        profile,  # type: ignore[arg-type]
+        plot_box,
+        image_height_mm=image_height_mm,
+        readings=extracted.readings,
+        dilation_radius_px=DEFAULT_DILATION_RADIUS_PX,
+    )
+    violations = check_all(extracted.readings)
+    verdict = triage(score, violations)
+    if verdict.verdict == "HIGH":
+        return "HIGH", None
+    reason_code = verdict.reasons[0].value if verdict.reasons else "unknown"
+    return "LOW", reason_code
 
 
 def emit_lens(
@@ -256,15 +316,27 @@ def emit_lens(
                 f"view {index} of {chart.slug!r} has no plot_box — "
                 f"emit requires a calibrated plot box on every view"
             )
-        extracted: ExtractedChart = extract_chart(
-            root / view.chart_path,
+        view_plot_box = _to_plotbox(view.plot_box)
+        view_image_path = root / view.chart_path
+        extracted = extract_chart(
+            view_image_path,
             profile,
-            _to_plotbox(view.plot_box),
+            view_plot_box,
             image_height_mm=chart.image_height_mm,
+        )
+        # ADR-053 + #1134: per-pass confidence verdict. emit shares the
+        # autotriage gate (ADR-052) — same render-match + priors as
+        # `autotriage._run_pipeline`, no new thresholds.
+        confidence, reason = _verdict_for_panel(
+            view_image_path,
+            profile,
+            view_plot_box,
+            chart.image_height_mm,
+            extracted,
         )
         rows = tuple(r for r in extracted.readings if _has_any_data(r))
         focal = focal_lengths[index] if focal_lengths is not None else None
-        panels.append((aperture_string, focal, rows))
+        panels.append((aperture_string, focal, rows, confidence, reason))
         total_positions += len(rows)
         for field in fields_in(extracted.readings):
             null_counts.setdefault(field, 0)

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -232,10 +232,15 @@ def _format_chart_block(
         if focal_length is not None
         else ""
     )
+    # ADR-053 + #1134: Fujifilm Tier 2 charts ship as HIGH — they are
+    # hand-curated from official manufacturer optical-design charts and
+    # don't run through the autotriage gate. The HIGH literal here is
+    # the explicit operator verdict for that provenance path.
     return (
         "      {\n"
         f'        aperture: "{aperture}",\n'
         f"{focal_line}"
+        '        confidence: "HIGH",\n'
         "        readings: [\n"
         f"{rows}\n"
         "        ],\n"

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -33,7 +33,7 @@ import re
 import sys
 from pathlib import Path
 
-from mtfdigitizer.calibrate import _extract_multi_aperture_chart
+from mtfdigitizer.autotriage import _run_pipeline
 from mtfdigitizer.pipeline.types import SampledReading
 from mtfdigitizer.referenceset.charts import REFERENCE_CHARTS, ReferenceChart
 
@@ -91,22 +91,33 @@ def _has_any_data(r: SampledReading) -> bool:
 
 
 def _format_chart_block(
-    aperture: str, readings: tuple[SampledReading, ...]
+    aperture: str,
+    readings: tuple[SampledReading, ...],
+    confidence: str,
+    confidence_reason: str | None,
 ) -> str:
     """Emit one MtfChart panel — aperture string + readings array.
 
     Mirrors the prime-shape emit in `emit_fuji_tier2._format_chart_block`
     but without focalLength (TTartisan does not publish per-focal-length
-    charts; even the 500mm super-tele ships one chart per lens).
+    charts; even the 500mm super-tele ships one chart per lens). Carries
+    the per-pass confidence verdict + reason code (ADR-053 + #1134).
     """
     rendered: list[str] = []
     for r in readings:
         if _has_any_data(r) or r.position_mm == 0.0:
             rendered.append(_format_reading(r))
     rows = "\n".join(rendered)
+    reason_line = (
+        f'        confidenceReason: "{confidence_reason}",\n'
+        if confidence == "LOW" and confidence_reason
+        else ""
+    )
     return (
         "      {\n"
         f'        aperture: "{aperture}",\n'
+        f'        confidence: "{confidence}",\n'
+        f"{reason_line}"
         "        readings: [\n"
         f"{rows}\n"
         "        ],\n"
@@ -164,8 +175,13 @@ def _emit_one_lens(
     profile's `apertures_per_chart`. The aperture in each panel is the
     actual f-number (from `chart.apertures[i]`), aligned positionally
     with the profile's aperture labels.
+
+    Confidence (ADR-053 + #1134): each panel runs through the
+    `autotriage._run_pipeline` gate (ADR-052) and emits
+    `confidence: HIGH|LOW` plus, when LOW, the first reason code from
+    `verdict.reasons`. The pipeline is the single source of truth for
+    both autotriage's CLI and emit's verdict — they always agree.
     """
-    results_by_aperture = _extract_multi_aperture_chart(chart)
     blocks: list[str] = []
     total_positions = 0
 
@@ -181,10 +197,29 @@ def _emit_one_lens(
         f"chart.apertures ({chart.apertures!r}) length"
     )
 
+    pass_results = _run_pipeline(chart)
+    by_aperture = {pr.verdict.pass_key: pr for pr in pass_results}
+
     for label, f_number in zip(profile.apertures_per_chart, chart.apertures):
-        result = results_by_aperture[label]
-        blocks.append(_format_chart_block(f_number, result.readings))
-        total_positions += len(result.readings)
+        pass_result = by_aperture[label]
+        verdict = pass_result.verdict
+        if verdict.verdict == "HIGH":
+            confidence = "HIGH"
+            reason: str | None = None
+        else:
+            confidence = "LOW"
+            reason = (
+                verdict.reasons[0].value if verdict.reasons else "unknown"
+            )
+        blocks.append(
+            _format_chart_block(
+                f_number,
+                pass_result.extracted.readings,
+                confidence,
+                reason,
+            )
+        )
+        total_positions += len(pass_result.extracted.readings)
 
     chart_blocks = "\n".join(blocks)
     literal = (

--- a/tools/mtfdigitizer/tests/test_emit.py
+++ b/tools/mtfdigitizer/tests/test_emit.py
@@ -120,12 +120,13 @@ def test_format_entry_wraps_a_lens_block() -> None:
         slug="test-lens",
         source="https://example.com/lens",
         mtf_type="measured",
-        panels=(("f/2.8", None, rows),),
+        panels=(("f/2.8", None, rows, "HIGH", None),),
     )
     assert '"test-lens":' in out
     assert 'source: "https://example.com/lens",' in out
     assert 'mtfType: "measured",' in out
     assert 'aperture: "f/2.8",' in out
+    assert 'confidence: "HIGH",' in out
     # Both rows appear
     assert out.count("position:") == 2
 
@@ -135,7 +136,7 @@ def test_format_entry_emits_computed_mtf_type_when_requested() -> None:
         slug="sigma-lens",
         source="https://sigma-global.com/x",
         mtf_type="computed",
-        panels=(("f/1.4", None, (_r(pos=0),)),),
+        panels=(("f/1.4", None, (_r(pos=0),), "HIGH", None),),
     )
     assert 'mtfType: "computed",' in out
     assert 'mtfType: "measured",' not in out
@@ -146,7 +147,7 @@ def test_format_entry_empty_readings_block_is_valid_ts() -> None:
         slug="test-lens",
         source="https://x",
         mtf_type="measured",
-        panels=(("f/2", None, ()),),
+        panels=(("f/2", None, (), "HIGH", None),),
     )
     assert "readings: [\n\n        ]," in out
 
@@ -158,8 +159,8 @@ def test_format_entry_emits_two_panels_for_zoom() -> None:
         source="https://sigma-global.com/x",
         mtf_type="computed",
         panels=(
-            ("f/2.8", 10, (_r(pos=0), _r(pos=14.0))),
-            ("f/2.8", 18, (_r(pos=0), _r(pos=14.0))),
+            ("f/2.8", 10, (_r(pos=0), _r(pos=14.0)), "HIGH", None),
+            ("f/2.8", 18, (_r(pos=0), _r(pos=14.0)), "HIGH", None),
         ),
     )
     # One charts: [...] array, two chart objects inside
@@ -174,6 +175,20 @@ def test_format_entry_prime_emits_no_focal_length_line() -> None:
         slug="sigma-56mm-f1-4-dc-dn-c",
         source="https://sigma-global.com/x",
         mtf_type="computed",
-        panels=(("f/1.4", None, (_r(pos=0),)),),
+        panels=(("f/1.4", None, (_r(pos=0),), "HIGH", None),),
     )
     assert "focalLength" not in out
+
+
+def test_format_entry_emits_low_confidence_with_reason() -> None:
+    """ADR-053 + #1134: LOW pass carries confidence + confidenceReason."""
+    out = _format_entry(
+        slug="ttartisan-50mm-f1-2",
+        source="https://x",
+        mtf_type="computed",
+        panels=(
+            ("f/5.6", None, (_r(pos=0),), "LOW", "prior_failed_center_ge_edge"),
+        ),
+    )
+    assert 'confidence: "LOW",' in out
+    assert 'confidenceReason: "prior_failed_center_ge_edge",' in out

--- a/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
@@ -61,10 +61,38 @@ def test_format_chart_block_carries_aperture_and_readings():
             samples={"freq10S": 0.9, "freq10M": 0.9, "freq30S": 0.5, "freq30M": 0.5},
         ),
     )
-    out = _format_chart_block("f/1.2", readings)
+    out = _format_chart_block("f/1.2", readings, "HIGH", None)
     assert 'aperture: "f/1.2",' in out
     assert "readings: [" in out
     assert "position: 0," in out
+
+
+def test_format_chart_block_emits_high_confidence():
+    """HIGH passes carry `confidence: "HIGH"` and no `confidenceReason`."""
+    readings = (
+        SampledReading(
+            position_mm=0.0,
+            samples={"freq10S": 0.9},
+        ),
+    )
+    out = _format_chart_block("f/1.2", readings, "HIGH", None)
+    assert 'confidence: "HIGH",' in out
+    assert "confidenceReason" not in out
+
+
+def test_format_chart_block_emits_low_confidence_with_reason():
+    """LOW passes carry `confidence: "LOW"` and the reason code."""
+    readings = (
+        SampledReading(
+            position_mm=0.0,
+            samples={"freq10S": 0.9},
+        ),
+    )
+    out = _format_chart_block(
+        "f/5.6", readings, "LOW", "prior_failed_center_ge_edge"
+    )
+    assert 'confidence: "LOW",' in out
+    assert 'confidenceReason: "prior_failed_center_ge_edge",' in out
 
 
 def test_format_chart_block_keeps_position_0_even_when_all_null():
@@ -80,7 +108,7 @@ def test_format_chart_block_keeps_position_0_even_when_all_null():
             samples={"freq10S": 0.6, "freq10M": 0.6, "freq30S": 0.3, "freq30M": 0.3},
         ),
     )
-    out = _format_chart_block("f/1.2", readings)
+    out = _format_chart_block("f/1.2", readings, "HIGH", None)
     assert "position: 0," in out  # kept despite all-null samples
 
 
@@ -101,7 +129,7 @@ def test_format_chart_block_drops_intermediate_all_null_rows():
             samples={"freq10S": 0.6, "freq30S": 0.3},
         ),
     )
-    out = _format_chart_block("f/1.2", readings)
+    out = _format_chart_block("f/1.2", readings, "HIGH", None)
     assert "position: 0," in out
     assert "position: 14," in out
     assert "position: 5," not in out


### PR DESCRIPTION
## Summary

- ADR-054 records the schema decision: `confidence: \"HIGH\" | \"LOW\"` required on `MtfChart`, `confidenceReason?: string` set only on LOW
- All 182 existing hand-curated chart literals migrate to `confidence: \"HIGH\"`
- TTartisan emit (`scripts/emit_ttartisan_tier2.py`) runs through autotriage and writes 25 HIGH + 13 LOW per-pass verdicts — matches ADR-053's Q2 numbers byte-for-byte
- emit.py base path also runs the autotriage gate; emit_fuji_tier2 ships HIGH literal (Fujifilm Tier 2 = hand-curated optical-design charts)
- This is the schema/emit half of #1134; the lens-page badge + `/wiki/mtf-confidence` explainer are the UI half — next session

## Test plan

- [x] `npm run validate` green — 461 pages, 0 errors, 0 warnings
- [x] vitest 222/222 (was 220, +2: HIGH/LOW present; reason iff LOW)
- [x] pytest 348/348 (was 345, +3: emit accepts confidence + reason, HIGH no reason line, LOW with reason line)
- [x] TTartisan emit verified end-to-end: dry-run produced 25 HIGH + 13 LOW matching Q2; \`--write\` patched src/data/mtf-readings.ts cleanly
- [x] `ttartisan-50mm-f1-2` shows f/1.2 HIGH and f/5.6 LOW with `confidenceReason: \"prior_failed_center_ge_edge\"` — matches Q5
- [ ] User merges

## Verification samples

\`\`\`
\$ grep -c 'confidence: \"HIGH\"' src/data/mtf-readings.ts
169
\$ grep -c 'confidence: \"LOW\"'  src/data/mtf-readings.ts
13
\$ grep -c 'confidenceReason'    src/data/mtf-readings.ts
13
\`\`\`

\`ttartisan-50mm-f1-2\` (Tier 1 anchor) in mtf-readings.ts:

\`\`\`typescript
{
  aperture: \"f/1.2\",
  confidence: \"HIGH\",
  readings: [...]
},
{
  aperture: \"f/5.6\",
  confidence: \"LOW\",
  confidenceReason: \"prior_failed_center_ge_edge\",
  readings: [...]
},
\`\`\`

## Out of scope (next session)

- Lens-page LOW badge (UI shape)
- `/wiki/mtf-confidence` explainer page (wiki content)
- Brands other than TTartisan (per ADR-053: Q2-style probe before each new brand's data lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)