### PR TITLE
feat(ci): run tools/ pytest on PRs that touch tools/** (#1299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       lighthouse: ${{ steps.filter.outputs.lighthouse }}
+      tools: ${{ steps.filter.outputs.tools }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -38,6 +39,12 @@ jobs:
               - 'astro.config.mjs'
               - 'tsconfig.json'
               - 'lighthouserc.json'
+              - '.github/workflows/**'
+            # Python tooling — mtfdigitizer + brand extractors + pagefetch.
+            # The emit_*_tier2 --check gates (#1296/#1300/#1303) only have
+            # teeth when this job runs on PRs that could affect them.
+            tools:
+              - 'tools/**'
               - '.github/workflows/**'
 
   build:
@@ -80,14 +87,36 @@ jobs:
           configPath: lighthouserc.json
           uploadArtifacts: true
 
+  pytest:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tools == 'true'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: tools/requirements.txt
+
+      - name: Install tools dependencies
+        run: pip install -r tools/requirements.txt
+
+      - name: Run pytest
+        working-directory: tools
+        run: python -m pytest -n auto
+
   gate:
     runs-on: ubuntu-latest
-    needs: [build, lighthouse]
+    needs: [build, lighthouse, pytest]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" ]]; then
+          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" || "${{ needs.pytest.result }}" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -32,19 +32,24 @@ cd wuseria
 npm install
 ```
 
-For optical specs research tools (optional):
+For Python tools (optional — needed only to run mtfdigitizer, brand
+extractors, or pagefetch's higher-tier fetchers):
 
 ```bash
-pip install playwright nodriver seleniumbase pytest
-playwright install chromium
+cd tools && pip install -r requirements.txt   # mtfdigitizer + brand tests + pytest
+pip install playwright nodriver seleniumbase  # pagefetch tiers 2-4 (optional)
+playwright install chromium                   # required only if using tier 2
 ```
 
-The web-fetch package (`tools/pagefetch/`) works with only the Python
-standard library; the browser libraries above enable its higher tiers and
-are imported lazily. `pytest` runs the Python tool tests:
+`tools/requirements.txt` pins the mtfdigitizer image-processing deps
+(opencv-python, numpy, scikit-image, Pillow) plus pytest + pytest-xdist.
+The browser libraries on the second line stay optional — pagefetch
+imports them lazily and falls back gracefully if absent. Run the Python
+tool tests:
 
 ```bash
-cd tools && py -m pytest pagefetch/tests/ brandkit/tests/
+cd tools && py -m pytest                       # full suite (~3 min with xdist)
+cd tools && py -m pytest pagefetch/tests/      # just pagefetch
 ```
 
 The `--recursive` flag pulls the `docs/solid-ai-templates` submodule. If you

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -906,8 +906,10 @@ detectable by the tool; manual page inspection may find additional images.
 **Extract MTF readings from chart PNGs:**
 
 Use `tools/mtfdigitizer/` — unified digitizer per ADR-038. Requires Python
-
-- scikit-image + opencv-python.
+3.13+ with image-processing dependencies pinned in `tools/requirements.txt`
+(opencv-python, numpy, scikit-image, Pillow, pytest, pytest-xdist).
+Install: `cd tools && pip install -r requirements.txt`. CI installs the
+same file to run the pytest suite on `tools/**` PRs (#1299).
 
 Charts live per-lens under `docs/optical-specs/<slug>/` (ADR-033) as
 `mtf-chart.{png,jpg}`, or `mtf-f<aperture>.png` per aperture.

--- a/tools/mtfdigitizer/emit.py
+++ b/tools/mtfdigitizer/emit.py
@@ -200,6 +200,25 @@ ChartPanel = tuple[
 ]
 
 
+def format_source_line(source: str) -> str:
+    """Render the `    source: "<url>",` line for a top-level entry.
+
+    Matches Prettier's default printWidth=80 wrap: single line when the
+    full `    source: "<url>",` fits in 80 chars, otherwise wrapped as
+
+        source:
+          "<url>",
+
+    Without this, the bulk-emit output drifts under lint-staged's
+    Prettier pass and the --check gate (#1296/#1299) reports false
+    positives on every long-URL entry.
+    """
+    single = f'    source: "{source}",'
+    if len(single) <= 80:
+        return single + "\n"
+    return f'    source:\n      "{source}",\n'
+
+
 def _format_entry(
     slug: str,
     source: str,
@@ -218,7 +237,7 @@ def _format_entry(
     )
     return (
         f"  \"{slug}\": {{\n"
-        f"    source: \"{source}\",\n"
+        f"{format_source_line(source)}"
         f"    mtfType: \"{mtf_type}\",\n"
         "    charts: [\n"
         f"{chart_blocks}\n"

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -35,6 +35,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from mtfdigitizer.emit import format_source_line
 from mtfdigitizer.family_profile import profile_for_chart
 from mtfdigitizer.per_frequency import parse_filename_frequency
 from mtfdigitizer.pipeline import extract_chart
@@ -357,9 +358,10 @@ def _emit_one_lens(
         total_positions += len(merged)
 
     chart_blocks = "\n".join(blocks)
+    source_url = _source_url(chart.slug, official_urls)
     literal = (
         f'  "{chart.slug}": {{\n'
-        f'    source: "{_source_url(chart.slug, official_urls)}",\n'
+        f"{format_source_line(source_url)}"
         '    mtfType: "computed",\n'
         "    charts: [\n"
         f"{chart_blocks}\n"

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -34,6 +34,7 @@ import sys
 from pathlib import Path
 
 from mtfdigitizer.autotriage import _run_pipeline
+from mtfdigitizer.emit import format_source_line
 from mtfdigitizer.pipeline.types import SampledReading
 from mtfdigitizer.referenceset.charts import REFERENCE_CHARTS, ReferenceChart
 
@@ -222,9 +223,10 @@ def _emit_one_lens(
         total_positions += len(pass_result.extracted.readings)
 
     chart_blocks = "\n".join(blocks)
+    source_url = _source_url(chart.slug, official_urls)
     literal = (
         f'  "{chart.slug}": {{\n'
-        f'    source: "{_source_url(chart.slug, official_urls)}",\n'
+        f"{format_source_line(source_url)}"
         '    mtfType: "computed",\n'
         "    charts: [\n"
         f"{chart_blocks}\n"

--- a/tools/mtfdigitizer/tests/test_emit.py
+++ b/tools/mtfdigitizer/tests/test_emit.py
@@ -8,8 +8,48 @@ from mtfdigitizer.emit import (
     _format_reading,
     _format_value,
     _has_any_data,
+    format_source_line,
 )
 from mtfdigitizer.pipeline.types import SampledReading
+
+
+# --- format_source_line --------------------------------------------------
+# Matches Prettier's printWidth=80 wrap. Without this, lint-staged
+# rewraps long-URL entries and the --check gate (#1296/#1299) reports
+# false positives.
+
+
+def test_format_source_line_single_line_when_under_80() -> None:
+    """Short URL fits on one line."""
+    out = format_source_line("https://example.com/short")
+    assert out == '    source: "https://example.com/short",\n'
+
+
+def test_format_source_line_wraps_when_over_80() -> None:
+    """Long URL wraps onto two lines per Prettier's default."""
+    url = "https://fujifilm-x.com/en-us/products/lenses/gf100-200mmf56-r-lm-ois-wr/"
+    out = format_source_line(url)
+    assert out == f'    source:\n      "{url}",\n'
+
+
+def test_format_source_line_boundary_at_exactly_80() -> None:
+    """A URL that makes the single-line form exactly 80 chars stays
+    single (Prettier wraps strictly >80, not ≥80)."""
+    # Build a URL such that `    source: "<url>",` is exactly 80 chars.
+    # Prefix length: 4 + 8 + 1 + (url) + 2 = 15 + len(url) = 80 → url = 65.
+    url = "https://example.com/" + "a" * (65 - len("https://example.com/"))
+    assert len(url) == 65
+    out = format_source_line(url)
+    assert out == f'    source: "{url}",\n'
+    assert len(out.rstrip("\n")) == 80
+
+
+def test_format_source_line_boundary_at_81_wraps() -> None:
+    """One char over the boundary forces the wrap."""
+    url = "https://example.com/" + "a" * (66 - len("https://example.com/"))
+    assert len(url) == 66
+    out = format_source_line(url)
+    assert out == f'    source:\n      "{url}",\n'
 
 
 def _r(

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,18 @@
+# Python dependencies for tools/ — mtfdigitizer + brand extractors.
+#
+# Install: `cd tools && pip install -r requirements.txt`
+# CI uses this file via `.github/workflows/ci.yml` (pytest job).
+#
+# Floor pins (major-version only) — minor/patch upgrades are
+# expected to stay compatible. Tighten to exact pins if a CI run
+# breaks on a published-but-untested release.
+
+# mtfdigitizer image processing.
+opencv-python>=4.0,<5
+numpy>=2.0,<3
+scikit-image>=0.20,<1
+Pillow>=10,<13
+
+# Test runner + parallel runner (cuts ~5min sequential to ~2min).
+pytest>=8,<10
+pytest-xdist>=3,<4


### PR DESCRIPTION
## Summary

Wires the `tools/` pytest suite into CI so the `emit_*_tier2 --check` gates (#1296/#1300/#1303) actually fire on PRs, not just locally. Triggered by `dorny/paths-filter` on `tools/**` or `.github/workflows/**` changes. Sets up Python 3.13, installs `tools/requirements.txt`, runs `python -m pytest -n auto` (~2min with xdist vs ~5min sequential). Wired into the existing `gate` aggregator so pytest failures block PR merge alongside build/lighthouse.

## Surprise finding (and fix)

Discovered during smoke-test that lint-staged's Prettier pass wraps `source: "<url>",` lines onto two lines when >80 chars, but `emit_*_tier2 --write` was emitting them single-line. After S185's #1306 committed Fuji entries (where Prettier wrapped the source URLs), `--check` reported drift on every long-URL Fuji entry. The S185 hard-assertion test would have failed on the next pytest run — but there was no CI pytest job to catch it. This PR's gate-wiring would have caught the bug immediately; instead we both caught it and fixed it in the same PR.

Fix: new `format_source_line()` helper in `mtfdigitizer/emit.py` matches Prettier's printWidth=80 wrap rule (single line ≤80, wrapped >80). Both Fuji and TTartisan emit scripts now use it. 4 boundary tests added.

## Acceptance criteria
- [x] CI runs `py -m pytest` from `tools/` on PRs that touch `tools/**`
- [x] CI job fails when any pytest test fails (verified locally: 706 pass + 1 xfailed)
- [x] PR-only — deploy workflow unaffected (`gate` extended with `needs.pytest.result`, no changes to deploy.yml)

## Out of scope
- Adding Python tests to `npm run validate` (per the issue).
- TTartisan af-35 override (#1301) — still xfails by 1 cell, gate correctly tolerates.

## Test plan
- [x] `cd tools && py -m pytest -n auto` → 706 passed, 1 xfailed in 2:00
- [x] `cd tools && py -m mtfdigitizer.scripts.emit_fuji_tier2 --check` → exit 0
- [x] `cd tools && py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check` → exit 1 by exactly 1 cell (af-35 override per #1301)
- [x] `npm run validate` → clean
- [x] Workflow YAML syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)