### PR TITLE
test: use toHaveLength over generic toBe length checks (#1231)

### DIFF
--- a/src/components/interactive/GenreGuide/GenreGuide.test.tsx
+++ b/src/components/interactive/GenreGuide/GenreGuide.test.tsx
@@ -217,7 +217,7 @@ describe("GenreGuide", () => {
     const pipContainers = screen.getAllByLabelText(/Mark \d/);
     for (const container of pipContainers) {
       const pips = container.querySelectorAll("span");
-      expect(pips.length).toBe(5);
+      expect(pips).toHaveLength(5);
     }
   });
 

--- a/src/utils/lens-content.test.ts
+++ b/src/utils/lens-content.test.ts
@@ -137,10 +137,10 @@ describe("generateLensContent", () => {
     it("returns clusters for scored lens", () => {
       const content = generateLensContent(scoredLens, allLenses);
       expect(content.opticalClusters).not.toBeNull();
-      expect(content.opticalClusters!.sharpness.length).toBe(4);
-      expect(content.opticalClusters!.aberrations.length).toBe(5);
-      expect(content.opticalClusters!.rendering.length).toBe(4);
-      expect(content.opticalClusters!.distortion.length).toBe(1);
+      expect(content.opticalClusters!.sharpness).toHaveLength(4);
+      expect(content.opticalClusters!.aberrations).toHaveLength(5);
+      expect(content.opticalClusters!.rendering).toHaveLength(4);
+      expect(content.opticalClusters!.distortion).toHaveLength(1);
     });
 
     it("returns null for unscored lens", () => {
@@ -167,12 +167,12 @@ describe("generateLensContent", () => {
   describe("genre fit", () => {
     it("returns entries for scored lens", () => {
       const content = generateLensContent(scoredLens, allLenses);
-      expect(content.genreFit.length).toBe(9);
+      expect(content.genreFit).toHaveLength(9);
     });
 
     it("returns empty for unscored lens", () => {
       const content = generateLensContent(unscoredLens, allLenses);
-      expect(content.genreFit.length).toBe(0);
+      expect(content.genreFit).toHaveLength(0);
     });
 
     it("follows canonical genre order", () => {

--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -245,7 +245,7 @@ describe("computeAllGenreMarks", () => {
   it("returns empty object for unscored lens", () => {
     const lens = makeLens({ brand: "Fujifilm", model: "Empty" });
     const marks = computeAllGenreMarks(lens);
-    expect(Object.keys(marks).length).toBe(0);
+    expect(Object.keys(marks)).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace 8 `expect(x.length).toBe(N)` assertions with `expect(x).toHaveLength(N)` across 3 test files.
- Unblocks the eslint-plugin-sonarjs 4.0.3 → 4.1.0 Dependabot bump (#1231) — the new `prefer-specific-assertions` rule flags the generic form.

## Files

- `src/components/interactive/GenreGuide/GenreGuide.test.tsx` (1)
- `src/utils/lens-content.test.ts` (6)
- `src/utils/scoring.test.ts` (1)

## Test plan

- [x] `npm run validate` — lint + format + check + test + build all pass (against current sonarjs 4.0.3; forward-compatible with 4.1.0)
- [ ] After merge to main, re-trigger Dependabot rebase on #1231 — expected: build job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)