### PR TITLE
fix(mtfdigitizer): center anchor uses freq{lo}{D} when available (#1279)

### DIFF
--- a/docs/decisions/072-center-anchor-lo-when-available.md
+++ b/docs/decisions/072-center-anchor-lo-when-available.md
@@ -1,0 +1,271 @@
+# ADR-072: Center anchor uses freq{lo}{D} when available
+
+**Status:** Accepted
+**Date:** 2026-06-24
+
+## Prerequisites
+
+This ADR refines **ADR-066 (center-axis physics anchor at frac=0.0,
+S=M=1.0)**. ADR-066 fires when both `freq{N}S[0]` and `freq{N}M[0]`
+are None after sister fallback + intra-curve interpolation + coincident-
+top anchor, and slams both cells to MTF=1.0 on the B4 physics premise
+that the diffraction-free chart's optical-axis MTF is 1.0.
+
+It also depends on **ADR-068 / ADR-069 (coincident-top anchor)** for
+the same-direction lower-frequency copy mechanism — this ADR extends
+the same mechanism to a case where ADR-068/069's pair gate has vetoed.
+
+## Context
+
+`viltrox-af-75mm-f1-2-pro` f/1.2 (the Tier 1 anchor refreshed in
+PR #1278) publishes a chart whose `freq30S` and `freq30M` curves sit
+visibly below MTF=1.0 at the optical axis — eye-read GT records
+`freq30S[0] = 0.93` and `freq30M[0] = 0.92`. The lens is a fast prime
+with notable spherical aberration at f/1.2; the chart artist drew
+the high-frequency curves at their true centre values, not anchored
+to chart top.
+
+On this chart:
+
+- `freq10S` and `freq10M` extract at MTF ~0.99 at center (correct
+  against GT 1.00 within 0.01).
+- `freq30S` and `freq30M` skeletons miss the leftmost columns (both
+  buried under the brighter freq10 strokes, similar mechanism to
+  samyang-10mm stopped per ADR-066's diagnostic).
+- The ADR-068/069 coincident-top anchor's pair gate (`min |hi - lo|
+on clean cells where lo >= 0.90`) measures `|0.90 - 0.99| = 0.09`
+  at frac 0.4 and similar gaps at frac 0.3 and 0.6 — every clean
+  pair-cell has `|hi - lo| > 0.05`. The gate correctly identifies
+  this as a chart where `freq30S` does NOT track `freq10S` at chart
+  top, and vetoes the `(freq30S, freq10S)` pair (same for M).
+- ADR-066 then fires unconditionally on the remaining "both None"
+  state and slams `freq30S[0] = freq30M[0] = 1.0`.
+
+The result:
+
+```
+freq30S at frac=0.0:  EYE=0.93, EX=1.00, |Δ|=0.070  (over ±0.05 band)
+freq30M at frac=0.0:  EYE=0.92, EX=1.00, |Δ|=0.080  (over ±0.05 band)
+```
+
+This was previously masked: before PR #1268 (ADR-066) the cells
+stayed None and the log printed `—` for EX so no Δ was computed.
+PR #1278 refreshing the Tier 1 log surfaced the regression.
+
+### Physical invariant violation
+
+ADR-066's 1.0 anchor violates a strict physical invariant when
+`freq{lo}{D}` extracts below 1.0 at center:
+
+- **Physics:** MTF is monotonically non-increasing in spatial
+  frequency. `freq30S[f] <= freq10S[f]` at every frac, including
+  frac=0.0.
+- **Observed:** `freq10S[0] = 0.99` (extracted), `freq30S[0] = 1.00`
+  (ADR-066 anchor). `1.00 > 0.99` — physically impossible.
+
+ADR-069 already encodes this argument for the non-None case. From
+ADR-069 §"Per-cell decision":
+
+> `freq{lo}{D}` on the 300mm reflex extracts at ~0.985 at center
+> due to raster snap to the nearest pixel row. If ADR-066 fires for
+> the high-freq curve while the low-freq sits at 0.985, then
+> `freq30S = 1.0 > freq10S = 0.985` — physically impossible (MTF is
+> monotonically non-increasing in frequency).
+
+The same argument applies when ADR-066 reaches the "both None" case
+because ADR-069's pair gate vetoed. The gate's veto says "do not
+trust hi to track lo across the field" — it does NOT say "physics
+no longer constrains hi to lie at or below lo at the single optical-
+axis cell". Physics still bounds `hi <= lo` at frac=0.0.
+
+## Decision
+
+Extend `_apply_center_symmetry` in
+`tools/mtfdigitizer/pipeline/pipeline.py`'s "both None" branch (ADR-066,
+case 3) with a same-direction lower-frequency lookup:
+
+1. When both `freq{N}S[0]` and `freq{N}M[0]` are None at frac=0.0,
+   look up the closest lower frequency `freq{lo}{S}[0]` and
+   `freq{lo}{M}[0]`.
+2. If either lower-freq same-direction cell carries a value, anchor
+   the higher-freq cell to that value:
+   - `freq{N}S[0] = freq{lo}{S}[0]` if not None, else `freq{lo}{M}[0]`,
+     else 1.0
+   - `freq{N}M[0] = freq{lo}{M}[0]` if not None, else `freq{lo}{S}[0]`,
+     else 1.0
+3. If no lower frequency exists in the chart, or both lower-freq cells
+   are also None, fall back to ADR-066's original 1.0 anchor.
+
+```
+                         +--- ADR-069: coincident-top anchor ---+
+                         |    (vetoed on viltrox-75 by gate)    |
+                         v                                      |
+direct ---> sister --> intra-interp --> coincident-top ---> center-symmetry
+extract     fallback   (#1254)         (ADR-068/069)       (ADR-066+ADR-072)
+                                                            "both None":
+                                                            1) try freq{lo}{D}[0]
+                                                            2) try freq{lo}{!D}[0]
+                                                            3) fall back to 1.0
+```
+
+The new lookup runs before the 1.0 anchor, so:
+
+- On viltrox-75: `freq30S[0] = freq10S[0] = 0.99`, `freq30M[0] =
+freq10M[0] = 0.99`. Restores `hi <= lo`. Reduces Δ on freq30S from
+  0.070 to ~0.060 and on freq30M from 0.080 to ~0.070. Still over
+  the ±0.05 band — see Consequences.
+- On samyang-10mm stopped (an ADR-066-designed lens with `freq10S[0]
+= freq10M[0] = 0.99` extracted, GT 1.00): `freq30S[0] = 0.99`
+  instead of 1.0. Slight regression against GT (|Δ| 0.00 → 0.01,
+  still well inside the band). Restores `hi <= lo`.
+- On samyang-af-12mm stopped (where `freq10S[0]` and `freq10M[0]` are
+  themselves None at center, then ADR-066 anchors them to 1.0 in a
+  prior loop iteration): when the freq10 pair runs first, it gets
+  anchored to 1.0; when freq30 runs second, lo=1.0 is available and
+  freq30 gets anchored to 1.0. Identical behaviour to current code.
+  This holds because `_apply_center_symmetry` iterates by S-field
+  and mutates `out` in place — later iterations see prior
+  anchorings. No ordering guarantee is needed beyond what the
+  function already provides: lower frequencies are processed before
+  higher within a freq pair, but across pairs the iteration order
+  follows the input dict (insertion order). The fallback chain is
+  designed to be order-independent: any prior anchor leaves a usable
+  value behind.
+- On samyang-300mm reflex (ADR-069 anchor fires before ADR-066):
+  freq30 is already non-None by the time `_apply_center_symmetry`
+  runs. Both-None case never reached. Unchanged.
+
+### Per-cell decision
+
+```python
+if s_val is None and m_val is None:
+    freq_n = int(s_field[4:-1])
+    lower = _closest_lower_freq(out, freq_n)
+    if lower is None:
+        out[s_field][0] = _CENTER_AXIS_MTF
+        out[m_field][0] = _CENTER_AXIS_MTF
+    else:
+        lo_s = out[f"freq{lower}S"][0]
+        lo_m = out[f"freq{lower}M"][0]
+        out[s_field][0] = lo_s if lo_s is not None else (
+            lo_m if lo_m is not None else _CENTER_AXIS_MTF
+        )
+        out[m_field][0] = lo_m if lo_m is not None else (
+            lo_s if lo_s is not None else _CENTER_AXIS_MTF
+        )
+    anchor_count[s_field] += 1
+    anchor_count[m_field] += 1
+```
+
+### Why this is the right level for the rule
+
+The ADR-068/069 pair gate veto is intentionally local to the coincident-
+top anchor's domain (multi-cell copy of lo into hi across the field).
+It encodes "do not assume hi tracks lo wherever lo is at chart top".
+
+At the single frac=0.0 cell, the relevant constraint is not "does hi
+track lo across the field" but "is `hi <= lo` at this one cell". The
+latter is a strict physical invariant that holds regardless of the
+gate's verdict. So ADR-072 firing here is not a circumvention of the
+gate — it is using the gate's lo-value evidence (`lo extracts at 0.99`)
+at the one cell where physics gives a tight bound.
+
+A useful framing: ADR-066's 1.0 constant was a _prior_ applied when no
+data was available. The lower-freq value is _data_, and data should
+displace prior whenever it is available, regardless of upstream gating
+verdicts that govern other domains.
+
+## Alternatives considered
+
+1. **Path 1 (issue #1279 §"Possible fix paths" option 1): Gate ADR-066's
+   "both None" case on `freq{lo}{D}[0] >= 0.95`.** Rejected. The viltrox-75
+   case has `freq{lo}{D}[0] = 0.99` (passes the gate), so this change
+   does not affect the bug. Adding a precondition without changing the
+   anchor value would only affect lenses where lo extracts well below
+   0.95 at center — a different class of failure (lo also lost), where
+   anchoring to lo would be wrong but anchoring to 1.0 is also wrong.
+   For that class, the right answer is to leave the cell None; this ADR
+   does not address it.
+
+2. **Path 3 (issue #1279 §"Possible fix paths" option 3): Accept the
+   overshoot.** Rejected. Leaving `freq30 = 1.0 > freq10 = 0.99` is a
+   physical-invariant violation in committed log data. The 0.07/0.08
+   deltas are visible in the Tier 1 anchor log and will show up in any
+   future calibration aggregate.
+
+3. **Path 4: Bypass ADR-066's "both None" when ADR-069's pair gate
+   vetoed for that pair.** Rejected. The pair-gate veto is not exposed
+   to `_apply_center_symmetry` (it lives inside
+   `_apply_coincident_top_anchor`), so this would require a new
+   communication channel between the two passes. It also produces a
+   worse outcome: the freq30 cells stay None and the SVG re-introduces
+   the visible y-axis gap that #1267 fixed.
+
+4. **Path 5: Cap ADR-066's anchor by lo: `out[s_field][0] = min(1.0,
+lo_value)`.** Effectively equivalent to this ADR but loses the
+   fallback chain for the `lo is None` case. Less explicit; chose the
+   path-2 phrasing for readability.
+
+5. **Cross-direction fallback (`lo_s` -> `lo_m` -> 1.0).** Included in
+   the per-cell decision above as the second tier of the fallback chain.
+   The cross-direction copy is the same fallback ADR-066 already does
+   in cases 1 and 2 of `_apply_center_symmetry` (copy S to M or M to S
+   when one side is None). Same physics: S=M at the optical axis by B4.
+
+6. **Pre-anchor freq10 before iterating freq30.** Considered to remove
+   any ordering subtlety. Rejected: the existing in-place mutation of
+   `out` already gives this for free; an explicit ordering pass adds
+   code without changing behaviour.
+
+## Consequences
+
+### Positive
+
+- Restores the physical invariant `freq{hi}{D}[0] <= freq{lo}{D}[0]`
+  on every lens where the anchor fires AND `freq{lo}{D}` has a value
+  at center.
+- viltrox-75 Tier 1 anchor log: freq30S Δ at frac=0.0 drops from
+  0.070 → ~0.060; freq30M Δ from 0.080 → ~0.070. Still above the
+  ±0.05 band, but moving toward true value rather than away from it.
+- samyang-300mm reflex: unchanged (ADR-069 fires before reaching
+  here).
+- samyang-af-12mm stopped: unchanged (freq10 cells anchor to 1.0
+  first, freq30 cells then inherit 1.0).
+
+### Negative / accepted tradeoff
+
+- On lenses where the chart artist actually drew `freq30` at MTF=1.0
+  at center but `freq10` extracts at 0.99 (e.g. samyang-10mm stopped),
+  the anchor shifts from 1.0 → 0.99, regressing those cells by 0.01
+  against GT. Accepted: 0.01 inside the ±0.05 band is well below the
+  noise floor of the calibration metric, and the physical-invariant
+  win on lenses like viltrox-75 outweighs a 0.01 regression on lenses
+  where the prior happened to be exactly correct.
+- viltrox-75 remains over the ±0.05 band on freq30S/M at frac=0.0.
+  This is **data-limited, not algorithm-limited**: the extractor reads
+  freq10 at 0.99 (GT 1.00) and the chart's true freq30 is 0.93 (GT).
+  No anchor mechanism short of actually reading the freq30 skeleton
+  in the buried-leftmost-columns region can produce a value below
+  0.99 here. Recovering the freq30 skeleton from under the freq10
+  red ink is a separate problem (would require dispatch / HSV
+  retuning that risks regressing the 8 lenses ADR-066 was designed
+  to fix). Accepted.
+
+### Scope this ADR does NOT cover
+
+- Cases where the same-direction lower-freq cell at center is itself
+  None AND the cross-direction cell is also None. Falls through to
+  the 1.0 anchor; same behaviour as before this ADR.
+- Cases where the pair gate's veto signals the right answer would
+  be "leave cell None" rather than "anchor to a value". The trade-off
+  there is the y-axis visible gap (#1267) vs. an inaccurate filled
+  value. This ADR keeps the filled value; the gap-prevention principle
+  of ADR-066 is preserved.
+- Recovery of buried freq30 skeleton ink on fast primes with sub-1.0
+  chart-top curves. Out of scope; a separate spike against the
+  dispatch / HSV layer would be needed and would risk regressing the
+  ADR-066-recovered lenses.
+- Charts with three or more frequencies (e.g. Zeiss 10/20/40 press
+  kit). The "closest lower frequency" rule generalises naturally:
+  freq40 anchors to freq20 if available, else freq10. No special
+  case needed.

--- a/docs/optical-specs/viltrox-af-75mm-f1-2-pro/digitization-log.md
+++ b/docs/optical-specs/viltrox-af-75mm-f1-2-pro/digitization-log.md
@@ -28,17 +28,17 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm (per-hue Viterbi s
 | -------------- | ------ | --------- | --------- | ----------- |
 | freq10S        | 11/11  |     0.012 |     0.056 |  0/11       |
 | freq10M        |  5/11  |     0.035 |     0.092 |  0/11       |
-| freq30S        |  7/11  |     0.020 |     0.081 |  0/11       |
-| freq30M        |  5/11  |     0.062 |     0.094 |  0/11       |
+| freq30S        |  7/11  |     0.020 |     0.061 |  0/11       |
+| freq30M        |  5/11  |     0.062 |     0.103 |  0/11       |
 
 ```
   EX   freq10S        ███████████  (0.99 → 1.00)
   EYE  freq10S        ███████████
   EX   freq10M        ███·█▇·····  (0.99 →  — )
   EYE  freq10M        ███████▇▇▇▇
-  EX   freq30S        █··▇▇·▇▇▇▇·  (1.00 →  — )
+  EX   freq30S        █··▇▇·▇▇▇▇·  (0.99 →  — )
   EYE  freq30S        ████▇▇▇▇▇▇▆
-  EX   freq30M        █·····▇▇·▇▆  (1.00 → 0.71)
+  EX   freq30M        █·····▇▇·▇▆  (0.99 → 0.71)
   EYE  freq30M        ▇▇▇▇▇▇▇▇▆▆▆
 ```
 
@@ -78,7 +78,7 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm (per-hue Viterbi s
 
 | frac | EYE | EX | Δ |
 | ---- | --- | --- | --- |
-| 0.0 | 0.93 | 1.00 | 0.070 |
+| 0.0 | 0.93 | 0.99 | 0.057 |
 | 0.1 | 0.93 | — | — |
 | 0.2 | 0.93 | — | — |
 | 0.3 | 0.93 | 0.93 | 0.005 |
@@ -94,7 +94,7 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm (per-hue Viterbi s
 
 | frac | EYE | EX | Δ |
 | ---- | --- | --- | --- |
-| 0.0 | 0.92 | 1.00 | 0.080 |
+| 0.0 | 0.92 | 0.99 | 0.068 |
 | 0.1 | 0.91 | — | — |
 | 0.2 | 0.90 | — | — |
 | 0.3 | 0.90 | — | — |
@@ -112,8 +112,8 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm (per-hue Viterbi s
 | -------------- | ------------ | ---------- | ------------ |
 | freq10S        |         0.99 |       0.97 |         1.00 |
 | freq10M        |         0.99 |          — |            — |
-| freq30S        |         1.00 |       0.87 |            — |
-| freq30M        |         1.00 |       0.81 |         0.71 |
+| freq30S        |         0.99 |       0.87 |            — |
+| freq30M        |         0.99 |       0.81 |         0.71 |
 
 ### Shape metrics
 
@@ -121,5 +121,5 @@ See `tools/mtfdigitizer/README.md` for the dispatch algorithm (per-hue Viterbi s
 | -------------- | --------- | ---------- | ----------------- |
 | freq10S        |       1.0 |       1.00 |                 — |
 | freq10M        |       0.0 |       0.99 |                 — |
-| freq30S        |       0.0 |       1.00 |                 — |
-| freq30M        |       0.0 |       1.00 |                 — |
+| freq30S        |       0.0 |       0.99 |                 — |
+| freq30M        |       0.0 |       0.99 |                 — |

--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -482,16 +482,35 @@ def _apply_center_symmetry(
        less susceptible to drift, and almost always the cleaner
        anchor.
     2. One side is None — copy the other side over.
-    3. Both are None — anchor both to MTF=1.0 (#1267). At a
-       diffraction-free chart's optical axis the curves must start
-       at 1.0 by definition; this fires only when every prior stage
-       (direct extraction, sister fallback, intra-curve interp) has
-       failed to produce a value on either side of a frequency pair,
-       and only at frac=0.0 (the right edge has no equivalent
-       physical guarantee). The Samyang stopped panel triggers this
-       when the dark-grey 30S sits hidden under the saturated red
-       10S for the first ~25% of the field and both 30S and 30M
-       skeletons miss the leftmost columns.
+    3. Both are None — anchor from the closest same-direction lower
+       frequency if available, else MTF=1.0.
+
+       ADR-066 (#1267) introduced the 1.0 anchor for this case. The
+       diffraction-free chart's optical axis MTF is 1.0 by definition,
+       and on most affected lenses (samyang-10mm stopped, samyang-
+       af-12mm, etc.) the lower-freq curve also sits at chart top so
+       1.0 is correct.
+
+       ADR-072 (#1279) refines the rule: when the same-direction
+       lower-freq curve has a value at center (e.g. freq10S extracts
+       at 0.99 on viltrox-75 f/1.2 where the chart artist drew
+       freq30 below chart top), copy from it instead. This preserves
+       the physical invariant `freq{hi}{D}[0] <= freq{lo}{D}[0]`
+       which the 1.0 constant violates whenever lo extracts below
+       1.0. The fallback chain is:
+         freq{hi}{S}[0] := freq{lo}{S}[0]
+                     or freq{lo}{M}[0]   (cross-direction copy at the axis)
+                     or 1.0              (no lower frequency available)
+       and symmetric for the M field. ADR-069's pair gate veto on
+       multi-cell coincident-top copy is intentionally local to that
+       pass — at the single optical-axis cell the `hi <= lo`
+       invariant holds independent of gate verdicts.
+
+       Fires only at frac=0.0 (the right edge has no equivalent
+       physical guarantee) and only when every prior stage (direct
+       extraction, sister fallback, intra-curve interp, coincident-
+       top anchor) failed to produce a value on either side of a
+       frequency pair.
 
     Pairs up every `freq{N}S`/`freq{N}M` present in `samples` —
     per-frequency rule applies to every chart family (ADR-042).
@@ -502,6 +521,26 @@ def _apply_center_symmetry(
     """
     out = {field: list(values) for field, values in samples.items()}
     anchor_count: dict[str, int] = {field: 0 for field in samples}
+
+    # Pre-compute the closest-lower-frequency map so each "both None"
+    # case is O(1). Iterates only freq{N}{S|M} fields with integer N.
+    distinct_freqs: list[int] = []
+    for field in samples:
+        if not field.startswith("freq"):
+            continue
+        if field[-1] not in ("S", "M"):
+            continue
+        freq_str = field[4:-1]
+        if freq_str.isdigit():
+            n = int(freq_str)
+            if n not in distinct_freqs:
+                distinct_freqs.append(n)
+    distinct_freqs.sort()
+
+    def _closest_lower(freq_n: int) -> int | None:
+        candidates = [f for f in distinct_freqs if f < freq_n]
+        return max(candidates) if candidates else None
+
     # Collect every S field present and look for the matching M.
     for s_field in [f for f in samples if f.endswith("S") and f.startswith("freq")]:
         m_field = s_field[:-1] + "M"
@@ -510,8 +549,25 @@ def _apply_center_symmetry(
         s_val = out[s_field][0]
         m_val = out[m_field][0]
         if s_val is None and m_val is None:
-            out[s_field][0] = _CENTER_AXIS_MTF
-            out[m_field][0] = _CENTER_AXIS_MTF
+            freq_str = s_field[4:-1]
+            lo_freq = _closest_lower(int(freq_str)) if freq_str.isdigit() else None
+            lo_s = out[f"freq{lo_freq}S"][0] if lo_freq is not None else None
+            lo_m = out[f"freq{lo_freq}M"][0] if lo_freq is not None else None
+            # Fallback chain per direction: same-direction lo -> cross-
+            # direction lo (S=M at the axis by B4) -> 1.0 physical
+            # constant. The ordering is order-independent across freq
+            # pairs because a prior iteration's anchor leaves a value
+            # in `out` that a later iteration can read as its lo.
+            out[s_field][0] = (
+                lo_s if lo_s is not None
+                else lo_m if lo_m is not None
+                else _CENTER_AXIS_MTF
+            )
+            out[m_field][0] = (
+                lo_m if lo_m is not None
+                else lo_s if lo_s is not None
+                else _CENTER_AXIS_MTF
+            )
             anchor_count[s_field] += 1
             anchor_count[m_field] += 1
             continue

--- a/tools/mtfdigitizer/tests/test_pipeline.py
+++ b/tools/mtfdigitizer/tests/test_pipeline.py
@@ -868,8 +868,9 @@ def test_coincident_anchor_handles_meridional() -> None:
 
 
 def test_center_anchor_fires_when_both_sides_none() -> None:
-    """#1267 — when BOTH freq{N}S[0] and freq{N}M[0] are None, anchor
-    both to MTF=1.0 and report the counts."""
+    """#1267 — when BOTH freq{N}S[0] and freq{N}M[0] are None AND no
+    lower-freq same-direction value is available, anchor both to
+    MTF=1.0 and report the counts."""
     from mtfdigitizer.pipeline.pipeline import _apply_center_symmetry
 
     samples = {
@@ -882,6 +883,100 @@ def test_center_anchor_fires_when_both_sides_none() -> None:
     # Other indices must remain untouched — the rule is frac=0.0 only.
     assert out["freq30S"][1:] == (0.95, 0.90)
     assert out["freq30M"][1:] == (0.93, 0.88)
+    assert anchor["freq30S"] == 1 and anchor["freq30M"] == 1
+
+
+def test_center_anchor_uses_lo_when_available() -> None:
+    """ADR-072 (#1279) — when both freq{hi}{S}[0] and freq{hi}{M}[0]
+    are None at center BUT same-direction lower-freq cells carry
+    values, anchor from those values to preserve the physical
+    invariant freq{hi}{D}[0] <= freq{lo}{D}[0].
+
+    Replays viltrox-75 f/1.2: freq30 buried at center, freq10
+    extracted at 0.99 — anchor freq30 to 0.99, not 1.0."""
+    from mtfdigitizer.pipeline.pipeline import _apply_center_symmetry
+
+    samples = {
+        "freq10S": (0.99, 0.99, 0.98),
+        "freq10M": (0.99, 0.94, 0.95),
+        "freq30S": (None, None, None),
+        "freq30M": (None, None, None),
+    }
+    out, anchor = _apply_center_symmetry(samples)
+    # freq10S/M: case 1 (both extracted) — S wins, M overridden.
+    assert out["freq10S"][0] == pytest.approx(0.99)
+    assert out["freq10M"][0] == pytest.approx(0.99)
+    # freq30S/M: ADR-072 anchors from freq10 instead of 1.0.
+    assert out["freq30S"][0] == pytest.approx(0.99)
+    assert out["freq30M"][0] == pytest.approx(0.99)
+    # Anchor counter records only the both-None fills (freq30 pair).
+    assert anchor["freq30S"] == 1 and anchor["freq30M"] == 1
+    assert anchor["freq10S"] == 0 and anchor["freq10M"] == 0
+
+
+def test_center_anchor_cross_direction_fallback() -> None:
+    """ADR-072 — when same-direction lo is None but cross-direction lo
+    has a value, fall back to cross-direction. S=M at the optical axis
+    by B4, so either direction is a valid anchor."""
+    from mtfdigitizer.pipeline.pipeline import _apply_center_symmetry
+
+    samples = {
+        # freq10M[0]=None but freq10S[0]=0.97 is available.
+        "freq10S": (0.97, 0.95, 0.93),
+        "freq10M": (None, 0.94, 0.92),
+        "freq30S": (None, None, None),
+        "freq30M": (None, None, None),
+    }
+    out, anchor = _apply_center_symmetry(samples)
+    # freq10: case 2 (M None, S present) — copy S to M.
+    assert out["freq10M"][0] == pytest.approx(0.97)
+    # freq30S: same-direction lo (freq10S=0.97) exists, use it.
+    assert out["freq30S"][0] == pytest.approx(0.97)
+    # freq30M: same-direction lo (freq10M) was None going in but case 2
+    # filled it with 0.97 before freq30 iteration if order permits.
+    # Order-independent fallback chain: when same-dir is None at lookup
+    # time, cross-dir gives 0.97. Either path yields 0.97.
+    assert out["freq30M"][0] == pytest.approx(0.97)
+    assert anchor["freq30S"] == 1 and anchor["freq30M"] == 1
+
+
+def test_center_anchor_falls_back_to_1_when_no_lower_freq() -> None:
+    """ADR-072 — single-frequency chart (only freq30 present), both
+    None at center, no lower freq to anchor from: fall back to 1.0.
+    Preserves ADR-066 behaviour for charts without a freq10."""
+    from mtfdigitizer.pipeline.pipeline import _apply_center_symmetry
+
+    samples = {
+        "freq30S": (None, 0.85, 0.80),
+        "freq30M": (None, 0.83, 0.78),
+    }
+    out, anchor = _apply_center_symmetry(samples)
+    assert out["freq30S"][0] == pytest.approx(1.0)
+    assert out["freq30M"][0] == pytest.approx(1.0)
+    assert anchor["freq30S"] == 1 and anchor["freq30M"] == 1
+
+
+def test_center_anchor_chains_through_anchored_lo() -> None:
+    """ADR-072 — when freq10 itself enters _apply_center_symmetry with
+    both None, it anchors to 1.0 (no lower freq). When freq30 iterates
+    next, freq10 is now 1.0 — so freq30 anchors to 1.0 too. Replays
+    samyang-af-12mm stopped (10S+10M None AND 30S+30M None)."""
+    from mtfdigitizer.pipeline.pipeline import _apply_center_symmetry
+
+    samples = {
+        "freq10S": (None, 0.99, 0.98),
+        "freq10M": (None, 0.99, 0.96),
+        "freq30S": (None, 0.95, 0.85),
+        "freq30M": (None, 0.93, 0.83),
+    }
+    out, anchor = _apply_center_symmetry(samples)
+    # freq10 anchors to 1.0 (no lo).
+    assert out["freq10S"][0] == pytest.approx(1.0)
+    assert out["freq10M"][0] == pytest.approx(1.0)
+    # freq30 sees freq10=1.0 and inherits it.
+    assert out["freq30S"][0] == pytest.approx(1.0)
+    assert out["freq30M"][0] == pytest.approx(1.0)
+    assert anchor["freq10S"] == 1 and anchor["freq10M"] == 1
     assert anchor["freq30S"] == 1 and anchor["freq30M"] == 1
 
 


### PR DESCRIPTION
Closes #1279.

## Summary
- ADR-072: refines ADR-066's "both None" center anchor to prefer the closest same-direction lower-freq value before falling back to MTF=1.0.
- Restores the physical invariant \`freq{hi}{D}[0] <= freq{lo}{D}[0]\` on lenses where lo extracts below 1.0 at center (e.g. viltrox-75 f/1.2: was freq30=1.00 > freq10=0.99, now freq30=0.99=freq10).
- Reduces viltrox-75 Tier 1 anchor Δ at frac=0.0: freq30S 0.070 → 0.057, freq30M 0.080 → 0.068. Residual is data-limited (chart truth is 0.93/0.92, extractor reads lo at 0.99).
- Calibration aggregate unchanged: 900 paired, p95 |d| 0.0458, max |d| 0.1217, in-band 96.1%.

## Why path 2 from #1279
- Path 1 (gate ADR-066 on \`lo >= 0.95\`) doesn't help — lo IS 0.99 on viltrox-75, so the gate passes.
- Path 3 (accept the overshoot) leaves a physical-invariant violation in committed log data.
- Path 4 (bypass ADR-066 when ADR-069 vetoed) requires new state plumbing AND re-introduces the y-axis gap (#1267).
- **Path 2** (this PR) is the natural extension of ADR-069's same-direction copy mechanism to the both-None case. Pair-gate veto is intentionally local to multi-cell copy — at the single optical-axis cell, \`hi <= lo\` is a strict physical invariant that holds independent of gate verdicts.

## Verification
- [x] 56 mtfdigitizer/test_pipeline.py tests pass (52 prior + 4 new ADR-072 cases)
- [x] Full mtfdigitizer pytest suite passes
- [x] \`py -m mtfdigitizer.calibrate\` aggregate unchanged (900 paired, p95 0.0458, in-band 96.1%)
- [x] \`py -m mtfdigitizer.log --all --check\` reports only viltrox-75 stale; refreshed in this PR
- [x] \`npm run validate\` passes end-to-end

## Files changed
- \`docs/decisions/072-center-anchor-lo-when-available.md\` — new ADR
- \`tools/mtfdigitizer/pipeline/pipeline.py\` — refines case 3 in \`_apply_center_symmetry\`
- \`tools/mtfdigitizer/tests/test_pipeline.py\` — adds 4 new tests for ADR-072 cases (lo available / cross-direction / no lo / chained anchor)
- \`docs/optical-specs/viltrox-af-75mm-f1-2-pro/digitization-log.md\` — refreshed Tier 1 log

🤖 Generated with [Claude Code](https://claude.com/claude-code)