### PR TITLE
test(mtf): reconcile dir invariant with brandkit slug_prefix (#1085)

### DIFF
--- a/docs/decisions/056-brand-slug-prefix-divergence.md
+++ b/docs/decisions/056-brand-slug-prefix-divergence.md
@@ -1,0 +1,104 @@
+# ADR-056: Brand slug prefix may diverge from DB brand name
+
+**Status:** Accepted
+**Date:** 2026-06-17
+
+## Context
+
+Two slugging systems coexist for `docs/optical-specs/<slug>/` directory
+naming:
+
+1. **Python `brandkit`** (`tools/brandkit/extractor.py`,
+   `tools/brandkit/slug.py`) builds dir names as
+   `f"{slug_prefix}-{model_to_slug(model)}"`. Each `BrandExtractor`
+   subclass declares its own `slug_prefix`. The Zeiss extractor
+   (`tools/zeiss/extractor.py`) sets `slug_prefix="zeiss"` even though
+   `name="Carl Zeiss"` — historically Zeiss-branded products use the
+   shortened modern brand on disk and in filenames
+   (`zeiss-touit-12mm-f2-8-datasheet.pdf`).
+
+2. **TS directory-name invariant** (`src/data/mtf-readings.test.ts`,
+   added in #1069) computes the expected dir name as
+   `toSlug(lens.brand + " " + lens.model)` using `lens.brand` as it
+   appears in `lenses.ts`. For Zeiss lenses, `brand: "Carl Zeiss"` →
+   `carl-zeiss-touit-*`, which does not match the on-disk
+   `zeiss-touit-*` dirs.
+
+#1085 surfaced this as four "orphan" optical-specs directories on the
+allowlist:
+
+```
+zeiss-touit-12mm-f2-8
+zeiss-touit-32mm-f1-8
+zeiss-touit-50mm-f2-8-macro
+thingyfy-pinhole-pro-x   (separate cause: lens-accessory, not a lens)
+```
+
+The Zeiss directories are not orphan — they have matching
+`Carl Zeiss Touit *` entries in `lenses.ts`. They look orphan only
+because the two slugging systems disagree on whether "Carl" is part of
+the slug.
+
+```
+  lenses.ts entry         brandkit on-disk           TS invariant expects
+  ---------------------   ------------------------   -----------------------
+  brand: "Carl Zeiss"     zeiss-touit-12mm-f2-8/     carl-zeiss-touit-12mm-f2-8
+  model: "Touit 12..."    zeiss-touit-32mm-f1-8/     carl-zeiss-touit-32mm-f1-8
+                          zeiss-touit-50mm-f2-8-     carl-zeiss-touit-50mm-f2-8-
+                            macro/                     macro
+```
+
+## Decision
+
+Treat brandkit's `slug_prefix` as authoritative for directory names
+and DB brand as authoritative for display. The TS invariant honors
+brandkit divergences via a small explicit override map:
+
+```typescript
+// src/data/mtf-readings.test.ts
+const BRAND_SLUG_OVERRIDE: Record<string, string> = {
+  "Carl Zeiss": "Zeiss",
+};
+
+function dirBrand(brand: string): string {
+  return BRAND_SLUG_OVERRIDE[brand] ?? brand;
+}
+```
+
+Today only one divergence exists (Carl Zeiss → Zeiss). Future
+divergences MUST be added to this map and to the corresponding
+brandkit extractor's `slug_prefix`.
+
+The invariant also scans `accessories.ts` so accessory-only specs-log
+dirs (Thingyfy Pinhole Pro X) are not flagged as orphan.
+
+## Alternatives considered
+
+- **Rename `docs/optical-specs/zeiss-touit-*` → `carl-zeiss-touit-*`.**
+  Rejected: would break `ZeissExtractor.config.slug_prefix="zeiss"` —
+  the next extractor run would write `zeiss-*-datasheet.pdf` back into
+  the renamed dirs and create new orphans. Also touches
+  `tools/mtfdigitizer/referenceset/charts.py` chart_path, mtfdigitizer
+  README/REFERENCE_SET docs, and the zeiss extractor test fixture.
+- **Change DB brand `"Carl Zeiss"` → `"Zeiss"` in `lenses.ts`.**
+  Rejected: 13+ files reference "Carl Zeiss" (journal, ADR-042,
+  bookmarks, lenstip-index.json, zeiss tooling, brand-enum type).
+  Wide blast radius; the modern brand-name choice is orthogonal to
+  the slug mismatch.
+- **Keep the `KNOWN_PENDING_LENS_ENTRY` allowlist permanently.**
+  Rejected: makes the invariant permanently leaky and pushes the
+  systematic divergence into a list of one-off exceptions.
+
+## Consequences
+
+- The TS test and Python brandkit are weakly coupled through
+  `BRAND_SLUG_OVERRIDE`. A new brand with `slug_prefix != name.lower()`
+  MUST be added to both sides in the same PR.
+- `KNOWN_PENDING_LENS_ENTRY` is removed; the invariant now passes
+  without an allowlist. Future genuine orphans (dir for a lens that
+  is not in `lenses.ts`/`accessories.ts`) fail the test
+  unconditionally — which is the intended behavior of #1069.
+- The accessories scan means accessory-only specs-log dirs are
+  first-class. Per `specs-log.md` convention (CLAUDE.md §2.6
+  Specs-log workflow), accessories that have a specs-log dir
+  continue to satisfy the invariant without additional handling.

--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -2,8 +2,21 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import { lenses } from "./lenses";
+import accessories from "./accessories";
 import { mtfReadings } from "./mtf-readings";
 import { toSlug } from "../utils/slug";
+
+// Mirror of brandkit's `slug_prefix` overrides (see ADR-056). Most brands
+// slug as `toSlug(brand)`, but a few diverge: brandkit's Python tooling
+// writes `docs/optical-specs/<slug>` paths using these prefixes, and the
+// TS invariant must agree. Only divergences belong here.
+const BRAND_SLUG_OVERRIDE: Record<string, string> = {
+  "Carl Zeiss": "Zeiss",
+};
+
+function dirBrand(brand: string): string {
+  return BRAND_SLUG_OVERRIDE[brand] ?? brand;
+}
 
 describe("mtf-readings data integrity", () => {
   const entries = Object.entries(mtfReadings);
@@ -235,7 +248,9 @@ describe("mtf-readings data integrity", () => {
 // #1061 anchor lenses with disk data but no readings entry, #1062 60
 // auto-derived 404 source URLs) would have been caught here.
 describe("mtf-readings ↔ lenses.ts coverage", () => {
-  const lensSlugs = new Set(lenses.map((l) => toSlug(`${l.brand} ${l.model}`)));
+  const lensSlugs = new Set(
+    lenses.map((l) => toSlug(`${dirBrand(l.brand)} ${l.model}`)),
+  );
   const readingSlugs = Object.keys(mtfReadings);
 
   it("every mtfReadings key matches a lens via toSlug(brand model)", () => {
@@ -310,28 +325,21 @@ describe("docs/optical-specs ↔ mtf-readings coverage", () => {
 });
 
 // Directory-name invariant (#1069). Every `docs/optical-specs/<dir>`
-// must match `toSlug(lens.brand + " " + lens.model)` for some lens in
-// `lenses.ts`. Catches the S123 (#1063, #1066) class of bug where a
-// scaffolder wrote `-t-s-` directories because the brand tooling did
-// not match `toSlug`'s `/` → `` → `-` collapse for `T/S` → `ts`.
+// must match `toSlug(brand + " " + model)` for some lens in `lenses.ts`
+// or accessory in `accessories.ts` (e.g. Thingyfy Pinhole Pro X is an
+// accessory but has a specs-log dir). Catches the S123 (#1063, #1066)
+// class of bug where a scaffolder wrote `-t-s-` directories because the
+// brand tooling did not match `toSlug`'s `/` → `` → `-` collapse for
+// `T/S` → `ts`. Brand-prefix divergences (Carl Zeiss → zeiss) are
+// handled via BRAND_SLUG_OVERRIDE — see ADR-056.
 describe("docs/optical-specs directory-name invariant", () => {
-  const lensSlugs = new Set(lenses.map((l) => toSlug(`${l.brand} ${l.model}`)));
-
-  // Directories whose lens entry has not been added to `lenses.ts`
-  // yet. Pre-existing as of #1069 landing; remove an entry when the
-  // matching lens is added (or remove the directory if the lens was
-  // surveyed and rejected). Tracked via #1085.
-  const KNOWN_PENDING_LENS_ENTRY = new Set<string>([
-    "thingyfy-pinhole-pro-x",
-    "zeiss-touit-12mm-f2-8",
-    "zeiss-touit-32mm-f1-8",
-    "zeiss-touit-50mm-f2-8-macro",
+  const lensSlugs = new Set([
+    ...lenses.map((l) => toSlug(`${dirBrand(l.brand)} ${l.model}`)),
+    ...accessories.map((a) => toSlug(`${dirBrand(a.brand)} ${a.model}`)),
   ]);
 
   it("every optical-specs directory matches a lens via toSlug", () => {
-    const orphans = lensSpecDirs
-      .filter((dir) => !lensSlugs.has(dir))
-      .filter((dir) => !KNOWN_PENDING_LENS_ENTRY.has(dir));
+    const orphans = lensSpecDirs.filter((dir) => !lensSlugs.has(dir));
     expect(
       orphans,
       `optical-specs directories with no matching lens (slug drift?): ${orphans.join(", ")}`,


### PR DESCRIPTION
## Summary

Closes #1085 — four `docs/optical-specs/<dir>` allowlist entries were not orphan, just slug-mismatched between two coexisting slug systems.

- **Python brandkit** writes dirs as `f\"{slug_prefix}-{model_to_slug(model)}\"`. `ZeissExtractor` uses `slug_prefix=\"zeiss\"` (intentional — modern brand name).
- **TS dir invariant** (#1069) computed `toSlug(brand + \" \" + model)` from DB `brand: \"Carl Zeiss\"` → expected `carl-zeiss-touit-*`.

The invariant now honors brandkit divergences via a small explicit override map and also scans `accessories.ts` (so Thingyfy Pinhole Pro X — a lens-accessory — satisfies the invariant). `KNOWN_PENDING_LENS_ENTRY` is empty; all four entries resolve.

## Files

- `src/data/mtf-readings.test.ts` — `BRAND_SLUG_OVERRIDE` map (only \"Carl Zeiss\" → \"Zeiss\" today), `dirBrand()` helper applied to both invariant computations, accessories scanned, allowlist removed.
- `docs/decisions/056-brand-slug-prefix-divergence.md` — context, decision, alternatives (dir rename, DB brand rename, keep allowlist), consequences.

## Rejected alternatives

| Approach | Why not |
|---|---|
| Rename `zeiss-touit-*` dirs to `carl-zeiss-touit-*` | Would break `ZeissExtractor.slug_prefix=\"zeiss\"` — next run regenerates `zeiss-*` files; also touches mtfdigitizer charts/REFERENCE_SET/tests. |
| Change DB brand `\"Carl Zeiss\"` → `\"Zeiss\"` | 13+ files reference \"Carl Zeiss\" (journal, ADR-042, bookmarks, lenstip-index.json, brand-enum). Wide blast radius for an orthogonal naming choice. |
| Keep allowlist permanently | Makes the invariant leaky; pushes a systematic divergence into one-off exceptions. |

## Test plan

- [x] `npm run validate` — lint, format, check, 222/222 tests, build, link check all green
- [x] Directory-name invariant passes with empty allowlist
- [x] No path references on disk changed; brandkit/mtfdigitizer untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)