### PR TITLE
feat(mtf): per-view aperture override + Samyang F8 anchors (ADR-063, #1238)

### DIFF
--- a/docs/decisions/063-samyang-multi-panel-aperture.md
+++ b/docs/decisions/063-samyang-multi-panel-aperture.md
@@ -1,0 +1,166 @@
+# ADR-063: Samyang multi-panel per-view aperture
+
+**Status:** Accepted
+**Date:** 2026-06-21
+
+## Context
+
+Samyang publishes one chart image per lens containing **two stacked
+panels** — MAX aperture on top, F8 on the bottom — sharing the same
+x-axis (image-height in mm) and the same legend. Each panel is a
+complete `{10S, 10M, 30S, 30M}` rendering at its own f-stop. The two
+panels have identical templates: x range `31..461`, top panel `y
+43..463`, bottom panel `y 575..995` (both 421 px tall), confirmed
+by axis-line probe on the 85mm and 300mm reflex Tier 1 anchors.
+
+ADR-044 already added a `multi-aperture-per-chart` orchestrator path
+for TTartisan, where two apertures sit in **one panel encoded by
+color** (black/grey = max, red/orange = stopped). That mechanism is
+hue-filtered and driven by `MtfProfile.apertures_per_chart`: one
+`extract_chart` pass per declared aperture, with profile hues
+filtered to that aperture's color bucket. It does not fit Samyang:
+both Samyang panels use the same four hue ranges (`10S-red`,
+`10M-pink`, `30S-dark-grey`, `30M-light-grey`), only the plot box
+differs.
+
+Before this ADR, the 85mm and 300mm reflex Tier 1 anchors carried
+only the MAX panel (the issue notes called the F8 panel "deferred"),
+the eye-read `_SAMYANG_85_GT` had a single `"MAX"` key, and the 18
+Tier 2 Samyangs (#1238 follow-up to #792) could only ship MAX-panel
+readings — half the data each chart publishes.
+
+The straight read of the existing `ChartView` zoom mechanism (ADR-033)
+suggests a second view with a second plot_box. But the existing pass
+resolver `aperture_passes_for_view(chart, image_path)` keys on
+`image_path` (which is the SAME PNG for both Samyang panels) and
+on the profile (`apertures_per_chart=None` for Samyang, so it falls
+through to the single-pass default that labels with
+`chart.apertures[0]`). There is no plumbing to tell the orchestrator
+that this particular view should emit at a different aperture label.
+
+## Decision
+
+Add a per-view `aperture` override that:
+
+- lives on `ChartView` (`aperture: str | None = None`) — the panel
+  selector (`plot_box`) and the panel's aperture identity travel
+  together
+- is honored by `aperture_passes_for_view(chart, image_path, view)`
+  — when set, returns a single pass labelled with `view.aperture`,
+  short-circuiting both the Fujifilm per-frequency branch and the
+  ADR-044 hue-filtered fan-out
+- is honored by the calibration runner via a new
+  `_extract_per_view_aperture_chart` path that walks `chart.views`
+  and produces the same `{aperture_label: ExtractedChart}` shape as
+  ADR-044's `_extract_multi_aperture_chart`
+- composes with `chart.additional_views` — the primary view stays
+  `aperture=None` (the chart's first aperture in `chart.apertures`
+  by default), each additional view declares its own override
+
+```
++---------------------+      +-----------------------+
+|  MAX aperture       |      |  primary ChartView    |
+|  (top panel)        | <--- |  plot_box=(43..463)   |
+|  y 43..463          |      |  aperture=None        |
++---------------------+      +-----------------------+
++---------------------+      +-----------------------+
+|  F8                 |      |  additional ChartView |
+|  (bottom panel)     | <--- |  plot_box=(575..995)  |
+|  y 575..995         |      |  aperture="F8"        |
++---------------------+      +-----------------------+
+       shared PNG                shared style family
+```
+
+The orchestrator (`extract.py::_run_view_passes`) already walks every
+view; the only change is threading `view` into the resolver call.
+Legacy callers (`autotriage`, `diagnose`, `log`, `review`, `svg`) keep
+the two-arg form and operate on the primary chart raster — they
+predate multi-view orchestration and only handle Tier 1 calibration
+paths.
+
+The mechanism is orthogonal to ADR-044's hue-filtered fan-out:
+
+| Mechanism               | Plot box | Hue partition | Driver                      |
+| ----------------------- | -------- | ------------- | --------------------------- |
+| ADR-044 hue-filtered    | 1        | per aperture  | profile.apertures_per_chart |
+| ADR-063 per-view (this) | N        | shared        | view.aperture               |
+
+A profile could in principle declare both, but no shipped profile
+does today.
+
+## Alternatives considered
+
+1. **Add Samyang to `apertures_per_chart`** with a `MAX-`/`F8-` hue
+   prefix scheme. Rejected: the two panels share hue bands, so the
+   filter would empty one aperture's mask entirely. The hue-filter
+   mechanism assumes per-aperture color encoding inside one plot box.
+
+2. **Encode the panel choice in the image_path** (e.g. crop the PNG
+   into two separate files, one per panel). Rejected: doubles the
+   stored artifacts for no orchestrator benefit, and the source-of-
+   truth PNG is the single two-panel image Samyang publishes.
+
+3. **Match per-view aperture by `image_path` in the resolver**.
+   Rejected: both Samyang panels share the same `chart_path`, so the
+   path alone cannot disambiguate. A plot_box-based key would work
+   structurally but the per-view aperture is metadata, not a derived
+   property — keep it explicit on the view.
+
+4. **Bolt the aperture onto `PlotBoxCoords`**. Rejected: aperture is
+   an orchestrator concern (which pass label this panel emits at),
+   not a coordinate.
+
+## Consequences
+
+### Positive
+
+- 85mm Tier 1 anchor gains F8 panel calibration: `freq30S` p95 |d|
+  reads as **0.228** (the two known dropouts where dark grey 30S
+  sits one pixel below pink 10M and gets eaten by the 10S->10M halo
+  subtraction); the other three F8 fields are within 0.055.
+- 300mm reflex Tier 1 anchor gains F8 panel calibration (idealized-
+  flat: every curve at 1.0 across both panels). All F8 deltas
+  within 0.016.
+- Aggregate calibration p95 |d| improves **0.0466 -> 0.0463**,
+  in-band 95.9% -> 96.0%. Paired comparisons grow **810 -> 872**
+  (the extra 62 are the new F8 panel cells: 2 anchors x 4 fields
+  x ~8 paired fractions).
+- Unblocks #1238's scaffolder step (`scaffold_samyang_tier2.py`):
+  18 Tier 2 Samyangs can now declare `additional_views=(ChartView(
+..., aperture="F8"),)` and the orchestrator emits per-aperture
+  artifacts and digitization-log panels per ADR-041.
+- Foundation for any future "multi-panel single-PNG" chart family
+  (Sigma's stopped-down variants, Voigtlander APO-LANTHAR pairs)
+  without touching the hue-filter mechanism.
+
+### Negative / accepted tradeoff
+
+- Two pass-resolution paths share the orchestrator (`apertures_per_chart`
+  hue-filter from ADR-044 and `view.aperture` from this ADR). They
+  are routed in `_calibrate_chart` by an `if-elif` and could be
+  unified into a single "fan-out spec" if a future profile needs
+  both, but no shipped profile does today (YAGNI).
+- The two dropouts on 85mm freq30S F8 (p95 0.228) reflect a known
+  limitation of the ADR-059 / ADR-062 halo-subtraction pipeline when
+  the contaminator (10S-red) and the contaminated (10M-pink) sit
+  within a few pixels of the orthogonal-hue 30S-dark-grey curve. The
+  ring-subtraction mask radius spills onto the dark-grey curve at
+  exactly those two cells. Tracked as a follow-up; out of scope here.
+- `ChartView` now has a field that only Samyang uses (and the 18
+  Tier 2 entries the scaffolder will emit). Acceptable: the field
+  defaults to None so every existing entry stays unchanged.
+
+### Scope this ADR does NOT cover
+
+- The scaffolder `tools/mtfdigitizer/scripts/scaffold_samyang_tier2.py`
+  that walks the 18 Tier 2 Samyang folders, auto-detects both panel
+  plot boxes per chart, and emits `_samyang_tier2_charts.py` with
+  per-lens `(max, F8)` aperture tables. Tracked under #1238's
+  remaining acceptance criteria.
+- Per-lens max aperture eye-read table (parallel to TTartisan's
+  `_APERTURES_BY_SLUG`). The stopped aperture is universally `"F8"`
+  per S170 user confirmation; max is the lens's wide-open f-number.
+  Maintainer eye-read deferred to the scaffolder PR.
+- A redesign of the render-match precision metric to credit sister-
+  filled cells (ADR-062 §Consequences notes this as a known
+  limitation).

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -9397,3 +9397,104 @@ Theme: started S170 = #792 (digitize 20 Samyang charts), discovered two compound
 - Gitleaks CI: 9s pass.
 - `delete_branch_on_merge: true` on the repo.
 - Submodule: `docs/solid-ai-templates` 1 docs-only commit behind upstream (unchanged).
+
+---
+
+### Session 171 — Samyang multi-panel per-view aperture mechanism (#1238 step 1+2)
+
+Date: 2026-06-21 · Tool: Claude Code (Opus 4.7, 1M context)
+
+Theme: continued Samyang work from S170. Filed #1238 last session as the architectural blocker for closing #792 — this session shipped the mechanism (per-view aperture override) plus the two Tier 1 anchors' F8 panels with eye-read GT, leaving the scaffolder + 18 Tier 2 re-extraction for S172.
+
+#### PRs
+
+- **PR #1241 opened** (`dec3f90` on `feat/samyang-multi-panel-aperture`) — `feat(mtf): per-view aperture override + Samyang F8 anchors (ADR-063, #1238)`. 6 files: 3 code (`aperture_passes.py` + `extract.py` + `calibrate.py`) + 1 referenceset edit (`charts.py`) + 1 test fixture update + 1 new ADR. Awaiting merge.
+
+#### Issues opened / closed
+
+- **#1238 stays open** — step 1 (ChartView.aperture mechanism) and step 3a (Tier 1 anchors with GT) done; step 3b (scaffolder + 18 Tier 2 re-extraction) is next session.
+- **#792 stays open** — gated on #1238.
+- No issues closed or opened.
+
+#### Key technical findings
+
+- **Samyang's two stacked panels share one PNG with one hue palette, only the plot_box differs.** The ADR-044 hue-filtered fan-out (TTartisan) does not fit: filtering hues by aperture prefix would empty one panel's mask entirely. A second `ChartView` with its own `plot_box` is the right structural answer, but the existing pass resolver keys on `(chart, image_path)` and image_path is identical for both views — no way to disambiguate without a per-view aperture override.
+- **Calibrate had a hidden bug for multi-aperture GT on the standard path.** Pre-fix: `_calibrate_chart` called `extract_chart` ONCE on `chart.plot_box` (the MAX panel) and then iterated `chart.ground_truth.items()` — for BOTH MAX and F8 keys it compared against the same MAX-panel readings. Adding the F8 GT before the fix produced a fake "F8 freq30S med 0.366 / p95 0.423" delta that was actually `extractor(MAX 30S ~0.59 avg) vs eye-read(F8 30S ~0.96)`. Root cause: calibrate had no per-view walk for the non-`apertures_per_chart` case.
+- **Per-view fan-out is a clean parallel to ADR-044's hue-filtered fan-out — same dict shape, different driver.** Both produce `{aperture_label: ExtractedChart}`. Hue-filtered: driven by `MtfProfile.apertures_per_chart`, one extract per aperture with hues filtered. Per-view: driven by `ChartView.aperture`, one extract per view with the full profile. The two are orthogonal — no shipped profile uses both — but `_calibrate_chart` routes between them via a single `if-elif` that could unify later if needed.
+- **85mm F8 freq30S retains a p95 0.228 delta on two cells.** Same shape as ADR-062's accepted tradeoff: where dark-grey 30S sits a few pixels below pink 10M, the 10S->10M halo-subtraction ring spills onto the 30S curve and the sampler reads down to ~0.74 at positions 12.96mm and 17.28mm. Out of scope for this PR; tracked as ADR-063 follow-up.
+- **Axis-line probe confirmed both Samyang panels are 421 px tall identical templates.** Column 31 (y-axis) dark runs at `43..463` and `575..995`. Verified for both 85mm and 300mm reflex charts.
+- **300mm reflex F8 panel has no visible 30 lp/mm curves but the chart shape is "all curves at 1.0".** Eye-read GT mirrors the existing MAX panel's `(1.0,) * 11` quartet; passes calibrate with the same idealized-flat behaviour (5/11 paired for 30S/30M because the 1.0 line collides with the plot top).
+
+#### Key changes
+
+- **`tools/mtfdigitizer/referenceset/charts.py`** — extend `ChartView` with `aperture: str | None = None` (+11-line docstring on semantics). Extend `_SAMYANG_85_GT` and `_SAMYANG_300_GT` with `"F8"` keys (11 values x 4 fields each). Add `additional_views=(ChartView(..., aperture="F8"),)` to both Tier 1 anchor entries and rewrite their `notes` to document the two-panel layout.
+- **`tools/mtfdigitizer/aperture_passes.py`** — extend `aperture_passes_for_view` signature with `view: ChartView | None = None` (default keeps back-compat for legacy callers); add an early branch that returns `[(view.aperture, _apply_sm_swap_override(base, swap))]` when `view.aperture is not None`. +11 lines of docstring covering the new branch's priority over Fuji per-frequency and ADR-044 hue-filtered paths.
+- **`tools/mtfdigitizer/extract.py`** — single one-line change: `_run_view_passes` now passes `view` to `_aperture_passes_for_view`.
+- **`tools/mtfdigitizer/calibrate.py`** — add `_has_per_view_apertures(chart)` predicate (8 lines incl docstring) + `_extract_per_view_aperture_chart(chart)` walker (~30 lines incl docstring) that returns the `{aperture_label: ExtractedChart}` dict. Extend `_calibrate_chart` routing: when `_has_per_view_apertures(chart) or apertures_per_chart is not None`, dispatch to the matching extractor; reuse the same GT-walk loop. Error message updated from "apertures_per_chart" to "extracted passes" (more accurate for both shapes).
+- **`tools/mtfdigitizer/tests/test_calibrate.py`** — `test_multi_aperture_dispatch_rejects_unknown_gt_aperture` regex updated from `"apertures_per_chart"` to `"not in extracted passes"`.
+- **`docs/decisions/063-samyang-multi-panel-aperture.md`** — new ADR (~160 lines). 4 rejected alternatives (add to `apertures_per_chart` / encode in image_path / match by image_path / bolt onto PlotBoxCoords), ASCII diagram of the two-view-per-chart layout, mechanism comparison table vs ADR-044, "Scope this ADR does NOT cover" naming the scaffolder + 18 Tier 2 re-extraction + the render-match precision metric limitation.
+
+#### Calibration impact
+
+| Metric                      | S170    | S171                                            |
+| --------------------------- | ------- | ----------------------------------------------- |
+| Aggregate p95 \|d\|         | 0.0466  | **0.0463**                                      |
+| Aggregate in-band (+/-0.05) | 95.9%   | **96.0%**                                       |
+| Aggregate paired            | 810     | **872** (+62 F8 cells)                          |
+| Aggregate median \|d\|      | 0.0057  | 0.0066                                          |
+| Aggregate max \|d\|         | 0.1217  | 0.2265 (the two 85mm F8 freq30S dropouts)       |
+| 85mm F8 freq10S/10M p95     | n/a     | **0.023 / 0.016** (new)                         |
+| 85mm F8 freq30S/30M p95     | n/a     | **0.228 / 0.055** (new; 30S two-cell halo)      |
+| 300mm reflex F8 all fields  | n/a     | **within 0.016 p95** (new)                      |
+| MAX-panel deltas            | -       | unchanged (mechanism is per-view-additive only) |
+| mtfdigitizer pytest         | 389/389 | **389/389** (1 fixture regex updated)           |
+
+#### Verification
+
+- `py -m mtfdigitizer.calibrate` — aggregate p95 0.0466->0.0463, in-band 95.9%->96.0%, paired 810->872.
+- `py -m pytest mtfdigitizer/tests/` — 389 passed.
+- `npm run validate` — green (lint + format + check + test + build + link check).
+- Per-view extractor sanity check: ran `extract_chart` directly on the F8 view of 85mm to confirm the readings match the eye-read GT (within 0.05 on 9/11 freq30S cells); diagnosed the calibrate-side bug from the divergence between direct extract and calibrate output.
+- Pixel-level HSV probe on 85mm F8 panel columns x=100/200/300/400 confirmed the four-curve y-positions match GT eye-read (dark-grey 30S at y~591, light-grey 30M at y~639-700 depending on column).
+
+#### Key decisions (this session)
+
+- **Per-view aperture lives on `ChartView`, not on `PlotBoxCoords` or `image_path`.** Aperture is an orchestrator concern (which pass label this panel emits at), not a coordinate or a path-derived property. Keeping it on the same struct as `plot_box` means "this panel" and "this panel's aperture" travel together — the natural unit. Alternative (`image_path`-derived matching) is structurally impossible for same-PNG multi-panel.
+- **Calibrate uses a separate per-view extractor function rather than overloading `_extract_multi_aperture_chart`.** Both return the same shape but the input mechanics differ (one walks profile.apertures + hue-filters, the other walks chart.views + applies sm-swap). YAGNI-justified split — unify if a third dispatch arrives.
+- **Default `aperture_passes_for_view`'s new `view` arg to None.** Legacy callers (autotriage, diagnose, log, review, svg) keep working without churn; only the orchestrator (extract.py) passes `view` explicitly. The orchestrator is the only caller that walks multi-view today.
+- **Eye-read F8 panel GT against the 0.1 OTF gridlines directly from the chart image** rather than waiting for a separate maintainer pass. The chart's two-panel template renders both panels at the same x-scale and the legend is shared, so the eye-read is no harder than a MAX-panel read. Documented under "Verification" above so the next maintainer can re-check.
+
+#### Process patterns observed this session
+
+- **Run the extractor on the new view directly before trusting calibrate's delta report.** Initial calibrate output showed F8 freq30S med 0.366 — almost concluded "the GT is wrong". A 20-line one-shot script (load chart, build pass, call extract_chart, print readings) instead showed the extractor reading 0.95-0.97 across the F8 panel. That made the bug "calibrate uses the wrong plot_box per aperture key" obvious in 2 minutes. The probe -> diagnosis -> fix path was faster than re-reading the GT eye-read for errors.
+- **The S168/S169 "always check what the layer below does with the fix's output" pattern is becoming a session habit.** Last session it was sister fallback fighting the trim's None; this session it was calibrate's GT loop fighting the new per-view dispatch. Both times the surfaced symptom was downstream of the fix, and both times the diagnosis required understanding the layer's existing behaviour on the new input shape before declaring the fix correct.
+- **Visual chart eye-reads against axis gridlines are fast and accurate enough for Tier 1 GT when the chart's gridline pitch matches the precision target.** 0.1 OTF gridlines x 11 sample fractions = ~44 reads per panel, ~5 minutes per panel, +/-0.02 precision per value. Beats waiting for an automated tool to re-derive what's visually unambiguous.
+
+#### Follow-ups for next session (S172)
+
+- **#1238 step 3 (scaffolder + 18 Tier 2 re-extraction)** — write `scaffold_samyang_tier2.py`, eye-read `_APERTURES_BY_SLUG` (max per-lens, stopped="F8" universally per S170), emit `_samyang_tier2_charts.py`, run `extract --all --accept` per ADR-041 cohort flow, user-glance per batch. This closes both #1238 and #792.
+- **Stale Tokina digitization-logs** (4 Tokina + 1 ttartisan-af-35) — still deferred from S170. Small `--regen` PR.
+- **85mm F8 freq30S two-cell dropout** (positions 12.96mm + 17.28mm) — investigate whether ADR-059/062 halo-subtraction ring radius can be reduced where 30S and 30M sit within a few pixels of 10M without losing the existing coverage. ADR-063 lists this as out-of-scope follow-up.
+- **#1134 (P1, Backlog)** — confidence badge. Still deferred.
+- **#1110 (P1, Expedite)** — per-stage diagnostic bundle (ADR-050).
+- **#950 (P2, v0.8.0)** — auto-detect plot box.
+- **10 Dependabot PRs** from S169 weekly update still open; bulk-merge candidate if CI green on each.
+
+#### State of the project
+
+- v0.8.0 = MTF digitization (active milestone, **23 open / 73 closed** before #1241 lands).
+- Epic #790 (digitize all brands): 4/24 done (unchanged).
+- `REFERENCE_CHARTS` = 103 entries (unchanged count; 2 extended with F8 additional_views).
+- **5 Tier 1 anchors** (unchanged count; 2 now multi-panel).
+- Aggregate calibration: **872 paired, median \|d\| 0.0066, p95 \|d\| 0.0463, in-band 96.0%, max \|d\| 0.2265**.
+- **389 mtfdigitizer pytest pass** (unchanged count; 1 fixture regex updated). **223 vitest pass.**
+- **63 ADRs** (was 62 — +1 ADR-063).
+- 8 declared MTF profiles (unchanged).
+- v0.8.0 open: **#1238 (in progress) + #1134 + #1135 + #1110 + #1159 + #950 + epics #790, #932** + 19 P3 brand-digitization tasks (#792 stays open pending #1238).
+- **1 open PR (#1241 from this session). 10 stale Dependabot PRs** (carried from S169).
+- `mtf-readings.ts` — one cell hand-patched, locked by regression test (unchanged).
+- Stale digitization logs: **4 Tokina + 1 ttartisan-af-35** (carried from S170).
+- Stale `referenceset/readings/*.md` panels: **0** (unchanged).
+- Gitleaks CI: 9s pass.
+- `delete_branch_on_merge: true` on the repo.
+- Submodule: `docs/solid-ai-templates` 1 docs-only commit behind upstream (unchanged).

--- a/tools/mtfdigitizer/aperture_passes.py
+++ b/tools/mtfdigitizer/aperture_passes.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from .family_profile import profile_for_chart
 from .profiles.types import MtfProfile
-from .referenceset.charts import ReferenceChart
+from .referenceset.charts import ChartView, ReferenceChart
 
 
 _FUJI_FREQ_RE = re.compile(r"-(?P<freq>\d+)lp\.png$", re.IGNORECASE)
@@ -63,10 +63,16 @@ def _apply_sm_swap_override(
 
 
 def aperture_passes_for_view(
-    chart: ReferenceChart, image_path: Path
+    chart: ReferenceChart,
+    image_path: Path,
+    view: ChartView | None = None,
 ) -> list[tuple[str, MtfProfile]]:
     """Resolve a view to one or more (aperture, profile) extraction passes.
 
+    - Per-view aperture override (ADR-063, Samyang multi-panel): one pass,
+      labelled with `view.aperture`. Used when a chart family packs
+      multiple apertures into stacked panels sharing one PNG — each panel
+      is published as its own ChartView with its own plot_box.
     - Fujifilm per-frequency (ADR-043): one pass, profile copied with
       `frequencies_lpmm` substituted from the filename.
     - Multi-aperture-per-chart (ADR-044): N passes, one per aperture,
@@ -74,9 +80,16 @@ def aperture_passes_for_view(
     - Default: one pass with the chart's primary aperture label.
 
     `chart.sm_swap_per_hue` is applied to every returned profile.
+
+    `view` is optional for back-compat with callers that only operate on
+    the primary chart raster (autotriage, diagnose, log, review, svg —
+    all pre-multi-view orchestration). The orchestrator (extract.py)
+    always passes the active view so per-view aperture overrides apply.
     """
     base = profile_for_chart(chart)
     swap = chart.sm_swap_per_hue
+    if view is not None and view.aperture is not None:
+        return [(view.aperture, _apply_sm_swap_override(base, swap))]
     if chart.style_family in _FUJI_STYLE_FAMILIES:
         freq = _parse_filename_frequency(image_path)
         substituted = dataclasses.replace(base, frequencies_lpmm=(freq,))

--- a/tools/mtfdigitizer/calibrate.py
+++ b/tools/mtfdigitizer/calibrate.py
@@ -187,6 +187,49 @@ def _extract_per_frequency_chart(chart: ReferenceChart):
     return dataclasses.replace(last_result, readings=merged_readings)
 
 
+def _has_per_view_apertures(chart: ReferenceChart) -> bool:
+    """True when any chart view declares an explicit aperture label.
+
+    Used by `_calibrate_chart` to route multi-panel charts (Samyang
+    MAX/F8 per #1238 / ADR-063) through a per-view extraction loop
+    that builds a `{aperture_label: ExtractedChart}` dict — same
+    shape as `_extract_multi_aperture_chart`'s output for ADR-044
+    hue-filtered dual-aperture charts. The two mechanisms are
+    orthogonal: hue-filtered packs apertures by color into one panel,
+    per-view splits them across stacked panels with one plot_box per
+    panel.
+    """
+    return any(v.aperture is not None for v in chart.additional_views)
+
+
+def _extract_per_view_aperture_chart(chart: ReferenceChart) -> dict[str, "object"]:
+    """Run the extractor once per view, keyed by the view's declared aperture.
+
+    The primary view contributes the chart's first aperture label
+    (`chart.apertures[0]`); each additional view contributes its
+    declared `view.aperture`. Returns the same `{aperture_label:
+    ExtractedChart}` shape as `_extract_multi_aperture_chart` so the
+    downstream GT comparison loop in `_calibrate_chart` works
+    uniformly across both fan-out shapes.
+    """
+    from .aperture_passes import _apply_sm_swap_override  # noqa: PLC0415
+
+    assert chart.plot_box is not None
+    base_profile = profile_for_chart(chart)
+    profile = _apply_sm_swap_override(base_profile, chart.sm_swap_per_hue)
+    results: dict[str, object] = {}
+    for view in chart.views:
+        assert view.plot_box is not None
+        aperture = view.aperture if view.aperture is not None else chart.apertures[0]
+        image_path = REPO_ROOT / view.chart_path
+        plot_box = _to_plotbox(view.plot_box)
+        results[aperture] = extract_chart(
+            image_path, profile, plot_box,
+            image_height_mm=chart.image_height_mm,
+        )
+    return results
+
+
 def _extract_multi_aperture_chart(chart: ReferenceChart) -> dict[str, "object"]:
     """Run the extractor once per declared aperture and return a per-
     aperture result dict (ADR-044).
@@ -259,17 +302,20 @@ def _calibrate_chart(chart: ReferenceChart):
     assert chart.ground_truth is not None
 
     base_profile = profile_for_chart(chart)
-    if base_profile.apertures_per_chart is not None:
-        results_by_aperture = _extract_multi_aperture_chart(chart)
+    if base_profile.apertures_per_chart is not None or _has_per_view_apertures(chart):
+        if base_profile.apertures_per_chart is not None:
+            results_by_aperture = _extract_multi_aperture_chart(chart)
+        else:
+            results_by_aperture = _extract_per_view_aperture_chart(chart)
         out: list[FieldDelta] = []
         for aperture, gt_by_field in chart.ground_truth.items():
             if aperture not in results_by_aperture:
-                # GT carries an aperture key the profile didn't declare.
-                # Fail-loud: a typo here masks a missing extractor pass.
+                # GT carries an aperture key the chart didn't extract a
+                # pass for. Fail-loud: a typo or missing view here masks
+                # an absent extractor pass.
                 raise KeyError(
                     f"{chart.slug}: ground_truth aperture {aperture!r} not "
-                    f"in profile.apertures_per_chart "
-                    f"{base_profile.apertures_per_chart!r}"
+                    f"in extracted passes {sorted(results_by_aperture)!r}"
                 )
             result = results_by_aperture[aperture]
             for field, gt_values in gt_by_field.items():

--- a/tools/mtfdigitizer/extract.py
+++ b/tools/mtfdigitizer/extract.py
@@ -192,7 +192,7 @@ def _run_view_passes(
     )
     image_path = _resolve_view_image(chart, view)
     plot_box = _to_plotbox(view.plot_box)
-    passes = _aperture_passes_for_view(chart, image_path)
+    passes = _aperture_passes_for_view(chart, image_path, view)
 
     runs: list[ExtractRun] = []
     for aperture, profile in passes:

--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -75,10 +75,20 @@ class ChartView:
     lens). All other lens-level attributes — style family, apertures,
     image-height extent — live on `ReferenceChart` and are shared
     across views.
+
+    `aperture` overrides the pass aperture label for this view, used for
+    chart families that pack multiple apertures into stacked panels
+    sharing one PNG (Samyang: MAX panel on top, F8 panel below). The
+    view's plot_box selects the panel; `aperture` tells the orchestrator
+    which f-stop the readings belong to. None means default behavior:
+    profile-level `apertures_per_chart` fan-out for hue-filtered dual
+    aperture (TTartisan, ADR-044), or `chart.apertures[0]` for
+    single-aperture views.
     """
 
     chart_path: str
     plot_box: PlotBoxCoords | None = None
+    aperture: str | None = None
 
 
 @dataclass(frozen=True)
@@ -148,7 +158,10 @@ _SIGMA_56_GT: GroundTruthCurves = {
     },
 }
 
-# Samyang 85mm MAX panel — x positions: 0, 2.16, 4.32, 6.48, 8.64, 10.8, 12.96, 15.12, 17.28, 19.44, 21.6
+# Samyang 85mm two-panel chart — x positions: 0, 2.16, 4.32, 6.48, 8.64, 10.8, 12.96, 15.12, 17.28, 19.44, 21.6
+# MAX panel: top of chart (y_top=43, y_bottom=463).
+# F8 panel:  bottom of chart (y_top=575, y_bottom=995). Stops down to f/8 per the
+# panel label; eye-read against the chart's 0.1 OTF gridlines (#1238).
 _SAMYANG_85_GT: GroundTruthCurves = {
     "MAX": {
         # Dark red — 10S — flat near top, sharp knee past 17mm
@@ -160,15 +173,32 @@ _SAMYANG_85_GT: GroundTruthCurves = {
         # Light grey — 30M — near-linear drop
         "freq30M": (0.70, 0.67, 0.66, 0.64, 0.62, 0.61, 0.60, 0.59, 0.58, 0.57, 0.57),
     },
+    "F8": {
+        # Dark red — 10S — flat at ~1.0 across, slight dip at far edge
+        "freq10S": (1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99),
+        # Pink — 10M — flat ~0.98, dips at the far right
+        "freq10M": (0.98, 0.98, 0.98, 0.98, 0.98, 0.98, 0.97, 0.97, 0.97, 0.96, 0.93),
+        # Dark grey — 30S — near-flat ~0.96, gentle drop only at edge
+        "freq30S": (0.96, 0.96, 0.97, 0.97, 0.97, 0.97, 0.97, 0.96, 0.95, 0.93, 0.92),
+        # Light grey — 30M — steady decline; steep drop past 17mm
+        "freq30M": (0.96, 0.95, 0.93, 0.91, 0.88, 0.84, 0.79, 0.75, 0.74, 0.66, 0.55),
+    },
 }
 
 # Samyang 300mm reflex — x positions: 0, 1.4, 2.8, ..., 14.0
-# All four curves pinned at 1.0 across the entire field (idealized-flat).
-# This chart's value in the set is the plausibility prior, not a render-match
-# test — every extractor scores this chart well by IoU and that's the bug
-# the prior catches. Ground truth here is "what the chart literally shows."
+# All four curves pinned at 1.0 across the entire field on BOTH panels
+# (idealized-flat; 30 lp/mm curves are not visibly rendered on the chart,
+# the printed shape is "every curve at 1.0"). This chart's value in the
+# set is the plausibility prior, not a render-match test — every extractor
+# scores this chart well by IoU and that's the bug the prior catches.
 _SAMYANG_300_GT: GroundTruthCurves = {
     "MAX": {
+        "freq10S": (1.0,) * 11,
+        "freq10M": (1.0,) * 11,
+        "freq30S": (1.0,) * 11,
+        "freq30M": (1.0,) * 11,
+    },
+    "F8": {
         "freq10S": (1.0,) * 11,
         "freq10M": (1.0,) * 11,
         "freq30S": (1.0,) * 11,
@@ -760,11 +790,23 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("MAX", "F8"),
         frequencies_lpmm=(10, 30),
         image_height_mm=21.6,
-        notes="two stacked panels; MAX shows S/M divergence at edges, F8 mostly recovers except 30M edge dip",
-        # MAX panel only — F8 panel calibration deferred (requires a
-        # second plot box; the runnable subset is MAX-only today).
+        notes=(
+            "two stacked panels; MAX shows S/M divergence at edges, F8 "
+            "mostly recovers except 30M edge dip. Per-view aperture "
+            "override (#1238, ADR-063): primary view = MAX panel "
+            "(top, y 43..463), additional view = F8 panel (bottom, "
+            "y 575..995). Both panels share the same x range (31..461) "
+            "and the same image height (21.6 mm)."
+        ),
         plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=43, y_bottom=463),
         ground_truth=_SAMYANG_85_GT,
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/samyang-85mm-f1-4-as-if-umc/samyang-85mm-f1-4-as-if-umc-mtf.png",
+                plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=575, y_bottom=995),
+                aperture="F8",
+            ),
+        ),
     ),
     ReferenceChart(
         slug="samyang-300mm-f6-3-ed-umc-cs-reflex",
@@ -773,10 +815,21 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
         apertures=("MAX", "F8"),
         frequencies_lpmm=(10, 30),
         image_height_mm=14.0,
-        notes="ALL curves pinned at ~1.0 across both apertures; the flat-axis blind-spot probe case",
-        # Same layout as the Samyang 85mm (identical template); MAX panel.
+        notes=(
+            "ALL curves pinned at ~1.0 across both apertures; the flat-"
+            "axis blind-spot probe case. Same two-panel template as the "
+            "85mm (MAX at y 43..463, F8 at y 575..995, identical x "
+            "range). Per-view aperture override (#1238, ADR-063)."
+        ),
         plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=43, y_bottom=463),
         ground_truth=_SAMYANG_300_GT,
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/samyang-300mm-f6-3-ed-umc-cs-reflex/samyang-300mm-f6-3-ed-umc-cs-reflex-mtf.png",
+                plot_box=PlotBoxCoords(x_left=31, x_right=461, y_top=575, y_bottom=995),
+                aperture="F8",
+            ),
+        ),
     ),
     ReferenceChart(
         slug="7artisans-50mm-f1-2-mark-ii",

--- a/tools/mtfdigitizer/tests/test_calibrate.py
+++ b/tools/mtfdigitizer/tests/test_calibrate.py
@@ -170,7 +170,7 @@ def test_multi_aperture_dispatch_rejects_unknown_gt_aperture(
         },
     )
 
-    with pytest.raises(KeyError, match="apertures_per_chart"):
+    with pytest.raises(KeyError, match="not in extracted passes"):
         calibrate_mod._calibrate_chart(chart_with_bad_gt)
 
 


### PR DESCRIPTION
## Summary

- Mechanism (step 1+2 of #1238): adds `ChartView.aperture: str | None` so a single PNG can publish one panel per aperture via `additional_views` with their own `plot_box`. Threads `view` through `aperture_passes_for_view` (third arg, default None for back-compat); extends `calibrate._calibrate_chart` with a per-view fan-out path that produces the same `{aperture_label: ExtractedChart}` shape as ADR-044's hue-filtered multi-aperture.
- Tier 1 (step 3): 85mm + 300mm reflex anchors gain F8 ChartView at `y=575..995` (axis-line probe confirmed both panels are 421 px tall, identical x range). Eye-read F8 GT entries against the 0.1 OTF gridlines.
- ADR-063 documents the orthogonal-to-ADR-044 design (hue-filtered single-panel vs per-view stacked-panel) and the rejected alternatives.

This unblocks the scaffolder + 18 Tier 2 Samyang re-extraction in a follow-up PR (next session).

## Calibration impact

| Metric | Pre | Post |
|---|---|---|
| Aggregate p95 \|d\| | 0.0466 | **0.0463** |
| Aggregate in-band (±0.05) | 95.9% | **96.0%** |
| Aggregate paired | 810 | **872** (+62 F8 cells) |
| 85mm F8 freq10S/10M | n/a | 0.023 / 0.016 (p95) |
| 85mm F8 freq30S/30M | n/a | 0.228 / 0.055 (p95) |
| 300mm reflex F8 (all fields) | n/a | within 0.016 (p95) |

85mm F8 freq30S p95 0.228 reflects two cells where dark-grey 30S sits one pixel below pink 10M and gets eaten by the ADR-059 halo subtraction; same shape ADR-062's Consequences flagged. Out of scope here.

## Test plan

- [x] `py -m pytest mtfdigitizer/tests/` — 389 passed (+1 test renamed for new error wording)
- [x] `py -m mtfdigitizer.calibrate` — aggregate p95 0.0466 → 0.0463, in-band 95.9% → 96.0%
- [x] `npm run validate` — lint + format + check + test + build + link check all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)