### PR TITLE
docs(playbook): require readings dump for shape-error spike intake (ADR-071)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -242,6 +242,18 @@ run that changes the numbers materially. Reference the calibration entries
 when discussing the ADR-038 offset tolerance band or the 0.75 render-match
 threshold.
 
+**Shape-error spike intake (ADR-071 prevention).** Any spike that describes
+a shape error on a reference-set lens (curves tracking each other,
+dip-and-recover, sister-fill misfires) MUST run
+`py -m mtfdigitizer.calibrate --write-readings` and verify the diagnosis
+against the per-frac `GT | EX | Δ` grid in
+`tools/mtfdigitizer/referenceset/readings/<slug>.md` BEFORE the spike is
+treated as actionable. Visual inspection of the overlay PNG is a useful
+diagnostic but not authoritative — two legitimately near-coincident GT
+curves can look like a tracking error to the eye. The readings dump is the
+authoritative signal and would have refuted spike #1282 at intake. See
+ADR-071 for the worked example and post-mortem.
+
 **Run the MTF digitizer production extractor (Tier 2 per ADR-041):**
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a "Shape-error spike intake" rule next to the MTF digitizer calibration runner block in PLAYBOOK §2.7.
- Any spike describing a shape error on a reference-set lens MUST run `py -m mtfdigitizer.calibrate --write-readings` and verify against the per-frac `GT | EX | Δ` grid before the spike is treated as actionable.
- Locks in the ADR-071 prevention action — would have refuted spike #1282 at intake last session.

## Why now
ADR-071 (this PR's antecedent) names this PLAYBOOK update as the explicit prevention action, deferred from #1288 to keep that PR's scope focused on the supersession itself.

## Out of scope
- Pre-existing Prettier format drift in `docs/dev-journal.md` filed as #1290. Not related to this change.

## Test plan
- [x] `prettier --check docs/PLAYBOOK.md` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — 462 pages built
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)