### PR TITLE
fix(mtf): intra-curve interp guards sister fallback at mid-field (#1254)

### DIFF
--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -137,6 +137,57 @@ def _ink_presence_per_field(
     return out
 
 
+def _replace_sister_fills_with_intra_interp(
+    samples: dict[str, tuple[float | None, ...]],
+    sister_filled: dict[str, tuple[bool, ...]],
+) -> tuple[dict[str, tuple[float | None, ...]], dict[str, int]]:
+    """Replace single-column sister-filled cells with intra-curve interp.
+
+    Sister fallback assumes S and M track each other when one has a gap
+    — true near the optical axis (B4), often true near the field edge,
+    but false at mid-field where S and M can legitimately diverge by
+    0.2+ MTF (Samyang 85mm stopped 30S flat at 0.97 while 30M sweeps
+    0.95->0.55, see #1254). Continuity within a single optical curve is
+    a stronger prior than S~=M off-axis.
+
+    Runs AFTER sister fallback so we know exactly which cells it filled.
+    For each sister-filled cell, if both neighbours i-1 and i+1 are
+    present AND were NOT themselves sister-filled, linearly interpolate
+    the field's own value at i — overriding sister fallback's diverging
+    copy.
+
+    Conservatism (do not interpolate across):
+    - edge samples (i=0 or i=last) — no two-sided neighbour
+    - multi-cell sister-filled runs — interpolating across a run propagates
+      sister-fill error; the gap is genuinely too wide for intra-curve
+      to help
+    - center symmetry — runs after this pass and re-asserts S=M at frac 0,
+      so we never touch i=0 anyway
+
+    Returns ``(samples, intra_fill_count_by_field)``.
+    """
+    out: dict[str, tuple[float | None, ...]] = {}
+    intra_count: dict[str, int] = {}
+    for field, values in samples.items():
+        fills = sister_filled.get(field, (False,) * len(values))
+        fixed: list[float | None] = list(values)
+        count = 0
+        for i in range(1, len(values) - 1):
+            if not fills[i]:
+                continue
+            if fills[i - 1] or fills[i + 1]:
+                continue
+            prev_v = values[i - 1]
+            next_v = values[i + 1]
+            if prev_v is None or next_v is None:
+                continue
+            fixed[i] = (prev_v + next_v) / 2.0
+            count += 1
+        out[field] = tuple(fixed)
+        intra_count[field] = count
+    return out, intra_count
+
+
 def _apply_sister_fallback(
     samples: dict[str, tuple[float | None, ...]],
     presence: dict[str, tuple[bool, ...]],
@@ -170,40 +221,50 @@ def _apply_sister_fallback(
     frac=1.0). Default False preserves historical behaviour for
     profiles whose presence mask is a coarse per-hue raw signal.
 
-    Returns ``(samples, fallback_count_by_field)``. The counter records
-    how many of a field's 11 samples were filled from the sister curve
-    via either trigger; samples that stayed `None` because both curves
-    lacked data do not count as fallbacks.
+    Returns ``(samples, fallback_count_by_field, sister_filled_by_field)``.
+    The counter records how many of a field's 11 samples were filled
+    from the sister curve via either trigger; samples that stayed
+    `None` because both curves lacked data do not count as fallbacks.
+    The per-cell boolean tuple flags which cells came from the sister
+    (vs. the field's own sampler) so a downstream pass can intervene
+    on the diverging-curve case (#1254).
     """
     out: dict[str, tuple[float | None, ...]] = {}
     fallback_count: dict[str, int] = {}
+    sister_filled: dict[str, tuple[bool, ...]] = {}
     for field, values in samples.items():
         sister = _sister_of(field)
         sister_values = samples.get(sister, (None,) * len(SAMPLE_FRACTIONS)) if sister else (None,) * len(SAMPLE_FRACTIONS)
         field_presence = presence.get(field, (False,) * len(SAMPLE_FRACTIONS))
         sister_presence = presence.get(sister, (False,) * len(SAMPLE_FRACTIONS)) if sister else (False,) * len(SAMPLE_FRACTIONS)
         fixed: list[float | None] = []
+        filled_flags: list[bool] = []
         count = 0
         for i, v in enumerate(values):
             if v is None and sister_values[i] is not None and field_presence[i]:
                 # Sampler-None trigger (see docstring).
                 fixed.append(sister_values[i])
+                filled_flags.append(True)
                 count += 1
             elif field_presence[i]:
                 fixed.append(v)
+                filled_flags.append(False)
             elif sister_presence[i] and not presence_is_authoritative:
                 # Sister has real ink here; trust it over our drifted value.
                 # Suppressed when presence is authoritative — the trim's
                 # field_presence=False verdict overrides sister-has-ink.
                 fixed.append(sister_values[i])
+                filled_flags.append(True)
                 count += 1
             else:
                 # Neither curve has ink — keep whatever the DP path
                 # interpolated (or None if the curve was missing entirely).
                 fixed.append(v)
+                filled_flags.append(False)
         out[field] = tuple(fixed)
         fallback_count[field] = count
-    return out, fallback_count
+        sister_filled[field] = tuple(filled_flags)
+    return out, fallback_count, sister_filled
 
 
 def _apply_center_symmetry(
@@ -479,10 +540,23 @@ def extract_chart(
         and profile.hue_meaning == "GEODESIC_DP"
     )
     fallback_count: dict[str, int] = {}
+    sister_filled: dict[str, tuple[bool, ...]] = {}
     if presence:
-        samples_per_field, fallback_count = _apply_sister_fallback(
+        samples_per_field, fallback_count, sister_filled = _apply_sister_fallback(
             samples_per_field, presence,
             presence_is_authoritative=presence_authoritative,
+        )
+    # Intra-curve interpolation pass (#1254): for single-column sister-
+    # filled cells whose neighbours are NOT sister-filled, interpolate
+    # within the field's own curve. Sister fallback's S~=M assumption
+    # fails at mid-field when S and M diverge by 0.2+ MTF (Samyang 85mm
+    # stopped 30S flat at 0.97 while 30M sweeps 0.95->0.55); continuity
+    # within one optical curve is the stronger prior.
+    if sister_filled:
+        samples_per_field, intra_interp_count = (
+            _replace_sister_fills_with_intra_interp(
+                samples_per_field, sister_filled,
+            )
         )
     samples_after_fallback = {f: v for f, v in samples_per_field.items()}
     samples_per_field = _apply_center_symmetry(samples_per_field)

--- a/tools/mtfdigitizer/tests/test_pipeline.py
+++ b/tools/mtfdigitizer/tests/test_pipeline.py
@@ -63,6 +63,26 @@ SIGMA_56_CHART, SIGMA_56_PLOT_BOX, _ = _ref("sigma-56mm-f1-4-dc-dn-c")
 SAMYANG_85_CHART, SAMYANG_85_MAX_PLOT_BOX, _ = _ref("samyang-85mm-f1-4-as-if-umc")
 
 
+def _ref_view_plot_box(slug: str, view_idx: int) -> PlotBox:
+    """Pull the plot box for a specific view of a multi-view anchor.
+
+    Samyang charts stack two apertures (max + stopped) in one PNG; each
+    view has its own plot box. View 0 == max, view 1 == stopped.
+    """
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == slug)
+    box = chart.views[view_idx].plot_box
+    assert box is not None, f"{slug} view {view_idx}: no plot_box"
+    return PlotBox(
+        x_left=box.x_left, x_right=box.x_right,
+        y_top=box.y_top, y_bottom=box.y_bottom,
+    )
+
+
+SAMYANG_85_STOPPED_PLOT_BOX = _ref_view_plot_box(
+    "samyang-85mm-f1-4-as-if-umc", 1,
+)
+
+
 # --- Acceptance: 11 fixed points ------------------------------------------
 
 
@@ -149,6 +169,73 @@ def test_b2_returns_none_when_skeleton_has_no_data_at_target() -> None:
         assert sample_skeleton_at_fraction(empty, fraction, plot_box) is None
 
 
+def test_intra_curve_interp_replaces_single_sister_fill_with_neighbour_mean() -> None:
+    """#1254 — for a sister-filled cell whose neighbours are present and
+    NOT sister-filled, the intra-curve interp post-pass replaces the
+    cross-curve copy with the linear mean of the field's own neighbours.
+    Continuity within one optical curve is a stronger prior than S=~M
+    off-axis."""
+    from mtfdigitizer.pipeline.pipeline import (
+        _replace_sister_fills_with_intra_interp,
+    )
+
+    # 11 cells; index 5 was sister-filled with a diverging value (0.74)
+    # while the field's own neighbours hold ~0.96.
+    samples = {
+        "freq30S": (0.96, 0.96, 0.97, 0.97, 0.97, 0.74, 0.96, 0.96, 0.95, 0.93, 0.92),
+    }
+    sister_filled = {
+        "freq30S": (False, False, False, False, False, True, False, False, False, False, False),
+    }
+    out, count = _replace_sister_fills_with_intra_interp(samples, sister_filled)
+    assert count["freq30S"] == 1
+    assert out["freq30S"][5] == pytest.approx(0.965), (
+        f"sister-filled cell at i=5 should become mean(0.97, 0.96)=0.965, "
+        f"got {out['freq30S'][5]}"
+    )
+    # Non-sister-filled cells must not be touched.
+    assert out["freq30S"][:5] == samples["freq30S"][:5]
+    assert out["freq30S"][6:] == samples["freq30S"][6:]
+
+
+def test_intra_curve_interp_skips_adjacent_sister_fills() -> None:
+    """#1254 — when sister-filled cells run consecutively (i and i+1 both
+    filled), do NOT interpolate either one. Interpolating across a run
+    propagates the sister-fill error to its neighbours; the gap is too
+    wide for intra-curve continuity to help, and the existing sister
+    fallback is the right answer at that point."""
+    from mtfdigitizer.pipeline.pipeline import (
+        _replace_sister_fills_with_intra_interp,
+    )
+
+    samples = {
+        "freq30S": (0.96, 0.96, 0.97, 0.97, 0.74, 0.73, 0.96, 0.96, 0.95, 0.93, 0.92),
+    }
+    sister_filled = {
+        "freq30S": (False, False, False, False, True, True, False, False, False, False, False),
+    }
+    out, count = _replace_sister_fills_with_intra_interp(samples, sister_filled)
+    assert count["freq30S"] == 0
+    assert out["freq30S"] == samples["freq30S"]
+
+
+def test_intra_curve_interp_skips_edge_cells() -> None:
+    """#1254 — cells at index 0 and the last index have only one neighbour
+    and cannot be safely interpolated; leave them to sister fallback (or
+    None) regardless of the sister-fill flag. Center symmetry handles
+    index 0 separately downstream."""
+    from mtfdigitizer.pipeline.pipeline import (
+        _replace_sister_fills_with_intra_interp,
+    )
+
+    n = 11
+    samples = {"freq30S": (0.50,) + (0.96,) * (n - 2) + (0.50,)}
+    sister_filled = {"freq30S": (True,) + (False,) * (n - 2) + (True,)}
+    out, count = _replace_sister_fills_with_intra_interp(samples, sister_filled)
+    assert count["freq30S"] == 0
+    assert out["freq30S"] == samples["freq30S"]
+
+
 def test_sigma_dashed_M_curves_fully_covered_by_dp_bridging() -> None:
     """Under (SPLIT_BY_DASH, GEODESIC_DP) the dashed M curves are bridged
     end to end: the DP smoothness prior carries a continuous path across
@@ -219,6 +306,37 @@ def test_samyang_85_10S_knees_down_at_edge() -> None:
     # "drops sharply from ~0.91 center to ~0.78 edge", not exact value.
     assert edge.samples.get("freq10S") < 0.85, (
         f"10S edge should drop below 0.85, got {edge.samples.get("freq10S"):.3f}"
+    )
+
+
+def test_samyang_85_stopped_30S_no_sister_fill_spikes_mid_field() -> None:
+    """#1254 regression — on the 85mm stopped panel, the 30S skeleton has
+    single-column gaps at frac 0.6 and 0.8. Before the intra-curve interp
+    post-pass, sister fallback copied 30M's value at those columns
+    (~0.74, ~0.73), producing 0.226 / 0.222 spikes against EYE values of
+    0.97 / 0.95 — because 30S and 30M legitimately diverge by ~0.2 MTF
+    mid-field on this panel (30S flat ~0.97, 30M sweeps 0.95->0.55). The
+    intra-curve interpolation pass replaces those sister-filled cells
+    with the linear mean of the field's own neighbours. Lock both
+    affected cells within tolerance so a future change to sister-fallback
+    cannot silently re-introduce the spikes."""
+    result = extract_chart(
+        SAMYANG_85_CHART,
+        SAMYANG_4COLOR_ALL_SOLID,
+        SAMYANG_85_STOPPED_PLOT_BOX,
+        image_height_mm=21.6,
+    )
+    frac_06 = result.readings[6].samples.get("freq30S")
+    frac_08 = result.readings[8].samples.get("freq30S")
+    assert frac_06 is not None, "30S at frac 0.6 must read a value (#1254)"
+    assert frac_08 is not None, "30S at frac 0.8 must read a value (#1254)"
+    assert 0.92 <= frac_06 <= 1.0, (
+        f"30S at frac 0.6: expected ~0.97 (EYE), got {frac_06:.3f} — "
+        f"value near 0.74 means sister fallback re-took mid-field (#1254)"
+    )
+    assert 0.90 <= frac_08 <= 1.0, (
+        f"30S at frac 0.8: expected ~0.95 (EYE), got {frac_08:.3f} — "
+        f"value near 0.73 means sister fallback re-took mid-field (#1254)"
     )
 
 


### PR DESCRIPTION
## Summary

Closes #1254. Unblocks #1252.

Adds an intra-curve interpolation pass after sister fallback that replaces sister-filled cells with the linear mean of the field's own neighbours when those neighbours are present and not themselves sister-filled. Sister fallback's S~=M assumption is correct near the optical axis (B4) and often correct near the field edge, but fails at mid-field where S and M can legitimately diverge by 0.2+ MTF.

## Bug

On \`samyang-85mm-f1-4-as-if-umc\` stopped panel, the freq30S skeleton has single-column gaps at frac 0.6 and 0.8. The sampler returns \`None\`; sister fallback copies 30M's value (~0.74); but the true 30S curve sits flat at ~0.97 across this panel while 30M sweeps 0.95->0.55. Two spikes of \`|Δ|\` = 0.226 / 0.222 against EYE 0.97 / 0.95.

A/B test confirmed ADR-062's 30S->30M halo pair is **not** the cause — toggling it changes nothing on this panel. Skeleton gaps pre-date ADR-062. See #1254 for the full investigation transcript.

## Fix

\`_replace_sister_fills_with_intra_interp\` runs after sister fallback. For each sister-filled cell:

- if both i-1 and i+1 are present AND were NOT themselves sister-filled, replace the cross-curve copy with \`(prev + next) / 2\`
- otherwise leave the sister-filled value as-is

Conservative — skips edge cells (no two-sided neighbour) and adjacent sister-fill runs (genuine multi-cell gap; intra-curve interpolation cannot help there and would propagate sister-fill error).

\`_apply_sister_fallback\` now returns a third value: \`sister_filled\` per-cell bool tuple so the post-pass can target only sister-filled cells without re-deriving that information.

## Verification

Calibration aggregate (16-chart reference set):

| Metric | Before | After | Delta |
|---|---|---|---|
| paired comparisons | 872 | 872 | unchanged |
| median \|d\| | 0.0066 | 0.0066 | unchanged |
| p95 \|d\| | 0.0463 | 0.0454 | **-0.0009** |
| max \|d\| | 0.2265 | 0.1217 | **-0.1048** |
| in-band % | 96.0% | 96.2% | **+0.2pp** |

S175-noted regression (max-\|d\| 0.1745 -> 0.2265) is reversed and surpassed.

85mm anchor — stopped panel freq30S:

| frac | EYE | EX before | EX after | Δ before | Δ after |
|---|---|---|---|---|---|
| 0.6 | 0.97 | 0.744 | 0.965 | 0.226 | **0.005** |
| 0.7 | 0.96 | 0.964 | 0.964 | 0.004 | 0.004 |
| 0.8 | 0.95 | 0.728 | 0.962 | 0.222 | **0.012** |

No regression on 85mm MAX panel or any other anchor.

## Tests

Four new tests in \`test_pipeline.py\`:

- \`test_samyang_85_stopped_30S_no_sister_fill_spikes_mid_field\` — end-to-end regression on the real anchor, locks frac 0.6 and 0.8 in tolerance bands
- \`test_intra_curve_interp_replaces_single_sister_fill_with_neighbour_mean\` — unit, happy path
- \`test_intra_curve_interp_skips_adjacent_sister_fills\` — unit, run guard
- \`test_intra_curve_interp_skips_edge_cells\` — unit, edge guard

Full \`py -m pytest mtfdigitizer\` suite passed (exit 0).

## Test plan

- [ ] CI green
- [ ] \`py -m mtfdigitizer.calibrate\` shows max \|d\| ≤ 0.13, in-band ≥ 96%
- [ ] \`py -m pytest mtfdigitizer\` passes
- [ ] Re-extracted 50mm f/1.2 stopped overlay (visually inspected during dev) — blue solid line no longer jumps at 5/10mm; smooth descent

## Out of scope

- Re-extraction of the 6 defective Tier 2 Samyangs (#1252). Done as a follow-up bulk regen to keep diff focused.
- The two missing-artifact lenses (85mm f/1.4 stopped, 300mm f/6.3 reflex stopped) — separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)