### PR TITLE
fix(ci): authenticate gitleaks install API call + fail-loud version guard (#1210)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,11 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install gitleaks
-        run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz
-          sudo mv gitleaks /usr/local/bin/
-
-      - name: Run gitleaks
-        run: gitleaks detect --source . --config .gitleaks.toml --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,8 +15,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v3.0.0
+      - name: Install gitleaks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION=$(curl -sSf -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | grep tag_name | cut -d '"' -f 4 | sed 's/v//')
+          if [ -z "${GITLEAKS_VERSION}" ]; then
+            echo "Failed to resolve gitleaks version from releases API" >&2
+            exit 1
+          fi
+          echo "Installing gitleaks v${GITLEAKS_VERSION}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --config .gitleaks.toml --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Summary

The original gitleaks install pattern resolved the version via an unauthenticated GitHub releases API call (\`curl -s ... /releases/latest\`). The 60/hour unauthenticated rate limit is per-IP and shared across every PR running on the same GHA runner pool — so the call regularly returned an empty body, GITLEAKS_VERSION resolved to empty, and the tarball URL rendered as \`v_linux_x64.tar.gz\` → 404.

This PR fixes the install pattern with two real changes:

1. **Authenticate the API call** with \`Authorization: Bearer \${GITHUB_TOKEN}\` — raises the rate limit from 60/hr (unauth, per IP, shared) to 1000/hr (auth, per repo). Decouples from the shared runner-IP pool. This is the actual root cause fix.
2. **\`set -euo pipefail\` + explicit empty-string guard** — if version resolution ever fails again, the step fails loud with a clear message instead of silently producing the 404. Also \`-sSf\` (was \`-s\`) on the API call so curl itself exits non-zero on HTTP errors.

### Why not the official action

First attempt switched to \`gitleaks/gitleaks-action@v3.0.0\`. That action now requires a paid \`GITLEAKS_LICENSE\` secret for organization repos (Imbra-Ltd hit the paywall on first run). Reverted to the curl pattern with the real fixes applied.

Closes #1210.

## Test plan

- [ ] CI green on this PR (gitleaks step passes)
- [ ] CI green on the next PR after merge (#1209 — currently failing on the same infra issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)