### PR TITLE
test(mtf): skip diagnostic-only dirs in optical-specs walker (#1183)

### DIFF
--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -262,9 +262,18 @@ const opticalSpecsDir = resolve(process.cwd(), "docs/optical-specs");
 // Directories with a leading underscore are staging areas for
 // pre-collected materials (e.g. `_pending-mitakon-cine/`) and are
 // intentionally not lens slugs — exclude them from slug-shape checks.
+//
+// Directories whose only content is `diagnostic/` (ADR-050: per-stage
+// digitizer bundle, gitignored) are local-only artifacts from a
+// `mtfdigitizer diagnose` run on a slug that does not exist as a
+// lens. They appear on disk but never in git; excluding them keeps
+// `npm test` deterministic across machines (#1183).
 const lensSpecDirs: string[] = readdirSync(opticalSpecsDir).filter((entry) => {
   if (entry.startsWith("_")) return false;
-  return statSync(join(opticalSpecsDir, entry)).isDirectory();
+  const full = join(opticalSpecsDir, entry);
+  if (!statSync(full).isDirectory()) return false;
+  const trackedEntries = readdirSync(full).filter((e) => e !== "diagnostic");
+  return trackedEntries.length > 0;
 });
 
 describe("docs/optical-specs ↔ mtf-readings coverage", () => {


### PR DESCRIPTION
## Summary

- Fixes #1183 — `mtf-readings.test.ts` orphan slug check failed on local-only `<slug>/diagnostic/` directories produced by `mtfdigitizer diagnose` on slugs without a matching lens.
- Filter the `lensSpecDirs` walker to require at least one non-`diagnostic` entry per directory. Tracked content (analysis.md, specs-log.md, mtf-chart.png, etc.) always survives; purely-ignored diagnostic dirs are excluded.
- Test surface unchanged for committed content — only local untracked dirs are filtered. The `KNOWN_PENDING_LENS_ENTRY` and `KNOWN_PENDING_EMIT` allowlists remain intact for surveyed-but-unmodeled lenses.

## Test plan

- [x] Synthetic repro: create `docs/optical-specs/<orphan-slug>/diagnostic/<file>` for two fake slugs; pre-fix walker fails with the #1183 assertion, post-fix walker passes 18/18.
- [x] `npm run validate` — 222/222 tests pass, lint/format/build clean.
- [x] Diff is +10/-1 in a single file; confined to the walker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)