### PR TITLE
feat(mtfdigitizer): add --check mode to emit_*_tier2 scripts (#1296)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -350,6 +350,7 @@ cd tools && py -m mtfdigitizer.scripts.scaffold_fuji_tier2        # preview Tier
 cd tools && py -m mtfdigitizer.scripts.scaffold_fuji_tier2 --write  # materialize _fuji_tier2_charts.py
 cd tools && py -m mtfdigitizer.scripts.emit_fuji_tier2            # preview TS object literals
 cd tools && py -m mtfdigitizer.scripts.emit_fuji_tier2 --write    # patch src/data/mtf-readings.ts
+cd tools && py -m mtfdigitizer.scripts.emit_fuji_tier2 --check    # diff in-memory re-emit vs committed file; exit 1 on drift (#1296)
 ```
 
 Fujifilm publishes one chart image per spatial frequency
@@ -391,6 +392,7 @@ cd tools && py -m mtfdigitizer.scripts.scaffold_ttartisan_tier2          # previ
 cd tools && py -m mtfdigitizer.scripts.scaffold_ttartisan_tier2 --write  # materialize _ttartisan_tier2_charts.py
 cd tools && py -m mtfdigitizer.scripts.emit_ttartisan_tier2              # preview TS object literals
 cd tools && py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --write      # patch src/data/mtf-readings.ts
+cd tools && py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check      # diff in-memory re-emit vs committed file; exit 1 on drift (#1296)
 ```
 
 TTartisan publishes one chart image per lens packing TWO apertures by

--- a/tools/mtfdigitizer/scripts/_emit_check.py
+++ b/tools/mtfdigitizer/scripts/_emit_check.py
@@ -1,0 +1,52 @@
+"""Shared --check helper for emit_*_tier2 scripts (#1296).
+
+Both `emit_ttartisan_tier2` and `emit_fuji_tier2` need an in-memory
+"is the committed `mtf-readings.ts` up to date with the current
+extractor output?" gate. Each script owns its own `_splice_entries`
+(the splice patterns differ slightly), but the diff/exit logic is
+identical — that's what lives here.
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+from pathlib import Path
+
+
+def report_drift(
+    path: Path,
+    source: str,
+    patched: str,
+    *,
+    label: str,
+) -> int:
+    """Compare `source` (committed file text) to `patched` (in-memory
+    re-emit) and return a process exit code.
+
+    Returns 0 on match, 1 on drift. On drift, writes a unified diff
+    to stderr so the failure is actionable without an extra command.
+    """
+    if source == patched:
+        print(
+            f"OK: {label} entries in {path.name} match current "
+            f"extractor output.",
+            file=sys.stderr,
+        )
+        return 0
+
+    diff = difflib.unified_diff(
+        source.splitlines(keepends=True),
+        patched.splitlines(keepends=True),
+        fromfile=f"{path.name} (committed)",
+        tofile=f"{path.name} (re-emitted)",
+        n=3,
+    )
+    sys.stderr.writelines(diff)
+    print(
+        f"\nFAIL: {label} entries in {path.name} drift from current "
+        f"extractor output. Run the same script with --write to refresh, "
+        f"review the diff, then commit.",
+        file=sys.stderr,
+    )
+    return 1

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -449,11 +449,19 @@ def _splice_entries(source: str, new_entries: dict[str, str]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--write",
         action="store_true",
         help="Patch src/data/mtf-readings.ts with the emitted entries. "
         "Without this flag the literals print to stdout for review.",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Render entries in memory and compare against the committed "
+        "src/data/mtf-readings.ts. Exit non-zero with a unified diff if "
+        "any entry drifts from the current extractor output (#1296).",
     )
     parser.add_argument(
         "--limit",
@@ -494,6 +502,17 @@ def main(argv: list[str] | None = None) -> int:
             f"{len(entries)} entries, {total_panels} panels, "
             f"{total_positions} positions.",
             file=sys.stderr,
+        )
+    elif args.check:
+        from mtfdigitizer.scripts._emit_check import report_drift  # noqa: PLC0415
+
+        source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        patched = _splice_entries(source, entries)
+        return report_drift(
+            MTF_READINGS_PATH,
+            source,
+            patched,
+            label="Fujifilm tier 2",
         )
     else:
         print("\n".join(entries.values()))

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -299,11 +299,19 @@ def _splice_entries(source: str, new_entries: dict[str, str]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--write",
         action="store_true",
         help="Patch src/data/mtf-readings.ts with the emitted entries. "
         "Without this flag the literals print to stdout for review.",
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Render entries in memory and compare against the committed "
+        "src/data/mtf-readings.ts. Exit non-zero with a unified diff if "
+        "any entry drifts from the current extractor output (#1296).",
     )
     parser.add_argument(
         "--limit",
@@ -344,6 +352,17 @@ def main(argv: list[str] | None = None) -> int:
             f"{len(entries)} entries, {total_panels} panels, "
             f"{total_positions} positions.",
             file=sys.stderr,
+        )
+    elif args.check:
+        from mtfdigitizer.scripts._emit_check import report_drift  # noqa: PLC0415
+
+        source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        patched = _splice_entries(source, entries)
+        return report_drift(
+            MTF_READINGS_PATH,
+            source,
+            patched,
+            label="TTartisan tier 2",
         )
     else:
         print("\n".join(entries.values()))

--- a/tools/mtfdigitizer/tests/test_emit_check.py
+++ b/tools/mtfdigitizer/tests/test_emit_check.py
@@ -1,0 +1,114 @@
+"""Tests for the `--check` mode of `emit_*_tier2` scripts (#1296).
+
+Both `emit_ttartisan_tier2` and `emit_fuji_tier2` expose a `--check`
+flag that renders entries in memory, diffs against the committed
+`src/data/mtf-readings.ts`, and exits non-zero on drift. This is the
+gate that catches the next "extractor evolved past the last bulk
+re-emit" case at PR time instead of months later.
+
+The unit tests below exercise the shared diff helper and the script
+wiring with a fabricated source string — they do not depend on the
+production data file's current state. A separate marker test
+documents the known production-data drift (both brands stale as of
+S184) so the gate's behavior is recorded even while the catch-up
+PRs are in flight.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mtfdigitizer.scripts._emit_check import report_drift
+
+
+def test_report_drift_returns_0_on_match(capsys: pytest.CaptureFixture[str]) -> None:
+    """Identical source/patched → exit 0, OK line on stderr."""
+    text = "const x = 1;\n"
+    rc = report_drift(Path("dummy.ts"), text, text, label="dummy")
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "OK:" in err
+    assert "dummy" in err
+
+
+def test_report_drift_returns_1_on_drift(capsys: pytest.CaptureFixture[str]) -> None:
+    """Different source/patched → exit 1, FAIL line + diff on stderr."""
+    source = "const x = 1;\n"
+    patched = "const x = 2;\n"
+    rc = report_drift(Path("dummy.ts"), source, patched, label="dummy")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "FAIL:" in err
+    # Unified diff markers present
+    assert "-const x = 1;" in err
+    assert "+const x = 2;" in err
+
+
+def test_report_drift_diff_names_the_file(capsys: pytest.CaptureFixture[str]) -> None:
+    """The diff header references the file by basename so the reader
+    knows which file to refresh."""
+    rc = report_drift(
+        Path("src/data/mtf-readings.ts"),
+        "a\n",
+        "b\n",
+        label="dummy",
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "mtf-readings.ts (committed)" in err
+    assert "mtf-readings.ts (re-emitted)" in err
+
+
+def test_report_drift_fail_message_points_to_write(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """FAIL message tells the reader exactly which command refreshes
+    the file — the gate is only useful if the next step is obvious."""
+    rc = report_drift(Path("x.ts"), "a\n", "b\n", label="dummy")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--write" in err
+
+
+# --- script wiring --------------------------------------------------------
+#
+# These tests exercise the emit_* main() paths with --check enabled.
+# They run the real extractor pipeline against the real production
+# data file — so they are EXPECTED to fail until the bulk-refresh
+# catch-up PRs land (#1296 path 1).
+#
+# Once the catch-up lands, flip these from `xfail(strict=True)` to a
+# plain assertion. The strict marker means a passing run is itself a
+# test failure — that is the signal to remove the marker.
+
+
+@pytest.mark.xfail(
+    reason=(
+        "#1296: production mtf-readings.ts is stale for both TTartisan "
+        "and Fuji tier 2 entries. The --check gate correctly reports "
+        "drift; flip to a hard assertion after the bulk-refresh PRs."
+    ),
+    strict=True,
+)
+def test_ttartisan_check_passes_on_production_data() -> None:
+    """Production gate: TTartisan tier 2 entries match the extractor."""
+    from mtfdigitizer.scripts.emit_ttartisan_tier2 import main
+
+    assert main(["--check"]) == 0
+
+
+@pytest.mark.xfail(
+    reason=(
+        "#1296: production mtf-readings.ts is stale for both TTartisan "
+        "and Fuji tier 2 entries. The --check gate correctly reports "
+        "drift; flip to a hard assertion after the bulk-refresh PRs."
+    ),
+    strict=True,
+)
+def test_fuji_check_passes_on_production_data() -> None:
+    """Production gate: Fujifilm tier 2 entries match the extractor."""
+    from mtfdigitizer.scripts.emit_fuji_tier2 import main
+
+    assert main(["--check"]) == 0


### PR DESCRIPTION
## Summary
- Adds `--check` flag to `emit_fuji_tier2` and `emit_ttartisan_tier2` that diffs in-memory re-emit against the committed `src/data/mtf-readings.ts` and exits 1 on drift, with a unified diff on stderr.
- Shared diff/exit helper in `tools/mtfdigitizer/scripts/_emit_check.py`. Each script keeps its own `_splice_entries` (splice patterns differ between Fuji and TTartisan).
- Tests: 4 unit tests on the helper (match/drift/header/fail-message). 2 production-data tests marked `xfail(strict=True)` — they document the known drift on both brands as of S184; the strict marker auto-fails when the drift is gone, forcing the maintainer to flip them to hard assertions.

## Findings during implementation
Smoke-running the new gate uncovered drift on **both brands**, not just TTartisan as #1296 originally framed:
- TTartisan: ~636 lines (S/M curve swaps, value shifts) — known via #1296.
- Fuji: previously unreported drift, including a stale `source:` URL on `fujifilm-xf-8mm-f3-5-r-wr` (pointed at the 80mm Macro page).

The bulk-refresh catch-up for each brand is tracked under #1296. This PR is the gate, not the catch-up.

## Out of scope (filed separately)
- Wiring `tools/` pytest into CI — currently `npm run validate` runs vitest only, so the gate runs locally + in the maintainer's pytest, but not on PRs. Tracked as #1299.
- The bulk-refresh PRs for TTartisan and Fuji tier 2 entries (#1296 path 1).

## Test plan
- [x] `cd tools && py -m pytest mtfdigitizer/tests/test_emit_check.py -v` → 4 passed, 2 xfailed
- [x] `cd tools && py -m pytest` → 701 passed, 2 xfailed (matches baseline + 6 new)
- [x] `cd tools && py -m mtfdigitizer.scripts.emit_fuji_tier2 --check` exits 1 with diff
- [x] `cd tools && py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check` exits 1 with diff
- [x] `npm run validate` — clean
- [x] PLAYBOOK 2.8 emit command blocks updated with `--check` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)