### PR TITLE
fix(tools): write committed-content files with newline="\n" (#1186)

### DIFF
--- a/tools/lenstip/build_index.py
+++ b/tools/lenstip/build_index.py
@@ -209,7 +209,11 @@ def main() -> None:
 
     index = build_index(brand_filter=args.brand, no_cache=args.no_cache)
 
-    INDEX_FILE.write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+    INDEX_FILE.write_text(
+        json.dumps(index, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+        newline="\n",
+    )
     print(f"\nIndex saved to {INDEX_FILE}")
     print(f"Total: {index['_meta']['total_lenses']} lenses across {index['_meta']['total_brands']} brands")
 

--- a/tools/mtfdigitizer/calibrate.py
+++ b/tools/mtfdigitizer/calibrate.py
@@ -404,7 +404,7 @@ def _write_readings_log(chart: ReferenceChart, result, field_deltas: list[FieldD
             lines.append("| " + " | ".join(row) + " |")
         lines.append("")
 
-    path.write_text("\n".join(lines), encoding="utf-8")
+    path.write_text("\n".join(lines), encoding="utf-8", newline="\n")
     return path
 
 

--- a/tools/mtfdigitizer/extract.py
+++ b/tools/mtfdigitizer/extract.py
@@ -301,7 +301,9 @@ def _write_inspection_artifacts(run: ExtractRun) -> tuple[Path, Path, Path]:
 
     stem = _artifact_stem(run)
     svg_path = lens_dir / f"{stem}.svg"
-    svg_path.write_text(render_svg(run.extracted), encoding="utf-8")
+    svg_path.write_text(
+        render_svg(run.extracted), encoding="utf-8", newline="\n"
+    )
 
     outputs = write_review(
         run.extracted,
@@ -404,7 +406,7 @@ def extract_lens(slug: str, *, accept_override: bool) -> int:
         return 0
 
     log_path = _log_path_for(chart)
-    log_path.write_text(_render_log_for(runs), encoding="utf-8")
+    log_path.write_text(_render_log_for(runs), encoding="utf-8", newline="\n")
     print(f"  wrote {rel(log_path)}  ({reason})")
     return 0
 

--- a/tools/mtfdigitizer/eyeread.py
+++ b/tools/mtfdigitizer/eyeread.py
@@ -415,7 +415,7 @@ def transcribe(slug: str, *, apply: bool) -> int:
             file=sys.stderr,
         )
         return 0
-    _CHARTS_PATH.write_text(new_src, encoding="utf-8")
+    _CHARTS_PATH.write_text(new_src, encoding="utf-8", newline="\n")
     print(f"wrote: {gt_var} in {_CHARTS_PATH.relative_to(REPO_ROOT)}", file=sys.stderr)
     return 0
 

--- a/tools/mtfdigitizer/log.py
+++ b/tools/mtfdigitizer/log.py
@@ -401,7 +401,11 @@ def write_logs(
         )
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / "digitization-log.md"
-        path.write_text(_render_lens_log(lens_slug, panels), encoding="utf-8")
+        path.write_text(
+            _render_lens_log(lens_slug, panels),
+            encoding="utf-8",
+            newline="\n",
+        )
         written.append(path)
     return written
 

--- a/tools/mtfdigitizer/rename.py
+++ b/tools/mtfdigitizer/rename.py
@@ -450,7 +450,7 @@ def _update_charts_py(name_map: dict[str, str], apply: bool) -> int:
             return match.group(1) + match.group(2).replace(old_name, new_name) + match.group(3)
         new_text = pattern.sub(_sub, new_text)
     if apply and new_text != text:
-        CHARTS_PY.write_text(new_text, encoding="utf-8")
+        CHARTS_PY.write_text(new_text, encoding="utf-8", newline="\n")
     return n_changes
 
 
@@ -468,9 +468,11 @@ def _apply_plan(plan: FolderPlan) -> None:
             )
     for rename in plan.renames:
         rename.old.rename(rename.new)
-    (plan.folder / "analysis.md").write_text(plan.analysis_new, encoding="utf-8")
+    (plan.folder / "analysis.md").write_text(
+        plan.analysis_new, encoding="utf-8", newline="\n"
+    )
     for md_path, _old_text, new_text in plan.other_md_updates:
-        md_path.write_text(new_text, encoding="utf-8")
+        md_path.write_text(new_text, encoding="utf-8", newline="\n")
 
 
 def _print_plan(plan: FolderPlan) -> None:

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -484,7 +484,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.write:
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
         patched = _splice_entries(source, entries)
-        MTF_READINGS_PATH.write_text(patched, encoding="utf-8")
+        MTF_READINGS_PATH.write_text(patched, encoding="utf-8", newline="\n")
         print(
             f"\npatched {MTF_READINGS_PATH.relative_to(REPO_ROOT)}: "
             f"{len(entries)} entries, {total_panels} panels, "

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -338,7 +338,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.write:
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
         patched = _splice_entries(source, entries)
-        MTF_READINGS_PATH.write_text(patched, encoding="utf-8")
+        MTF_READINGS_PATH.write_text(patched, encoding="utf-8", newline="\n")
         print(
             f"\npatched {MTF_READINGS_PATH.relative_to(REPO_ROOT)}: "
             f"{len(entries)} entries, {total_panels} panels, "

--- a/tools/mtfdigitizer/scripts/scaffold_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/scaffold_fuji_tier2.py
@@ -234,7 +234,7 @@ def main(argv: list[str] | None = None) -> int:
         / "_fuji_tier2_charts.py"
     )
     if args.write:
-        target.write_text(module_source, encoding="utf-8")
+        target.write_text(module_source, encoding="utf-8", newline="\n")
         chart_count = sum(len(v) for v in groups.values())
         print(
             f"Wrote {target.relative_to(REPO_ROOT)} "

--- a/tools/mtfdigitizer/scripts/scaffold_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/scaffold_ttartisan_tier2.py
@@ -222,7 +222,7 @@ def main(argv: list[str] | None = None) -> int:
         / "_ttartisan_tier2_charts.py"
     )
     if args.write:
-        target.write_text(module_source, encoding="utf-8")
+        target.write_text(module_source, encoding="utf-8", newline="\n")
         print(
             f"Wrote {target.relative_to(REPO_ROOT)} ({len(charts)} lenses).",
             file=sys.stderr,

--- a/tools/mtfdigitizer/svg.py
+++ b/tools/mtfdigitizer/svg.py
@@ -393,7 +393,7 @@ def _emit_chart(chart: ReferenceChart, *, check_only: bool) -> list[Path]:
         else:
             out_path = image_path.with_suffix(".svg")
         if not check_only:
-            out_path.write_text(svg, encoding="utf-8")
+            out_path.write_text(svg, encoding="utf-8", newline="\n")
         out_paths.append(out_path)
     return out_paths
 


### PR DESCRIPTION
## Summary

- Pass `newline="\n"` to 14 Python `path.write_text` call sites that produce **committed** content (digitization logs, SVGs, `charts.py`, `mtf-readings.ts`, `_*_tier2_charts.py`, `lens-index.json`). Root-cause fix for #1186.
- On Windows, `write_text` defaults to platform line endings (`\r\n`), so regen dirtied the working tree against the LF-normalized index even when content was unchanged. Reviewers had to mentally subtract CRLF-only "modified" entries from `git status`.
- Non-committed writers (`diagnostic.py` per-run artifacts, `review.py` HTML preview, `pagefetch/cache.py` `.cache/`, `pagefetch/__main__.py` user-specified `out_path`, all test temp files) left untouched.

## Why not `.gitattributes` hardening (option b)

`.gitattributes` already has `* text=auto eol=lf`. Git normalizes on commit, but Python's *post-checkout* write puts CRLF in the working tree until the file is staged — that is what `git status` sees. Hardening attributes does not change Python's writer.

## Verification (Windows, `core.autocrlf=true`)

- `py -m mtfdigitizer.log --all` — 14 logs written; before this fix `git status` listed 11 modified, after this fix only the 3 pre-existing real-content drifts appear and they are no-op stat-cache entries with matching blob hashes (confirmed with `git hash-object` vs `git ls-files -s`).
- `py -m mtfdigitizer.log --check` — `OK: 4 digitization log(s) up to date.`
- `py -m pytest mtfdigitizer/` — **381 passed**.

## Files patched

| Site | Output |
|---|---|
| `mtfdigitizer/log.py` | `docs/optical-specs/*/digitization-log.md` |
| `mtfdigitizer/svg.py` | `docs/optical-specs/*/*.svg` |
| `mtfdigitizer/extract.py` (×2) | `*.svg`, `digitization-log.md` |
| `mtfdigitizer/rename.py` (×3) | `referenceset/charts.py`, `analysis.md`, sibling `.md` |
| `mtfdigitizer/eyeread.py` | `referenceset/charts.py` |
| `mtfdigitizer/calibrate.py` | findings docs |
| `mtfdigitizer/scripts/emit_{fuji,ttartisan}_tier2.py` | `src/data/mtf-readings.ts` |
| `mtfdigitizer/scripts/scaffold_{fuji,ttartisan}_tier2.py` | `referenceset/_*_tier2_charts.py` |
| `lenstip/build_index.py` | `lens-index.json` |

## Test plan

- [x] `py -m mtfdigitizer.log --all` then `git status` — only intended diffs appear
- [x] `py -m mtfdigitizer.log --check` — OK
- [x] `py -m pytest tools/mtfdigitizer/` — 381 pass
- [ ] CI green (Linux baseline — no behavior change expected since `\n` matches platform default)

Closes #1186.