### PR TITLE
docs(mtf): flag samyang-85mm M-curve shape limitation (#1282)

### DIFF
--- a/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/analysis.md
+++ b/docs/optical-specs/samyang-85mm-f1-4-as-if-umc/analysis.md
@@ -37,3 +37,7 @@ S/M divergence at 30 lp/mm:
 FF lens. 10 lp/mm: M rises above S at edge (crossing). 30 lp/mm: both drop with moderate gap. At f/8: heavy divergence at FF edge. LensTip lab measured 10.4% (1.0).
 
 **Score: 1.0 (moderate-heavy; lab data: 1.0 -- consistent)**
+
+## Known extraction limitation (#1282)
+
+The digitized M curves in the shipped SVG follow the wrong shape in the mid-field on the MAX panel: gold dashed freq10M tracks red S10 from ~0-15mm before jumping to actual pink at the edge; blue dashed freq30M traces the dark-grey S30 dip-and-recover at ~7-15mm instead of the smooth light-grey M30 descent. Mechanism is halo subtraction (ADR-059, ADR-062) erasing legitimate M pixels where S/M overlap vertically, with sister fallback copying S values. All 22 paired calibration cells stay within ±0.05 tolerance because the coarse 11-point sampling happens to land where S/M magnitudes are numerically close. Tracked in #1282.

--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -78,6 +78,22 @@ SAMYANG_4COLOR_ALL_SOLID: MtfProfile = MtfProfile(
     # tolerance because their 30S curves stay above 0.85 (85mm) or 0.95
     # (300mm reflex) across the field, keeping the halo outside the
     # 30M band's spatial overlap with the real 30M curve.
+    #
+    # KNOWN SHAPE LIMITATION (#1282): the "stays within tolerance" claim
+    # above is true cell-by-cell but masks a shape error on samyang-85mm.
+    # The 30S dip to ~0.57 around frac 0.5-0.6 IS inside the 30M band's
+    # vertical overlap; halo subtraction erases legitimate light-grey
+    # pixels there, the 30M skeleton goes blank, sister fallback copies
+    # 30S values, and the extracted 30M *contour* mimics 30S's dip-and-
+    # recover instead of the chart's smooth light-grey descent. Same
+    # mechanism on 10M-pink: pink sits visually adjacent to red S10
+    # for ~half the field, halo subtraction erases the legitimate pink
+    # skeleton, sister-fill copies red values. All 22 paired cells
+    # remain within the ±0.05 calibration band because at the coarse
+    # 11-point SAMPLE_FRACTIONS the S/M curves happen to be numerically
+    # close in those frac slots — the snake is invisible to the gate.
+    # See #1282 for the architectural decision (tighten subtraction vs
+    # densify sampling vs side-channel shape probe vs accept).
     halo_pairs=(
         ("10S-red", "10M-pink"),
         ("30S-dark-grey", "30M-light-grey"),


### PR DESCRIPTION
## Summary

- Extends the \`samyang-4color-all-solid\` profile docstring to acknowledge that the 85mm Tier 1 anchor's M curves are sister-influenced where S/M overlap, even though all 22 paired cells stay within ±0.05.
- Adds a parallel \"Known extraction limitation\" note to \`analysis.md\` so the limitation is discoverable from both the code-side (profile reader) and the lens-side (analysis reader).
- No behavior change; tracking the architectural decision in #1282.

## Why

The existing docstring claimed the 85mm anchor was safe because its 30S stays above 0.85. The claim is wrong: 30S dips to ~0.57 around frac 0.5-0.6, which is exactly where halo subtraction (ADR-062) erases legitimate 30M-light-grey pixels and sister-fill copies the 30S dip into the M extraction. The 10S→10M case (ADR-059) shows the same pattern. Calibration is blind to it because at coarse 11-point SAMPLE_FRACTIONS the magnitudes happen to align within tolerance.

## Test plan

- [x] \`py -m pytest mtfdigitizer/tests/test_profiles.py\` — 22 passed
- [x] No runtime change (docstring + analysis.md only)
- [x] Issue #1282 opened to track the architectural decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)