### PR TITLE
docs(journal): add Session 154 entry — Dependabot batch + #1184 + #1185

### DIFF
--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -7964,3 +7964,75 @@ Theme: after wrapping the #1178 ship, user asked to take #1177 (af-75 freq30M di
 - **Why missed**: gate verdict HIGH (precision 0.927, IoU 0.608, 0 prior violations) — the dip is a single-sample 0.13 MTF deviation, too small to drag down precision/IoU or trigger plausibility priors. ADR-041 maintainer overlay glance is supposed to catch this; on the original #1178 ship the user caught it in the glance and filed #1177.
 - **Fix**: PR #1180 — distinguish edge singletons (mirror coincidently to both tracks) from interior singletons (drop). Densification then bridges from neighbors with correct band identity.
 - **Prevention**: the existing maintainer overlay glance step caught it on #1178 ship. No process change needed; the pattern reinforced is "single-sample dip = file P3 with probe data, don't block ship on bounded-impact known-bug."
+
+---
+
+### Session 154 — Dependabot batch + #1183 test fix + ttartisan-50mm-f1-2 refresh
+
+Date: 2026-06-16 · Tool: Claude Code (Opus 4.7, 1M context)
+
+Theme: clear the 5 stale Dependabot PRs from S150–S153, then opportunistically fix and refresh whatever else surfaced. Ended up shipping 3 unplanned items: a test-hardening fix (#1184), a follow-up data refresh (#1185), and 2 filed bugs (#1183, #1186).
+
+#### PRs
+
+- **#1149 MERGED** — `chore(deps-dev): bump typescript-eslint from 8.60.1 to 8.61.0` (minor).
+- **#1150 MERGED** — `chore(deps-dev): bump @types/node from 25.9.2 to 25.9.3` (patch).
+- **#1151 MERGED** — `chore(deps): bump astro from 6.4.4 to 6.4.6` (patch).
+- **#1152 MERGED** — `chore(deps-dev): bump eslint from 10.4.1 to 10.5.0` (minor).
+- **#1153 MERGED** (`24a469d`, 14:16 UTC) — `chore(deps-dev): bump eslint-plugin-unicorn from 64.0.0 to 65.0.1` (major). Verified locally first — none of v65's 5 breaking changes affect this config (no `better-regex`, no `expiring-todo-comments`, no `prefer-dom-node-dataset`; `prefer-export-from` uses defaults). `npm run lint` clean against v65; `npm run validate` 222/222 pass.
+- **#1184 MERGED** (`2d5ed3f`, 15:30 UTC) — `test(mtf): skip diagnostic-only dirs in optical-specs walker (#1183)`. Closes #1183.
+- **#1185 MERGED** (`135ef42`, 15:48 UTC) — `data(mtf): refresh ttartisan-50mm-f1-2 log after #1180`.
+
+#### Issues opened / closed
+
+- **#1183 opened, then CLOSED via #1184** — `mtf-readings test fails on local-only diagnostic dirs (orphan slug check)`. P2 bug. Discovered while validating #1153 locally: `npm test` surfaced a pre-existing failure on `main` caused by `docs/optical-specs/tokina-atx-m-11-18mm-f2-8-x-at-{11,18}mm/diagnostic/` directories from a prior `mtfdigitizer diagnose` run on slugs that don't exist as lenses.
+- **#1186 opened** — `Windows CRLF papercut: digitizer regen dirties working tree without real content drift`. P3 Backlog bug. Root cause: Python's `path.write_text` on Windows writes CRLF by default; commit-time autocrlf normalizes to LF (committed content is correct), but `git status` after every regen shows phantom-modified files. DX papercut for Windows-only maintainers; no data integrity issue.
+
+#### Key changes
+
+- **`src/data/mtf-readings.test.ts`** — `lensSpecDirs` walker now requires at least one non-`diagnostic` entry per directory before treating it as a candidate lens slug. Tracked content (analysis.md, specs-log.md, mtf-chart.png, etc.) always survives; purely-ignored diagnostic dirs (ADR-050) are excluded. Negative repro proved: synthetic orphan dirs trip the original failure with the pre-fix walker, post-fix walker passes 18/18 despite their presence.
+- **`docs/optical-specs/ttartisan-50mm-f1-2/digitization-log.md`** — freq30 corner crossing now resolves correctly post-#1180. S/M labels were inverted in the pre-#1180 log; max |EX-EYE| dropped from 0.193 to 0.011 on both freq30 fields; coverage on freq30S 10/11 → 11/11. Center/edge summary now matches expected per-aperture corner direction.
+- **`package.json` / `package-lock.json`** — 5 Dependabot bumps applied: astro 6.4.6, eslint 10.5.0, @types/node 25.9.3, typescript-eslint 8.61.0, eslint-plugin-unicorn 65.0.1.
+
+#### Verification
+
+- `npm run validate` after each Dependabot PR: 222/222 tests, lint clean, build OK, 462 pages, all internal links have trailing slashes.
+- `py -m mtfdigitizer.log --check --all` post-#1185: `OK: 14 digitization log(s) up to date` (down from 1 stale).
+- `py -m pytest` from `tools/`: 651 pass (unchanged from #1178).
+- All 7 merged PRs CI green; deploys queued in order.
+
+#### Key decisions (this session)
+
+- **Hold #1153 until pre-existing test failure was fixed.** When `npm run validate` against v65 surfaced the orphan test failure, verified it reproduced on `main` too — the bump was clean. Rather than merging #1153 with main red, fixed #1183 first via #1184, then merged #1153. Cost: ~30 min. Benefit: main stayed green throughout.
+- **Filter walker at source rather than special-casing two slugs.** The orphan check could have been patched by adding `tokina-atx-m-11-18mm-f2-8-x-at-{11,18}mm` to `KNOWN_PENDING_LENS_ENTRY` — the existing allowlist mechanism. Chose instead to make the walker robust against any local-only diagnostic dir, anchored in the existing ADR-050 convention. The allowlist is for "real but not-yet-modeled lenses"; this class of orphan should never have entered the test surface in the first place.
+- **Did not bundle Windows CRLF fix with #1185.** The CRLF issue is a real bug that touches ~7 emitters across `tools/mtfdigitizer/` and is wider than the data refresh. Bundling would have ballooned the PR scope, mixed concerns (data + tooling), and risked subtle test regressions. Filed as P3 #1186 with the diagnosis embedded, kept #1185 minimal.
+- **Filed test-design bug rather than digitizer bug.** Two valid framings for #1183: "test is too liberal in what it walks" or "digitizer should refuse to write to non-existent-lens slugs." Picked the test framing because (a) the test's intent is documented in code (line 303–307 comment in mtf-readings.test.ts), (b) the digitizer writing to a per-FL variant of a zoom is a legitimate workflow (sub-charts for multi-aperture lenses use the same pattern), and (c) the test is the only thing that broke — the digitizer is doing its job.
+
+#### Process patterns observed this session
+
+- **`--check` count from prior session's memory was 33× off.** S153's `session_next_theme` memory said "33 stale logs `--check` sweep" — that count came from #1178's PR body and was accurate at that time. The actual count today was 1, because subsequent PRs (#1178, #1180, others) refreshed almost all of them as side effects of pipeline fixes. **Pattern:** memory pointers to "N items remaining" decay fast; verify at the start of a sweep session before estimating effort.
+- **Verifying a Dependabot major bump locally takes ~10 min, not "review the changelog."** For #1153 (eslint-plugin-unicorn v65), reading the changelog identified 5 breaking changes; running `npm run lint` against v65 in 10 min proved none affected this config. The lint run is the authoritative answer; the changelog is the question.
+- **A failing test on main can hide behind a Dependabot bump.** The #1183 orphan failure would have been discovered eventually by anyone running `npm test` locally, but it survived multiple `npm run validate` runs because CI is on Linux (no local diagnostic dirs) and Windows-only maintainers don't run `npm test` on every push. Discovered only because I validated v65 locally rather than trusting the green CI. **Pattern:** local validation finds Linux/Windows-specific bugs CI cannot.
+
+#### Follow-ups for next session
+
+- **#1186 Windows CRLF DX papercut** — P3 Backlog. Pick up in a Windows-DX cleanup session; not gating any other work.
+- **Per-hue anchor audit (deferred from S149/S150/S153)** — still untouched; 9 declared MTF profiles to audit for crossing geometry similar to TTartisan stopped-30-orange.
+- **#1085 orphan optical-specs dirs triage** — P3 agent-doable janitorial; #1183/#1184 hardened the test but did not address the underlying `KNOWN_PENDING_LENS_ENTRY` Thingyfy / Zeiss Touit entries.
+- **#1131 detection-method survey (P2 spike)** — C-trigger; do not pick before trigger fires.
+- **#1181 af-35 max-pass grey-30 mask hygiene** — P4 Backlog; only worth tackling as part of a broader TTartisan max-pass investment.
+
+#### State of the project
+
+- v0.8.0 = MTF digitization.
+- Epic #790 (digitize all brands): 4/24 done (unchanged).
+- `REFERENCE_CHARTS` = 103 entries (unchanged).
+- 4 Tier 1 anchors (unchanged).
+- **381 mtfdigitizer pytest pass** (unchanged).
+- **651 total pytest pass** from `tools/` (unchanged).
+- **222 vitest pass** (unchanged).
+- 55 ADRs (unchanged).
+- 9 declared MTF profiles (unchanged).
+- v0.8.0 open: #1131 + #1134 (UI deferred) + #1135 + #1159. #1174 + #1175 + #1181 + **#1186** in Backlog. **0 open feature PRs.** **0 stale Dependabot PRs** (cleared this session).
+- `mtf-readings.ts` unchanged.
+- Stale digitization logs: **0** (was 1 at S153 close per `--check --all`).


### PR DESCRIPTION
## Summary

S154 dev journal entry. Records the 7 merged PRs (Dependabot #1149–#1153, #1184 test fix, #1185 data refresh) and 2 filed issues (#1183 closed, #1186 P3 Windows CRLF DX papercut).

Captures three patterns worth carrying forward:

1. **Walker filter at source vs. allowlist.** #1183 could have been patched by extending `KNOWN_PENDING_LENS_ENTRY` with the two orphan slugs. Chose instead to make the walker robust against any local-only diagnostic dir (anchored in ADR-050) — the allowlist is for "real but unmodeled" lenses; diagnostic dirs should never have entered the test surface.
2. **Major-bump verification by local gate.** For #1153 (eslint-plugin-unicorn v65 major), ~10 min of changelog reading and ~10 min of local lint produced the same conclusion — but only the lint run is authoritative.
3. **Memory pointer count decay.** The S153 `33 stale logs` memory was actually 1 stale log; the 32 others had been refreshed as side effects of subsequent pipeline-fix PRs.

## Test plan

- [x] Append-only edit to `docs/dev-journal.md` following S153-continued's structure exactly
- [x] No source code or data changes
- [ ] CI green
- [ ] Deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)