### PR TITLE
fix(mtf): strip axis-line anti-aliased halo in coverage band (#1165)

### DIFF
--- a/docs/optical-specs/ttartisan-tilt-50mm-f1-4/digitization-log.md
+++ b/docs/optical-specs/ttartisan-tilt-50mm-f1-4/digitization-log.md
@@ -31,7 +31,7 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm and [ADR-041](../.
 
 ```
   EX   freq10S        ▆▆▇▆▆▆▅▅▄▃·  (0.75 →  — )
-  EX   freq10M        ▆▇▆▆▇▆▆▇▆▅·  (0.75 →  — )
+  EX   freq10M        ▆▆▆▆▆▆▆▅▅▄·  (0.75 →  — )
   EX   freq30S        ▃▃▃▃▂▂▂▂▂▂·  (0.28 →  — )
   EX   freq30M        ▃▃▃▃▃▃▃▃▂▂·  (0.28 →  — )
 ```
@@ -57,15 +57,15 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm and [ADR-041](../.
 | frac | EX |
 | ---- | --- |
 | 0.0 | 0.75 |
-| 0.1 | 0.87 |
+| 0.1 | 0.76 |
 | 0.2 | 0.75 |
 | 0.3 | 0.76 |
-| 0.4 | 0.87 |
+| 0.4 | 0.74 |
 | 0.5 | 0.71 |
 | 0.6 | 0.67 |
-| 0.7 | 0.81 |
-| 0.8 | 0.78 |
-| 0.9 | 0.61 |
+| 0.7 | 0.63 |
+| 0.8 | 0.58 |
+| 0.9 | 0.48 |
 | 1.0 | — |
 
 **freq30S**
@@ -105,7 +105,7 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm and [ADR-041](../.
 | Field          | center (0.0) | edge (0.9) | corner (1.0) |
 | -------------- | ------------ | ---------- | ------------ |
 | freq10S        |         0.75 |       0.33 |            — |
-| freq10M        |         0.75 |       0.61 |            — |
+| freq10M        |         0.75 |       0.48 |            — |
 | freq30S        |         0.28 |       0.08 |            — |
 | freq30M        |         0.28 |       0.08 |            — |
 
@@ -114,7 +114,7 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm and [ADR-041](../.
 | Field          | peak frac | peak value | half-falloff frac |
 | -------------- | --------- | ---------- | ----------------- |
 | freq10S        |       0.2 |       0.80 |               0.9 |
-| freq10M        |       0.1 |       0.87 |                 — |
+| freq10M        |       0.3 |       0.76 |                 — |
 | freq30S        |       0.0 |       0.28 |               0.6 |
 | freq30M        |       0.3 |       0.30 |               0.9 |
 
@@ -124,8 +124,8 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm and [ADR-041](../.
 
 | metric    | value | threshold | pass |
 | --------- | ----- | --------- | ---- |
-| precision | 0.746 |      0.80 |   no |
-| IoU       | 0.516 |      0.20 |  yes |
+| precision | 0.917 |      0.80 |  yes |
+| IoU       | 0.643 |      0.20 |  yes |
 
 #### Plausibility priors
 
@@ -133,10 +133,9 @@ All four priors held (`center_ge_edge`, `low_freq_ge_high`, `not_suspiciously_fl
 
 ### Gate
 
-**Gate verdict:** `LOW`
+**Gate verdict:** `HIGH`
 
-**Reasons:**
-- `precision_below_threshold`
+No reasons — both confidence signals cleared.
 
 ## Panel
 

--- a/docs/optical-specs/ttartisan-tilt-50mm-f1-4/ttartisan-tilt-50mm-f1-4-mtf-max.svg
+++ b/docs/optical-specs/ttartisan-tilt-50mm-f1-4/ttartisan-tilt-50mm-f1-4-mtf-max.svg
@@ -25,7 +25,7 @@
 <text class="axis-label axis-x" x="304.0" y="186">20.5</text>
 <text class="axis-title" x="170.0" y="198">Image height (mm)</text>
 <polyline class="curve curve-10" style="stroke:#c89b3c" points="36.0,52.7 62.8,49.4 89.6,44.3 116.4,49.0 143.2,59.3 170.0,69.1 196.8,74.7 223.6,84.7 250.4,99.5 277.2,119.1"/>
-<polyline class="curve curve-10 curve-m" style="stroke:#c89b3c" points="36.0,52.7 62.8,32.8 89.6,51.3 116.4,50.1 143.2,33.5 170.0,58.3 196.8,64.6 223.6,42.4 250.4,46.9 277.2,74.9" stroke-dasharray="4 2"/>
+<polyline class="curve curve-10 curve-m" style="stroke:#c89b3c" points="36.0,52.7 62.8,50.8 89.6,51.3 116.4,50.1 143.2,53.6 170.0,58.5 196.8,64.6 223.6,71.2 250.4,79.6 277.2,95.5" stroke-dasharray="4 2"/>
 <polyline class="curve curve-30" style="stroke:#6b9bd2" points="36.0,126.6 62.8,129.4 89.6,127.6 116.4,130.8 143.2,138.8 170.0,146.0 196.8,152.6 223.6,157.3 250.4,157.5 277.2,159.8"/>
 <polyline class="curve curve-30 curve-m" style="stroke:#6b9bd2" points="36.0,126.6 62.8,125.7 89.6,126.2 116.4,123.8 143.2,124.0 170.0,129.0 196.8,131.3 223.6,135.5 250.4,145.8 277.2,158.4" stroke-dasharray="4 2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="36.0" cy="52.7" r="2"/>
@@ -39,15 +39,15 @@
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="250.4" cy="99.5" r="2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="277.2" cy="119.1" r="2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="36.0" cy="52.7" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="62.8" cy="32.8" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="62.8" cy="50.8" r="2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="89.6" cy="51.3" r="2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="116.4" cy="50.1" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="143.2" cy="33.5" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="170.0" cy="58.3" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="143.2" cy="53.6" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="170.0" cy="58.5" r="2"/>
 <circle class="dot dot-10" style="stroke:#c89b3c" cx="196.8" cy="64.6" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="223.6" cy="42.4" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="250.4" cy="46.9" r="2"/>
-<circle class="dot dot-10" style="stroke:#c89b3c" cx="277.2" cy="74.9" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="223.6" cy="71.2" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="250.4" cy="79.6" r="2"/>
+<circle class="dot dot-10" style="stroke:#c89b3c" cx="277.2" cy="95.5" r="2"/>
 <circle class="dot dot-30" style="stroke:#6b9bd2" cx="36.0" cy="126.6" r="2"/>
 <circle class="dot dot-30" style="stroke:#6b9bd2" cx="62.8" cy="129.4" r="2"/>
 <circle class="dot dot-30" style="stroke:#6b9bd2" cx="89.6" cy="127.6" r="2"/>

--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -187,6 +187,30 @@ class Track:
 _CHROME_MAX_HEIGHT: int = 4
 _CHROME_MIN_WIDTH_FRACTION: float = 0.90
 
+# Axis-halo strip parameters (#1165). Rows immediately adjacent to a
+# stripped border row that have at least `_AXIS_HALO_MIN_COVERAGE`
+# column coverage are treated as anti-aliased halo and stripped too.
+# Confined to `_AXIS_HALO_DEPTH` rows of the border to avoid touching
+# genuine curve readings near MTF=1.0 or MTF=0.0.
+#
+# Sized from the cohort:
+# - TTartisan tilt-50 GFX template: 80 pixels (15.5%) at y_top+3,
+#   60 pixels at y_top+4 — pure top-axis anti-aliased halo, no real
+#   curve at MTF~0.99 here. Stripped.
+# - TTartisan 7.5 fisheye: 2 pixels (0.4%) at each of y_top+1..+4 —
+#   genuine freq10S/M near MTF=1.0 in the corner. Kept.
+# Threshold 10% separates them cleanly.
+_AXIS_HALO_DEPTH: int = 4
+# Coverage band for axis-halo: rows with coverage in
+# [_AXIS_HALO_MIN_COVERAGE, _AXIS_HALO_MAX_COVERAGE) within
+# `_AXIS_HALO_DEPTH` of a border are anti-aliased halo and stripped.
+# Below MIN: sparse genuine curve corners (7.5 fisheye: 0.4% near
+# MTF=1.0). Above MAX: dense real curves close to the axis (Viltrox
+# 10S contrast: 36-65% within y_top+1..y_top+6 because the curves
+# physically sit near MTF~0.95-1.0).
+_AXIS_HALO_MIN_COVERAGE: float = 0.12
+_AXIS_HALO_MAX_COVERAGE: float = 0.30
+
 
 def _strip_chrome(mask: np.ndarray, plot_box: PlotBox) -> np.ndarray:
     """Zero out plot-box border rows + rows with >=90% horizontal coverage.
@@ -228,6 +252,24 @@ def _strip_chrome(mask: np.ndarray, plot_box: PlotBox) -> np.ndarray:
     # high-coverage threshold and was misread as a curve at MTF=0.
     cleaned[plot_box.y_top, plot_box.x_left : plot_box.x_right + 1] = 0
     cleaned[plot_box.y_bottom, plot_box.x_left : plot_box.x_right + 1] = 0
+    # Also strip rows within `_AXIS_HALO_DEPTH` of the border that
+    # have at least `_AXIS_HALO_MIN_COVERAGE` column coverage — see
+    # #1165. TTartisan tilt-50's max-10-black mask has 80 sparse halo
+    # pixels at y_top+3 (15.5% coverage) from the top axis anti-
+    # aliasing that survive the 90% chrome threshold. The DP latched
+    # onto them as freq10M candidates when the dashed T10 curve was in
+    # a dash gap, producing 0.99 spikes interleaved with real readings.
+    # Threshold 12% separates that halo from genuine corner readings
+    # near MTF=1.0 (~0.4% coverage on 7.5 fisheye).
+    halo_min_count = int(_AXIS_HALO_MIN_COVERAGE * width)
+    halo_max_count = int(_AXIS_HALO_MAX_COVERAGE * width)
+    for dy in range(1, _AXIS_HALO_DEPTH + 1):
+        for y in (plot_box.y_top + dy, plot_box.y_bottom - dy):
+            if plot_box.y_top <= y <= plot_box.y_bottom:
+                row = cleaned[y, plot_box.x_left : plot_box.x_right + 1]
+                count = int(row.sum())
+                if halo_min_count <= count < halo_max_count:
+                    cleaned[y, plot_box.x_left : plot_box.x_right + 1] = 0
     for y in range(plot_box.y_top, plot_box.y_bottom + 1):
         row = cleaned[y, plot_box.x_left : plot_box.x_right + 1]
         if int(row.sum()) >= min_count:

--- a/tools/mtfdigitizer/tests/test_ridge.py
+++ b/tools/mtfdigitizer/tests/test_ridge.py
@@ -103,16 +103,41 @@ def test_strip_chrome_zeros_plot_box_border_rows_unconditionally() -> None:
 
 
 def test_strip_chrome_keeps_curve_ink_just_inside_borders() -> None:
-    """A curve sample one pixel inside the y_top / y_bottom borders is
-    real data and MUST survive the border-strip. Distinguishes border
-    chrome from a curve that happens to peak/trough near the frame.
+    """A sparse curve sample one pixel inside the y_top / y_bottom
+    borders is real data and MUST survive the border-strip. Real chart
+    data at MTF~0.99 / MTF~0.01 is sparse — a few pixels per row —
+    because curves near the axis are physically rare. Dense ink at
+    those rows is anti-aliased axis-line halo and is correctly stripped
+    by the axis-halo rule (#1165).
     """
     mask = np.zeros((100, 100), dtype=np.uint8)
-    mask[21, 10:30] = 1  # one pixel inside y_top — real curve ink
-    mask[79, 10:30] = 1  # one pixel inside y_bottom — real curve ink
+    # Sparse curve corner: 5 of 100 columns = 5% coverage, well below
+    # _AXIS_HALO_MIN_COVERAGE. This represents a real curve approaching
+    # MTF=1.0 at the chart corner (e.g. 7.5 fisheye max-10-black has
+    # 2/521 ~ 0.4% coverage near the top axis).
+    mask[21, 10:15] = 1  # one pixel inside y_top
+    mask[79, 10:15] = 1  # one pixel inside y_bottom
     cleaned = _strip_chrome(mask, _box(y_top=20, y_bottom=80))
-    assert cleaned[21, 10:30].sum() == 20
-    assert cleaned[79, 10:30].sum() == 20
+    assert cleaned[21, 10:15].sum() == 5
+    assert cleaned[79, 10:15].sum() == 5
+
+
+def test_strip_chrome_kills_dense_halo_just_inside_borders() -> None:
+    """Halo immediately below the top axis (or above the bottom axis)
+    that has >= _AXIS_HALO_MIN_COVERAGE column coverage is anti-aliased
+    chrome, not real curve data. See #1165: TTartisan tilt-50 GFX
+    template has 80/517 ~ 15.5% coverage at y_top+3 from the top axis
+    halo that survives the standard 90% chrome threshold but is not a
+    real curve at MTF~0.99.
+    """
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    # Dense halo: 20 of 100 columns = 20% coverage, above
+    # _AXIS_HALO_MIN_COVERAGE (12%). Stripped.
+    mask[21, 10:30] = 1  # one pixel inside y_top
+    mask[79, 10:30] = 1  # one pixel inside y_bottom
+    cleaned = _strip_chrome(mask, _box(y_top=20, y_bottom=80))
+    assert cleaned[21, :].sum() == 0
+    assert cleaned[79, :].sum() == 0
 
 
 # --- _cluster_into_tracks ------------------------------------------------


### PR DESCRIPTION
Closes #1165.

## Summary

TTartisan tilt-50mm f/1.4 max pass returned LOW (precision **0.746** < 0.80 threshold) because the `max-10-black` mask had 80 sparse halo pixels at `y_top+3` (15.5% column coverage) from the top axis line's anti-aliased gradient. The standard 90% chrome strip missed it. The ridge DP latched onto those halo pixels as freq10M candidates whenever the dashed T10 curve was in a dash gap, producing 0.99 MTF spikes interleaved with real readings:

```
Before: 0.75, 0.87, 0.75, 0.76, 0.87, 0.71, 0.67, 0.81, 0.78, 0.61  (bouncy)
After:  0.75, 0.76, 0.75, 0.76, 0.74, 0.71, 0.67, 0.63, 0.58, 0.48  (smooth)
```

## Fix

Extend `_strip_chrome` to also clear rows within `_AXIS_HALO_DEPTH` (4) of the border whose column coverage falls in the band [`_AXIS_HALO_MIN_COVERAGE` (12%), `_AXIS_HALO_MAX_COVERAGE` (30%)].

The band carefully separates three regimes seen across the cohort:

| Coverage | Regime | Action |
|---|---|---|
| < 12% | Sparse genuine curve corner (7.5 fisheye: 0.4% near MTF=1.0) | **KEPT** |
| 12-30% | Anti-aliased halo (tilt-50 GFX template: 15.5% at `y_top+3`) | **STRIPPED** |
| ≥ 30% | Dense real curves near axis (Viltrox 10S contrast: 36-65%) | **KEPT** (then `≥90%` chrome strip applies if axis line) |

## Verdict impact

- **tilt-50 max precision: 0.746 → 0.917** (above 0.80 threshold)
- **tilt-50 verdict: LOW → HIGH** ✓
- Zero verdict changes on the other 16 TTartisan Tier 2 lenses
- Tier 1 anchors (50/1.2, 7.5) unchanged

## Calibration

Aggregate: **670/715 (93.7%)** — identical to pre-fix baseline. Zero regression.

## Test plan

- [x] 366 pytest pass (was 365; +1 new test)
- [x] 1 new test: `test_strip_chrome_kills_dense_halo_just_inside_borders` verifies the new band behavior
- [x] `test_strip_chrome_keeps_curve_ink_just_inside_borders` updated: 20% coverage ink (which doesn't exist on any real chart) → 5% sparse ink (matches 7.5 fisheye corner reality)
- [x] `py -m mtfdigitizer.calibrate` clean
- [x] `py -m mtfdigitizer.extract` on all 17 TTartisan lenses: 1 LOW→HIGH (tilt-50), 16 unchanged

## Refreshed artifacts

- tilt-50 digitization-log.md + max SVG (now reflects HIGH/HIGH verdict and the smooth freq10M descent)

## Root-cause investigation (S149)

Three hypotheses from #1165 evaluated:

1. **Plot box detection on GFX template** — DISPROVED. All four GFX charts (tilt-50, 90mm-gfx, 100mm-macro-2x-gfx, 11mm-fisheye-gfx) have identical plot box coordinates.

2. **Precision metric scaling on extreme crashes** — NOT NEEDED. The precision recovered from 0.746 → 0.917 just by fixing the freq10M spikes; the metric is fine.

3. **Mid-curve trace fidelity** — CONFIRMED ROOT CAUSE. The dispatch had wildly bouncy freq10M values from the axis halo getting picked as candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)