### PR TITLE
test(mtf-readings): same-product MTF chart invariant (#1265)

### DIFF
--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import { lenses } from "./lenses";
@@ -386,6 +387,68 @@ describe("docs/optical-specs directory-name invariant", () => {
     expect(
       orphans,
       `optical-specs directories with no matching lens (slug drift?): ${orphans.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+// Same-product MTF chart invariant (#1265). Two lens entries that share
+// an `officialUrl` are, by construction, the same optical product sold
+// in two mount variants (e.g. TTartisan 100mm Macro 2X X-mount vs
+// GFX-mount — same lens, different rear adapter). The manufacturer
+// publishes one MTF chart per optical design, so the primary
+// `<slug>-mtf.png` source chart MUST be byte-identical across mount
+// variants. The investigation behind #1265 found three TTartisan pairs
+// in this state and confirmed all three have matching upstream charts —
+// any future drift (e.g. someone fetches a different chart for one
+// variant) is a data-quality bug.
+//
+// The test scopes to lens-pairs that share an `officialUrl` AND both
+// have a primary MTF chart file on disk; pairs missing one side are
+// out of scope (different cause).
+describe("same-product MTF chart invariant", () => {
+  const SPECS_ROOT = resolve(__dirname, "../../docs/optical-specs");
+
+  function hashFile(path: string): string {
+    // sha256: identity check, not security — sonarjs flags md5/sha1.
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  }
+
+  function primaryChartPath(slug: string): string {
+    return join(SPECS_ROOT, slug, `${slug}-mtf.png`);
+  }
+
+  const groupsByUrl = new Map<string, string[]>();
+  for (const lens of lenses) {
+    if (!lens.officialUrl) continue;
+    const slug = toSlug(`${dirBrand(lens.brand)} ${lens.model}`);
+    const list = groupsByUrl.get(lens.officialUrl) ?? [];
+    list.push(slug);
+    groupsByUrl.set(lens.officialUrl, list);
+  }
+  const sharedUrlGroups = [...groupsByUrl.entries()].filter(
+    ([, slugs]) => slugs.length > 1,
+  );
+
+  it("lens entries sharing an officialUrl share their primary MTF chart", () => {
+    const mismatches: string[] = [];
+    for (const [url, slugs] of sharedUrlGroups) {
+      const present = slugs.filter((s) => existsSync(primaryChartPath(s)));
+      if (present.length < 2) continue;
+      const hashes = present.map((s) => ({
+        slug: s,
+        hash: hashFile(primaryChartPath(s)),
+      }));
+      const distinctHashes = new Set(hashes.map((h) => h.hash));
+      if (distinctHashes.size > 1) {
+        const detail = hashes
+          .map((h) => `${h.slug}=${h.hash.slice(0, 8)}`)
+          .join(", ");
+        mismatches.push(`${url}: ${detail}`);
+      }
+    }
+    expect(
+      mismatches,
+      `lenses sharing officialUrl have divergent MTF charts (one mount variant was likely fetched from the wrong page — see #1265): ${mismatches.join("; ")}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Part of the #1265 audit follow-up (regression test for the future bug class).

## Summary
- Adds a test that lens entries sharing an \`officialUrl\` must share their primary \`<slug>-mtf.png\` byte-for-byte.
- Catches the \"someone fetched a different chart for the GFX vs X variant of the same lens\" bug at commit time.
- Currently 3 TTartisan pairs are in scope (100mm Macro 2X X/GFX, 500mm f/6.3 X/GFX, plus 23mm + 90mm GFX which share an upstream chart at the manufacturer). All pass.

## Why this is the right invariant
The #1265 audit established that:
- TTartisan publishes ONE product page (and ONE MTF chart) per optical design.
- Two lens entries sharing an \`officialUrl\` are by construction the same optical product in two mount variants.
- So their MTF charts MUST agree byte-for-byte — divergence indicates a misplaced fetch.

See the comment on #1265 for the full audit.

## Test count
223 → 224.

## Verification
- [x] \`npm run validate\` passes end-to-end
- [x] All 224 tests pass; new test specifically passes against current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)