### PR TITLE
refactor(mtfdigitizer): align Samyang plot-box names with cross-brand convention

### DIFF
--- a/docs/decisions/064-plotbox-detector-naming.md
+++ b/docs/decisions/064-plotbox-detector-naming.md
@@ -1,0 +1,125 @@
+# ADR-064: Cross-brand plot-box detector naming convention
+
+**Status:** Accepted
+**Date:** 2026-06-21
+
+## Context
+
+The mtfdigitizer ships one plot-box detector per brand whose chart
+layout warrants auto-detection: `fuji_plotbox.py`, `ttartisan_plotbox.py`,
+`samyang_plotbox.py`. They share a contract — given a chart PNG,
+return the plot-box coordinates the downstream extractor needs — but
+the surface names drifted as each brand was added incrementally
+(Fuji: S140s; TTartisan: S160s; Samyang: S171 / ADR-063):
+
+| Field       | Fuji            | TTartisan             | Samyang               |
+| ----------- | --------------- | --------------------- | --------------------- |
+| result type | `FujiBoxResult` | `TTartisanBoxResult`  | `SamyangBoxes`        |
+| primary box | `plot_box`      | `plot_box`            | `max_box`             |
+| extra box   | n/a             | n/a                   | `f8_box`              |
+| error class | (raises inline) | (raises `ValueError`) | `SamyangPlotBoxError` |
+
+The Samyang names are accurate for _today's_ Samyang chart family
+(MAX panel + F8 panel), but two problems are visible right now:
+
+1. **Cross-brand cognitive cost.** A reader bouncing between
+   `scaffold_*_tier2.py` files sees `c.boxes.max_box` in one and
+   `c.detected.plot_box` in the next. The shared concept ("the
+   primary plot box this detector found") has two different names.
+
+2. **F8 is hardcoded in a field name.** If Samyang ever publishes
+   a chart whose second panel is anything other than F8 (the brand's
+   AF zooms already mix conventions on other axes), `f8_box` becomes
+   a lie. The detector does not — and cannot — know the panel's
+   aperture: it only knows there is a top panel and a bottom panel.
+   The aperture label travels via the scaffolder, not the detector
+   (see ADR-063: `additional_views=(ChartView(..., aperture="F8"),)`
+   is constructed in the scaffolder).
+
+Formalizing now is cheap (3 files touched, no behavior change). Next
+brand that lands picks up the convention for free.
+
+## Decision
+
+A plot-box detector module MUST follow this naming convention:
+
+```
++-----------------------------------------------------------+
+|  <brand>_plotbox.py                                        |
+|                                                            |
+|    detect_<brand>_plotbox(path) -> <Brand>BoxResult        |
+|                                                            |
+|    @dataclass(frozen=True)                                 |
+|    class <Brand>BoxResult:                                 |
+|        plot_box: tuple[int, int, int, int]   # primary    |
+|        # ...brand-specific extras: secondary boxes,        |
+|        #    image_height_mm, scheme, notes, etc.           |
+|                                                            |
+|    class <Brand>PlotBoxError(RuntimeError):                |
+|        """Raised when detection fails."""                  |
++-----------------------------------------------------------+
+```
+
+Concrete rules:
+
+1. **Module name** — `<brand>_plotbox.py`.
+2. **Entry point** — `detect_<brand>_plotbox(chart_path: Path)`.
+3. **Result type** — `<Brand>BoxResult` (dataclass, frozen). The
+   _primary_ box field MUST be named `plot_box` regardless of
+   how many panels the chart contains. Brands with multiple
+   panels MAY add additional box fields, but those fields MUST
+   NOT bake an aperture f-number into the name. Use semantic
+   names tied to the _role_ of the panel
+   (`stopped_box`, `secondary_box`), not the f-stop value
+   (`f8_box`, `f11_box`). The aperture label is the scaffolder's
+   responsibility.
+4. **Error type** — `<Brand>PlotBoxError`, subclass of
+   `RuntimeError`. Detectors MUST raise this class on detection
+   failure, not bare `ValueError`. Loud, named failures help the
+   maintainer identify which chart broke detection.
+
+## Alternatives considered
+
+**Status quo (keep brand-specific names).** Cheap today, expensive
+on every onboarding and on every new brand. The cross-brand
+mental switching cost compounds as the digitizer grows; we already
+have a third brand and a fourth (Tokina, per the open epic) is in
+flight.
+
+**Introduce a shared `BasePlotBoxResult` Protocol.** Stronger
+guarantee than convention, but premature. The result dataclasses
+have wildly different optional fields (Fuji has `px_per_mm` and
+`tick_count`; TTartisan has `scheme`; Samyang has `image_size`)
+and no scaffolder treats them polymorphically — each scaffolder
+imports its detector by name. Defer until a 4th brand or a shared
+consumer (e.g. a diagnostic walker) makes the abstraction pay.
+
+**Rename to `panel_box` instead of `plot_box`.** Closer to the
+multi-panel reality but breaks Fuji and TTartisan (which are
+single-panel). `plot_box` is the existing convention in 2/3
+modules; align the third.
+
+## Consequences
+
+- `SamyangBoxes` -> `SamyangBoxResult` (matches Fuji/TTartisan).
+- `SamyangBoxes.max_box` -> `SamyangBoxResult.plot_box`.
+- `SamyangBoxes.f8_box` -> `SamyangBoxResult.stopped_box` — name
+  describes the panel's role (stopped down from MAX), not its
+  f-stop. F8 is still emitted by the scaffolder via
+  `additional_views=(ChartView(..., aperture="F8"),)` per ADR-063;
+  that path is unchanged.
+- `SamyangBoxes.image_size` retained — unique to Samyang and used
+  nowhere downstream yet, but a cheap diagnostic value to keep.
+- New `TTartisanPlotBoxError(RuntimeError)`; the detector raises
+  it instead of bare `ValueError`.
+- `scaffold_samyang_tier2.py` updates to `c.boxes.plot_box` /
+  `c.boxes.stopped_box` and re-runs cleanly with `--write` to
+  regenerate `_samyang_tier2_charts.py` byte-identical (only
+  the underlying field names change; emitted literals stay the
+  same because the scaffolder formats `PlotBoxCoords(...)`).
+- Future brand detectors (Tokina next per epic #790) follow the
+  convention from day one — no rename PR.
+- Fuji is already conformant (`FujiBoxResult.plot_box`); only its
+  error path is non-conformant (no custom error class). Out of
+  scope for this PR — Fuji has not had a detection-failure mode
+  worth catching specifically. Add when the need arises.

--- a/tools/mtfdigitizer/samyang_plotbox.py
+++ b/tools/mtfdigitizer/samyang_plotbox.py
@@ -51,8 +51,14 @@ _F8_TOP_BAND = (570, 585)
 
 
 @dataclass(frozen=True)
-class SamyangBoxes:
+class SamyangBoxResult:
     """Detected plot-box coordinates for both Samyang panels.
+
+    Naming follows ADR-064: the primary panel is ``plot_box``; the
+    secondary panel is ``stopped_box`` (role-based, not f-stop-based).
+    The aperture label for the stopped panel ("F8" today) is supplied
+    by the scaffolder via ``ChartView.aperture`` per ADR-063 — this
+    detector intentionally does not bake the f-number into a field name.
 
     Coordinates use the same convention as the S171 Tier 1 anchors:
     ``y_top`` is the outer plot-rectangle top edge (where the chart's
@@ -60,8 +66,8 @@ class SamyangBoxes:
     gridline row. All coordinates are pixel positions in the source PNG.
     """
 
-    max_box: tuple[int, int, int, int]  # (x_left, x_right, y_top, y_bottom)
-    f8_box: tuple[int, int, int, int]
+    plot_box: tuple[int, int, int, int]  # (x_left, x_right, y_top, y_bottom)
+    stopped_box: tuple[int, int, int, int]
     image_size: tuple[int, int]  # (width, height) of the source PNG
 
 
@@ -96,9 +102,11 @@ def _find_axis_top(
     return int(hits[0] + y_lo)
 
 
-def detect_samyang_plotbox(chart_path: Path) -> SamyangBoxes:
+def detect_samyang_plotbox(chart_path: Path) -> SamyangBoxResult:
     """Detect the MAX and F8 plot boxes for one Samyang chart image.
 
+    Returns ``SamyangBoxResult`` with ``plot_box`` for the primary
+    (MAX-aperture) panel and ``stopped_box`` for the secondary panel.
     Raises ``SamyangPlotBoxError`` if any required signal is missing.
     """
     with Image.open(chart_path) as raw:
@@ -139,10 +147,10 @@ def detect_samyang_plotbox(chart_path: Path) -> SamyangBoxes:
             f"max_top={max_top}, f8_top={f8_top} on column x={x_left}"
         )
 
-    max_box = (x_left, x_right, max_top, max_bot)
-    f8_box = (x_left, x_right, f8_top, f8_bot)
-    return SamyangBoxes(
-        max_box=max_box,
-        f8_box=f8_box,
+    plot_box = (x_left, x_right, max_top, max_bot)
+    stopped_box = (x_left, x_right, f8_top, f8_bot)
+    return SamyangBoxResult(
+        plot_box=plot_box,
+        stopped_box=stopped_box,
         image_size=(width, height),
     )

--- a/tools/mtfdigitizer/scripts/scaffold_samyang_tier2.py
+++ b/tools/mtfdigitizer/scripts/scaffold_samyang_tier2.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mtfdigitizer.samyang_plotbox import (
-    SamyangBoxes,
+    SamyangBoxResult,
     detect_samyang_plotbox,
 )
 
@@ -96,7 +96,7 @@ class _ChartFile:
     slug: str
     path: Path  # relative to repo root
     image_height_mm: float
-    boxes: SamyangBoxes
+    boxes: SamyangBoxResult
 
 
 def _gather_charts() -> list[_ChartFile]:
@@ -172,12 +172,12 @@ def _format_lens_entry(c: _ChartFile) -> str:
         "        frequencies_lpmm=(10, 30),\n"
         f"        image_height_mm={c.image_height_mm},\n"
         f'        notes=(\n            "{notes}"\n        ),\n'
-        f"        plot_box={_box_repr(c.boxes.max_box)},\n"
+        f"        plot_box={_box_repr(c.boxes.plot_box)},\n"
         "        ground_truth=None,\n"
         "        additional_views=(\n"
         "            ChartView(\n"
         f'                chart_path="{chart_lit}",\n'
-        f"                plot_box={_box_repr(c.boxes.f8_box)},\n"
+        f"                plot_box={_box_repr(c.boxes.stopped_box)},\n"
         '                aperture="F8",\n'
         "            ),\n"
         "        ),\n"

--- a/tools/mtfdigitizer/ttartisan_plotbox.py
+++ b/tools/mtfdigitizer/ttartisan_plotbox.py
@@ -46,6 +46,15 @@ class TTartisanBoxResult:
     notes: tuple[str, ...]
 
 
+class TTartisanPlotBoxError(RuntimeError):
+    """Raised when a TTartisan chart's plot box cannot be detected.
+
+    Per ADR-064 every brand detector raises a brand-specific subclass
+    of RuntimeError on detection failure, so the failure mode is loud
+    and identifies the brand without parsing the message.
+    """
+
+
 # Verified-by-eye plot-box convention for the 800x600 TTartisan
 # template. The pixel auto-detection drifts ±2 px across the 19-chart
 # survey; the hand-verified constants below ship with the scaffolder
@@ -98,7 +107,7 @@ def _label_cluster_widths(gray: np.ndarray, y_bottom: int, x_max: int) -> list[i
 def _detect_scheme(widths: list[int]) -> str:
     """Classify the chart as APS-C (2 two-digit labels) or GFX (3)."""
     if len(widths) != 5:
-        raise ValueError(
+        raise TTartisanPlotBoxError(
             f"expected 5 x-axis label clusters, found {len(widths)}; "
             f"chart does not match the known TTartisan template"
         )
@@ -107,7 +116,7 @@ def _detect_scheme(widths: list[int]) -> str:
         return "aps-c"
     if two_digit == 3:
         return "gfx-or-ff"
-    raise ValueError(
+    raise TTartisanPlotBoxError(
         f"could not classify chart: {two_digit} two-digit labels in {widths}"
     )
 


### PR DESCRIPTION
## Summary

ADR-064 formalizes the plot-box detector contract across brands. Samyang's names diverged from Fuji/TTartisan as it was added in S171; align them now while the cost is small (3 source files, no behavior change).

## Changes

- **ADR-064** — cross-brand plot-box detector naming convention
- `SamyangBoxes` → `SamyangBoxResult` (matches `FujiBoxResult` / `TTartisanBoxResult`)
- `SamyangBoxResult.max_box` → `.plot_box` (matches cross-brand primary-box name)
- `SamyangBoxResult.f8_box` → `.stopped_box` — role-based, not f-stop-based. F8 is still emitted by the scaffolder via `additional_views=(ChartView(..., aperture=\"F8\"),)` per ADR-063; that path is unchanged.
- New `TTartisanPlotBoxError(RuntimeError)` — detector raises it instead of bare `ValueError`
- Scaffolder updated; regenerated `_samyang_tier2_charts.py` is byte-identical

## Out of scope

- Shared `BasePlotBoxResult` Protocol — premature; deferred until a 4th brand or a polymorphic consumer (ADR §Alternatives)
- Fuji error class — Fuji has no detection-failure mode worth catching specifically yet (ADR §Consequences)

## Test plan

- [x] `py -m pytest mtfdigitizer/tests/` — 401 passed (same as baseline)
- [x] `npm run validate` — green
- [x] `py -m mtfdigitizer.scripts.scaffold_samyang_tier2 --write` produces byte-identical `_samyang_tier2_charts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)