### PR TITLE
docs(mtf): record S155 per-hue dp_y_anchor audit findings

### DIFF
--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -97,6 +97,9 @@ SEVENARTISANS_2COLOR_SAMECOLOR_DASHED: MtfProfile = MtfProfile(
     # leave a single centroid behind. The anchor lets the DP coast past
     # those single-centroid columns instead of swapping curve identity
     # at the corner crossing. See ADR-049 §"Known limitation".
+    # Per-hue audit (S155, 2026-06-17): flipping blue or green to False
+    # regresses aggregate in-band count and p95 |d|. Scalar True confirmed
+    # optimal for both hues.
     ridge_dp_y_anchor=True,
     notes="7Artisans/Chinese convention: blue=10, green=30; T1/T2 (blue) = M pair, S1/S2 (green) = S pair; dashed=S within hue",
 )
@@ -257,6 +260,16 @@ FUJIFILM_PERMFREQ_2COLOR_SOLID_DASHED: MtfProfile = MtfProfile(
 #   stopped-30S-orange: 1417 px (h≈17, S≥80, V∈[80,220])
 TTARTISAN_4COLOR_DUAL_APERTURE: MtfProfile = MtfProfile(
     name="ttartisan-4color-dual-aperture",
+    # Per-hue `dp_y_anchor` audit (S155, 2026-06-17): four candidate hues
+    # toggled against the 14-anchor reference set. Findings:
+    #   max-10-black  False->True: median 0.0079->0.0083, p95 unchanged.
+    #   max-30-grey   False->True: ttartisan-50 freq30S p95 0.024->0.146
+    #                              (anchor punishes the legitimate corner
+    #                              dive — ADR-049 known limitation confirmed).
+    #   stopped-10-red False->True: median 0.0079->0.0084, p95 unchanged.
+    #   stopped-30-orange True->False: tilt-50 freq30S p95 0.011->0.188,
+    #                              freq30M 0.011->0.193 (confirms #1168 fix).
+    # No flips warranted; current settings are locally optimal.
     hues=(
         # Black — 10 lp/mm at max aperture. Low V, low S; the S<60 cap
         # admits anti-aliased curve edges, V<80 rejects mid-grey gridlines.


### PR DESCRIPTION
## Summary

Per-hue audit of `FREQUENCY_PER_HUE_RIDGE` profiles (7Artisans, TTartisan)
against the 14-anchor reference set: toggled `dp_y_anchor` on every
candidate hue, measured aggregate median / p95 |d| and per-anchor
field-level deltas.

**Verdict:** all six candidate hues are at their locally-optimal setting.
No code changes. Findings recorded inline above the profile declarations.

## Audit table

| Hue | Toggle | median |d| | p95 |d| | in-band 0.05 |
|---|---|---|---|---|
| 7artisans `blue` | True→False | 0.0079→0.0079 | 0.0559→**0.0589** | 675→673 |
| 7artisans `green` | True→False | 0.0079→0.0080 | 0.0559→**0.0575** | 675→674 |
| ttartisan `max-10-black` | False→True | 0.0079→**0.0083** | 0.0559→0.0559 | 675→675 |
| ttartisan `max-30-grey` | False→True | 0.0079→0.0080 | 0.0559→**0.0589** | 675→**672** |
| ttartisan `stopped-10-red` | False→True | 0.0079→**0.0084** | 0.0559→0.0559 | 675→675 |
| ttartisan `stopped-30-orange` | True→False | 0.0079→**0.0090** | 0.0559→**0.0589** | 675→**672** |

Two of the regressions are large enough to call out explicitly:

- `max-30-grey False→True`: ttartisan-50 freq30S p95 **0.024→0.146** —
  anchor punishes the legitimate corner dive (confirms ADR-049 known
  limitation).
- `stopped-30-orange True→False`: tilt-50 freq30S p95 **0.011→0.188**,
  freq30M **0.011→0.193** — confirms the #1168 per-hue fix is doing
  real work.

Closes the audit deferred S149/S150/S153/S154.

## Test plan

- [x] `npm run validate` green (lint, format, check, vitest 222 pass, build)
- [x] `py -m pytest mtfdigitizer/tests` — 381 pass (unchanged)
- [x] Diff is comment-only (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)