### PR TITLE
fix(mtf): port ADR-044 fan-out to review.py (#1132)

### DIFF
--- a/tools/mtfdigitizer/review.py
+++ b/tools/mtfdigitizer/review.py
@@ -44,13 +44,13 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from .aperture_passes import aperture_passes_for_view
 from .loader import load_chart_bgr
 from .pipeline import ExtractedChart, SampledReading, extract_chart
 from .pipeline.dispatch import parse_field_name
 from .pipeline.plotbox import image_height_mm_to_x_pixel
 from .pipeline.rendermatch import fields_in
 from .pipeline.types import PlotBox
-from .family_profile import profile_for_chart
 from .referenceset import REFERENCE_CHARTS
 from .referenceset.charts import PlotBoxCoords, ReferenceChart
 
@@ -356,39 +356,76 @@ def _svg_path_for(image_path: Path) -> Path:
     return image_path.with_suffix(".svg")
 
 
-def _emit_chart(chart: ReferenceChart, *, check_only: bool) -> ReviewOutputs | None:
-    """Render one reference chart's review file. Returns ``None`` in
-    ``--check`` mode after rendering everything in memory."""
+def _emit_chart(
+    chart: ReferenceChart,
+    *,
+    check_only: bool,
+    out_dir: Path | None = None,
+) -> list[ReviewOutputs]:
+    """Render one reference chart's review file(s). Returns an empty list
+    in ``--check`` mode after rendering everything in memory.
+
+    Multi-aperture charts (ADR-044) fan out to one review file per
+    aperture via ``aperture_passes_for_view`` — matching the per-aperture
+    output naming convention svg.py uses (``<stem>-<aperture>.svg``) and
+    the per-aperture review files autotriage.py already writes. Without
+    this fan-out, ``extract_chart`` is called with the full multi-aperture
+    profile and ``dispatch.field_skeletons`` raises KeyError because
+    ``unique_named_hues`` lists N aperture hues but ``frequencies_lpmm``
+    only lists the per-aperture frequencies (#1132).
+
+    ``out_dir`` defaults to the source image's directory (the production
+    layout under ``docs/optical-specs/<slug>/``); tests pass a temp dir
+    to avoid touching the reference tree.
+    """
     assert chart.plot_box is not None
-    profile = profile_for_chart(chart)
     image_path = REPO_ROOT / chart.chart_path
     plot_box = _to_plotbox(chart.plot_box)
-    extracted = extract_chart(
-        image_path, profile, plot_box, image_height_mm=chart.image_height_mm
-    )
+    passes = aperture_passes_for_view(chart, image_path)
+    multi = len(passes) > 1
 
-    if check_only:
-        # Exercise the overlay + HTML paths without touching disk so
-        # --check still catches regressions in either code path.
-        bgr = load_chart_bgr(image_path)
-        _ = render_overlay(bgr, extracted.readings, plot_box, chart.image_height_mm)
-        _ = render_review_html(
-            title=image_path.stem,
-            paths=ReviewPaths(
-                original_filename=image_path.name,
-                svg_filename=_svg_path_for(image_path).name,
-                overlay_filename=f"{image_path.stem}-overlay.png",
-            ),
+    outputs: list[ReviewOutputs] = []
+    for aperture, profile in passes:
+        extracted = extract_chart(
+            image_path, profile, plot_box, image_height_mm=chart.image_height_mm
         )
-        return None
+        stem_override = f"{image_path.stem}-{aperture}" if multi else None
+        stem = stem_override if stem_override is not None else image_path.stem
+        svg_path = (
+            image_path.with_name(f"{stem_override}.svg")
+            if stem_override is not None
+            else _svg_path_for(image_path)
+        )
 
-    return write_review(
-        extracted,
-        image_path,
-        plot_box=plot_box,
-        image_height_mm=chart.image_height_mm,
-        svg_path=_svg_path_for(image_path),
-    )
+        if check_only:
+            # Exercise the overlay + HTML paths without touching disk so
+            # --check still catches regressions in either code path.
+            bgr = load_chart_bgr(image_path)
+            _ = render_overlay(
+                bgr, extracted.readings, plot_box, chart.image_height_mm
+            )
+            _ = render_review_html(
+                title=stem,
+                paths=ReviewPaths(
+                    original_filename=image_path.name,
+                    svg_filename=svg_path.name,
+                    overlay_filename=f"{stem}-overlay.png",
+                ),
+            )
+            continue
+
+        outputs.append(
+            write_review(
+                extracted,
+                image_path,
+                plot_box=plot_box,
+                image_height_mm=chart.image_height_mm,
+                svg_path=svg_path,
+                out_dir=out_dir,
+                stem_override=stem_override,
+            )
+        )
+    return outputs
 
 
 def main() -> None:
@@ -408,13 +445,14 @@ def main() -> None:
 
     for chart in runnable:
         outputs = _emit_chart(chart, check_only=args.check)
-        if outputs is None:
+        if not outputs:
             print(f"  {chart.slug:<40}  rendered (--check)")
             continue
-        rel_html = outputs.html_path.relative_to(REPO_ROOT)
-        rel_overlay = outputs.overlay_path.relative_to(REPO_ROOT)
-        print(f"  {chart.slug:<40}  wrote  {rel_html}")
-        print(f"  {'':<40}  wrote  {rel_overlay}")
+        for out in outputs:
+            rel_html = out.html_path.relative_to(REPO_ROOT)
+            rel_overlay = out.overlay_path.relative_to(REPO_ROOT)
+            print(f"  {chart.slug:<40}  wrote  {rel_html}")
+            print(f"  {'':<40}  wrote  {rel_overlay}")
 
 
 if __name__ == "__main__":

--- a/tools/mtfdigitizer/tests/test_review.py
+++ b/tools/mtfdigitizer/tests/test_review.py
@@ -34,6 +34,7 @@ from mtfdigitizer.review import (
     ReviewPaths,
     _OVERLAY_COLOR_10,
     _OVERLAY_COLOR_30,
+    _emit_chart,
     render_overlay,
     render_review_html,
     write_review,
@@ -332,6 +333,67 @@ def test_write_review_on_real_sigma_chart(tmp_path: Path) -> None:
     assert image_path.name in html
     assert outputs.overlay_path.name in html
     assert svg_path.name in html
+
+
+def test_emit_chart_check_mode_clears_full_reference_set() -> None:
+    """`_emit_chart(check_only=True)` must complete on every runnable
+    reference chart without raising — regression for #1132 where ADR-044
+    multi-aperture charts (TTartisan cohort) crashed the review pipeline
+    with `KeyError: 'stopped-10-red'` because dispatch was handed the
+    full multi-aperture profile instead of one filtered per pass."""
+    runnable = [c for c in REFERENCE_CHARTS if c.plot_box and c.ground_truth]
+    # Must include at least one TTartisan multi-aperture chart, otherwise
+    # we're not actually exercising the fan-out path.
+    assert any(
+        c.slug.startswith("ttartisan-") for c in runnable
+    ), "reference set lost its TTartisan multi-aperture coverage"
+    for chart in runnable:
+        # In --check mode no files are written; an exception is the only
+        # failure signal.
+        _emit_chart(chart, check_only=True)
+
+
+def test_emit_chart_multi_aperture_fans_out_to_per_pass_files(
+    tmp_path: Path,
+) -> None:
+    """ADR-044 multi-aperture charts emit one (HTML, overlay PNG) pair
+    per aperture pass, stems named `<chart-stem>-<aperture>` to match
+    svg.py's `<chart-stem>-<aperture>.svg` and autotriage.py's per-pass
+    review files."""
+    chart = next(
+        c for c in REFERENCE_CHARTS if c.slug == "ttartisan-50mm-f1-2"
+    )
+    outputs = _emit_chart(chart, check_only=False, out_dir=tmp_path)
+    assert len(outputs) == 2, (
+        f"expected 2 passes for multi-aperture chart; got {len(outputs)}"
+    )
+    stems = {o.html_path.stem for o in outputs}
+    # `apertures_per_chart=("max", "stopped")` on the profile drives the
+    # pass labels — the chart's `apertures=("f/1.2", "f/5.6")` are the
+    # human aperture values, not the orchestrator's pass keys.
+    expected = {
+        "ttartisan-50mm-f1-2-mtf-max-review",
+        "ttartisan-50mm-f1-2-mtf-stopped-review",
+    }
+    assert stems == expected, f"unexpected review stems: {stems}"
+    for o in outputs:
+        assert o.html_path.is_file()
+        assert o.overlay_path.is_file()
+        assert o.overlay_path.stat().st_size > 0
+
+
+def test_emit_chart_single_aperture_emits_one_pair(tmp_path: Path) -> None:
+    """Single-aperture charts (Sigma, Samyang, 7Artisans, etc.) keep the
+    pre-#1132 shape: one review HTML + one overlay PNG, stems untouched
+    by aperture suffixes."""
+    chart = next(
+        c for c in REFERENCE_CHARTS if c.slug == "sigma-56mm-f1-4-dc-dn-c"
+    )
+    outputs = _emit_chart(chart, check_only=False, out_dir=tmp_path)
+    assert len(outputs) == 1
+    assert outputs[0].html_path.stem == (
+        "sigma-56mm-f1-4-dc-dn-c-mtf-diffraction-review"
+    )
 
 
 def test_write_review_default_out_dir_is_image_folder(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Port the `aperture_passes_for_view` orchestrator into `review.py:_emit_chart`, fixing the `KeyError: 'stopped-10-red'` crash on TTartisan multi-aperture charts (#1132). Same class of bug as #1107 (svg.py) and #1123 (autotriage.py), both fixed via this orchestrator.
- Multi-aperture charts (ADR-044) now emit one `(review HTML, overlay PNG)` pair per aperture pass with stems `<chart-stem>-<aperture>` — matching `svg.py`'s `<chart-stem>-<aperture>.svg` and the per-pass review files `autotriage.py` already writes. Single-aperture charts keep their existing 1-pair output and stem (no `-<aperture>` suffix; regression test asserts this).
- Add `out_dir` to `_emit_chart` so the two new write-based tests target `tmp_path` rather than the real `docs/optical-specs/` tree.

## Test plan

- [x] `py -m pytest` from `tools/` — **621 pass** (was 618; +3 new tests)
- [x] `py -m mtfdigitizer.review --check` completes on all 14 runnable reference charts, including `ttartisan-50mm-f1-2` (previous crash point)
- [x] Single-aperture chart regression test confirms unchanged behavior

Closes #1132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)