### PR TITLE
fix(mtf): strip vertical chrome from ridge candidates (#1122)

### DIFF
--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -104,6 +104,15 @@ from .types import PlotBox
 # stray pixel between dash and gridline). Filtered before clustering.
 _MIN_RUN_LENGTH: int = 1
 
+# A column run taller than this is vertical chrome (axis tick labels,
+# axis line ink, legend box edge) that `_strip_chrome` does not catch —
+# its row-coverage pass strips horizontal chrome only. Real MTF curve
+# ridges measured across the reference set fit within ~3 px at p95 and
+# ~13 px at p99; runs >20 px are chrome. The fisheye #1122 case fired
+# 52-px and 265-px runs at the leftmost two plot columns (Y-axis "1"
+# label + axis line) and corrupted downstream densify-pass interpolation.
+_MAX_RUN_LENGTH: int = 20
+
 # Rows within this distance (inclusive) belong to the same column run.
 # Larger values merge adjacent curves; smaller values split a single
 # anti-aliased curve into two runs. 1 means "touching only".
@@ -210,7 +219,13 @@ def _strip_chrome(mask: np.ndarray, plot_box: PlotBox) -> np.ndarray:
 def _column_runs(
     column: np.ndarray, gap_tolerance: int = _RIDGE_RUN_GAP_TOLERANCE
 ) -> list[tuple[float, int]]:
-    """Group a binary column into runs; return (centroid_y, length) per run."""
+    """Group a binary column into runs; return (centroid_y, length) per run.
+
+    Runs outside ``[_MIN_RUN_LENGTH, _MAX_RUN_LENGTH]`` are dropped: too
+    short is anti-aliasing noise, too tall is vertical chrome (axis
+    label glyphs, axis line) that `_strip_chrome`'s row-coverage pass
+    misses.
+    """
     rows = np.nonzero(column)[0]
     if rows.size == 0:
         return []
@@ -223,12 +238,12 @@ def _column_runs(
             prev = y_int
             continue
         length = prev - start + 1
-        if length >= _MIN_RUN_LENGTH:
+        if _MIN_RUN_LENGTH <= length <= _MAX_RUN_LENGTH:
             runs.append(((start + prev) / 2.0, length))
         start = y_int
         prev = y_int
     length = prev - start + 1
-    if length >= _MIN_RUN_LENGTH:
+    if _MIN_RUN_LENGTH <= length <= _MAX_RUN_LENGTH:
         runs.append(((start + prev) / 2.0, length))
     return runs
 


### PR DESCRIPTION
## Summary

Closes #1122. Adds a `_MAX_RUN_LENGTH = 20` cap inside `_column_runs` so column-tall ink — Y-axis tick-label glyphs, axis line ink, legend box edge — is filtered out of ridge candidates. `_strip_chrome` only catches horizontal chrome (rows with >=90% coverage); the symmetric vertical case had no defense.

## Root cause (probed end-to-end)

On `ttartisan-7-5mm-f2-0-fisheye` max, columns x=88 and x=89 sit just inside the plot box, on top of the Y-axis "1" tick label and the axis line. Their `_column_runs` output:

```
x=88: centroid_y=168.5, length=52   (label glyph)
x=88: centroid_y=328.0, length=265  (axis line down to plot bottom)
x=89: centroid_y=168.5, length=50
x=89: centroid_y=329.0, length=263
```

Compare to the rest of the plot: across 528 legitimate column runs, p99 = 13 px, p95 = 3 px, median = 2 px. Anything > ~20 px is chrome, not a curve.

Pass-1 of the per-column DP correctly stayed on the real S10 ridge at y≈134 (otf 0.948). Pass-2 had to land somewhere, picked up the y=168.5 spurious centroids at x=88-89, and `_path_to_track` accepted them. `_fill_coincident_column_gaps_extending` then admitted some near-coincidence columns; `_densify_track` linearly interpolated from (89, 168.5) to track-2's next real point at (202, 132.5), drawing a phantom dashed line across 113 columns of the low-field S=T coincidence region. At x=139 (sample[1]), this interpolation yielded y=152.6 → **otf=0.894**, matching the original manifest's 0.893 reading.

## Verification

| Check | Before | After |
|---|---|---|
| fisheye max freq10M sample[1] | 0.893 | **0.948** (delta from freq10S: 0.000) |
| fisheye max freq10S sample[1] | 0.948 | 0.948 (unchanged) |
| ttartisan-50mm-f1-2 anchor calibration | byte-identical | byte-identical |
| ttartisan-50mm-f2-0 max samples | (44 values) | byte-identical |
| Aggregate calibration paired comparisons | 583/627 (93.0%) | 583/626 (93.1%) |
| Aggregate p95 \|d\| | 0.0638 | 0.0632 |
| pytest | 621/621 | 621/621 |
| vitest | 222/222 | 222/222 |
| astro check | 0 errors | 0 errors |

The only chart with measurable drift is **viltrox-af-75mm-f1-2-pro freq30S** (1 paired comparison fewer, p95 0.136 → 0.061): a previously out-of-tolerance reading is now correctly None instead, because the column it relied on was column-tall chrome.

## Acceptance criteria (#1122)

- [x] Probe identifies the per-column DP mechanism producing 0.06 dive — turned out **NOT** to be DP mistracking with black candidates available, but downstream `_densify_track` linear-interp from a spurious chrome ridge upstream of the candidate set.
- [x] fisheye max freq10M sample[1] within 0.03 of freq10S sample[1] — delta 0.000
- [x] No regression on ttartisan-50mm-f1-2 Tier 1 anchor — byte-identical
- [x] No regression on ttartisan-50mm-f2-0 — all max-pass samples byte-identical
- [x] pytest pass — 621/621

## Follow-up

`py -m mtfdigitizer.extract --check` reports 12 TTartisan production digitization-logs went stale from the change (small within-tolerance drift on production lenses; the calibration anchors are unaffected). Will refresh as a separate PR following the S146 pattern (#1143 fix → #1144 refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)