### PR TITLE
feat(mtfdigitizer): override-respecting splice in emit_*_tier2 (#1305)

### DIFF
--- a/docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/eye-read.md
+++ b/docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/eye-read.md
@@ -1,0 +1,48 @@
+# Eye-read — Fujifilm GF 55mm f/1.7 R WR
+
+Scoped to the two cells where the freq40 M ridge tracker mistracks the
+plateau ceiling (issue #1305). The rest of the chart is left to the
+extractor; this file documents only the maintainer-overridden cells
+so the override comment in `src/data/mtf-readings.ts` has a citeable
+ground-truth source.
+
+Per ADR-072 the center symmetry rule fills `(M, S) = (1.0, 1.0)` at
+position 0 when both are None. That is intentional behaviour, not an
+override candidate — even though physically wrong on this chart
+(same class as #1279/viltrox-75). The two cells below are different:
+the chart shows a clearly resolved M40 curve dipping below 1.0, the
+extractor pins it at 1.0, and the chart's own dashed lines give the
+correct readings.
+
+## Source
+
+`docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/fujifilm-gf-55mm-f1-7-r-wr-40lp.png`
+— Fujifilm-published 40 lp/mm MTF chart, single aperture (f/1.7).
+
+The red dashed M40 curve plateaus around 0.92–0.95 across the inner-
+to-mid field, dips at ~18mm, drops to ~0.55 at the edge. Eye precision
+is ±0.02 per cell (half a printed gridline tick at 0.10 spacing).
+
+## f/1.7 — freq 40 M overrides
+
+| Position (mm) | Extractor | Eye-read | Reason                                                |
+| ------------- | --------- | -------- | ----------------------------------------------------- |
+| 10.76         | 1.00      | 0.95     | ridge tracker pins to plateau ceiling; chart at ~0.95 |
+| 13.45         | 1.00      | 0.92     | ridge tracker pins to plateau ceiling; chart at ~0.92 |
+
+Values stated by the maintainer in issue #1305.
+
+## Mistrack pattern
+
+Same family as #1279 (center-anchor overshoot) and #1301 (af-35
+bend-point M30 mistrack): the ridge tracker locks onto the high-MTF
+plateau ceiling instead of following the curve as it dips below 1.0.
+GF 55's case is distinctive in that the mistrack is on inner-to-mid
+positions, not at the center or right corner.
+
+Long-term fix is a ridge-tracker prior that penalizes "value pinned
+at 1.0 across N consecutive positions when paired direction (S) is
+dropping" (fix-path-1 in #1305). Until then the override comment in
+`src/data/mtf-readings.ts` carries the corrected values and the
+override-respecting splice (#1301 fix-path-2) preserves them across
+`emit_fuji_tier2 --write`.

--- a/src/data/mtf-readings.ts
+++ b/src/data/mtf-readings.ts
@@ -5785,7 +5785,10 @@ const mtfReadings: Record<string, MtfData> = {
             samples: {
               10: { S: 0.96, M: 0.98 },
               20: { S: 0.91, M: 0.94 },
-              40: { S: 0.96, M: 1 },
+              // 40 M: eye-read override 0.95 (extractor pins to plateau
+              // ceiling 1.0; chart shows M40 dipping below S40). See
+              // docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/eye-read.md.
+              40: { S: 0.96, M: 0.95 },
             },
           },
           {
@@ -5793,7 +5796,10 @@ const mtfReadings: Record<string, MtfData> = {
             samples: {
               10: { S: 0.93, M: 0.98 },
               20: { S: 0.81, M: 0.94 },
-              40: { S: 0.83, M: 1 },
+              // 40 M: eye-read override 0.92 (extractor pins to plateau
+              // ceiling 1.0; chart shows M40 dipping). See
+              // docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/eye-read.md.
+              40: { S: 0.83, M: 0.92 },
             },
           },
           {
@@ -13586,7 +13592,6 @@ const mtfReadings: Record<string, MtfData> = {
               // ridge tracker still locks onto solid S30 at the right
               // corner crossing despite #1214 fixing pos 14). See
               // docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md.
-              // WARN: emit_ttartisan_tier2 --write will overwrite this.
               30: { S: 0.31, M: 0.58 },
             },
           },

--- a/tools/mtfdigitizer/scripts/_emit_overrides.py
+++ b/tools/mtfdigitizer/scripts/_emit_overrides.py
@@ -1,0 +1,282 @@
+"""Eye-read override preservation for emit_*_tier2 splice (#1301, #1305).
+
+Some MTF chart cells are mistracked by the ridge-tracker extractor but
+the correct value is documented in `docs/optical-specs/<slug>/eye-read.md`.
+The maintainer applies the corrected value inline in
+`src/data/mtf-readings.ts` with a comment block whose first or any line
+contains the literal string ``eye-read override``. Without this module,
+the next `emit_*_tier2 --write` would silently clobber those cells back
+to the (wrong) extractor output.
+
+The detector here scans committed entry text for cells annotated with
+the override marker and returns enough information for the splice to
+swap the override block back over the freshly emitted cell line.
+
+Grammar of an override:
+
+    <indent>// ... eye-read override ... (the marker; may be one of many comment lines)
+    <indent>// ... (zero or more additional comment lines)
+    <indent><freq>: { S: <V>, M: <V> },
+
+The contiguous run of `//` lines immediately above a freq cell line
+is preserved verbatim, along with the cell line itself. Whitespace
+and exact byte content carry through unchanged.
+
+Override key: ``(slug, position_mm, freq)``. The freq line is the
+preservation unit — the comment may say "30 M: override 0.58" but
+the data row is `30: { S: ..., M: ... },`, which is the cell-line
+unit the splice can match against the fresh literal.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# Marker that flags an override comment block. Match is case-sensitive
+# and literal; underscoring/hyphenation variants are explicitly NOT
+# supported — the convention is the literal string ``eye-read override``.
+OVERRIDE_MARKER = "eye-read override"
+
+
+# Cell line: 14 leading spaces (one per emit level: chart → readings →
+# reading → samples → freq), then ``<freq>: { S: ..., M: ... },``.
+# The freq must be an integer; S and M values may be null or numeric.
+_CELL_LINE_RE = re.compile(
+    r"^(?P<indent>\s+)(?P<freq>\d+):\s*\{\s*S:\s*[^,]+,\s*M:\s*[^}]+\},\s*$"
+)
+
+# Position line: ``            position: <value>,`` at the parent indent
+# (12 spaces in emit output). Captures the numeric position.
+_POSITION_LINE_RE = re.compile(
+    r"^\s+position:\s*(?P<pos>-?\d+(?:\.\d+)?),\s*$"
+)
+
+# Aperture line: ``        aperture: "f/N",`` — discriminates which
+# MtfChart panel (which f-stop) a cell belongs to. A single lens has
+# multiple panels (TTartisan: f/max + f/5.6; Fuji zooms: wide + tele),
+# so two cells can share (position, freq) under different apertures.
+_APERTURE_LINE_RE = re.compile(
+    r'^\s+aperture:\s*"(?P<aperture>[^"]+)",\s*$'
+)
+
+# Comment line at the cell indent: ``// ...``. Trailing newline kept off.
+_COMMENT_LINE_RE = re.compile(r"^\s+//.*$")
+
+
+@dataclass(frozen=True)
+class OverrideBlock:
+    """One preserved cell line and its comment block.
+
+    The block is keyed by ``(aperture, position_mm, freq)`` and carries
+    the verbatim text lines (without trailing newlines) so the splice
+    can re-emit them byte-for-byte. Aperture is part of the key because
+    a lens has multiple MtfChart panels (e.g. TTartisan: max + stopped;
+    Fuji zooms: wide + tele) and the same (position, freq) cell appears
+    in each — overrides MUST be panel-specific.
+    """
+
+    aperture: str
+    position_mm: float
+    freq: int
+    comment_lines: tuple[str, ...]
+    cell_line: str
+
+
+# Key shape: (aperture, position_mm, freq).
+OverrideKey = tuple[str, float, int]
+
+
+def parse_overrides(entry_text: str) -> dict[OverrideKey, OverrideBlock]:
+    """Extract override blocks from one committed entry's literal text.
+
+    `entry_text` is the multi-line text of a single ``"slug": { ... },``
+    entry (the slug header line through its closing brace). Returns a
+    dict keyed by ``(aperture, position_mm, freq)`` so the splice can
+    look up overrides per cell within each MtfChart panel.
+
+    A cell qualifies as an override iff the contiguous run of comment
+    lines immediately above it contains the literal ``eye-read override``
+    marker in at least one of those comments.
+    """
+    lines = entry_text.splitlines()
+    overrides: dict[OverrideKey, OverrideBlock] = {}
+
+    current_aperture: str | None = None
+    current_position: float | None = None
+    for index, line in enumerate(lines):
+        ap_match = _APERTURE_LINE_RE.match(line)
+        if ap_match:
+            current_aperture = ap_match.group("aperture")
+            current_position = None
+            continue
+
+        pos_match = _POSITION_LINE_RE.match(line)
+        if pos_match:
+            current_position = float(pos_match.group("pos"))
+            continue
+
+        cell_match = _CELL_LINE_RE.match(line)
+        if (
+            not cell_match
+            or current_aperture is None
+            or current_position is None
+        ):
+            continue
+
+        # Walk backward to collect the contiguous run of comment lines
+        # directly above this cell line.
+        comment_run: list[str] = []
+        scan = index - 1
+        while scan >= 0 and _COMMENT_LINE_RE.match(lines[scan]):
+            comment_run.append(lines[scan])
+            scan -= 1
+        comment_run.reverse()
+
+        if not comment_run:
+            continue
+
+        if not any(OVERRIDE_MARKER in c for c in comment_run):
+            continue
+
+        freq = int(cell_match.group("freq"))
+        overrides[(current_aperture, current_position, freq)] = OverrideBlock(
+            aperture=current_aperture,
+            position_mm=current_position,
+            freq=freq,
+            comment_lines=tuple(comment_run),
+            cell_line=line,
+        )
+
+    return overrides
+
+
+def apply_overrides(
+    fresh_literal: str,
+    overrides: dict[OverrideKey, OverrideBlock],
+) -> str:
+    """Overlay `overrides` onto the freshly-emitted entry literal text.
+
+    For each ``(aperture, position, freq)`` in `overrides`, find the
+    matching cell line in `fresh_literal` (under the corresponding
+    ``aperture:`` panel and ``position:`` reading) and replace it with
+    the override's comment lines followed by the override's cell line.
+
+    Cells in `fresh_literal` that do not have an override pass through
+    unchanged. Overrides whose key no longer appears in the fresh
+    literal are skipped silently — the underlying reading may have
+    been dropped by the extractor (e.g. all-null row drop) or the
+    panel may have been renamed, in which case there is nothing to
+    overlay.
+    """
+    if not overrides:
+        return fresh_literal
+
+    lines = fresh_literal.splitlines(keepends=True)
+    out: list[str] = []
+
+    current_aperture: str | None = None
+    current_position: float | None = None
+    for line in lines:
+        ap_match = _APERTURE_LINE_RE.match(line)
+        if ap_match:
+            current_aperture = ap_match.group("aperture")
+            current_position = None
+            out.append(line)
+            continue
+
+        pos_match = _POSITION_LINE_RE.match(line)
+        if pos_match:
+            current_position = float(pos_match.group("pos"))
+            out.append(line)
+            continue
+
+        cell_match = _CELL_LINE_RE.match(line)
+        if (
+            not cell_match
+            or current_aperture is None
+            or current_position is None
+        ):
+            out.append(line)
+            continue
+
+        freq = int(cell_match.group("freq"))
+        override = overrides.get((current_aperture, current_position, freq))
+        if override is None:
+            out.append(line)
+            continue
+
+        # Replace this cell line with the comment block + override cell
+        # line. Comment lines carry no trailing newline (splitlines()
+        # stripped them in `parse_overrides`), so add one each.
+        for comment in override.comment_lines:
+            out.append(comment + "\n")
+        out.append(override.cell_line + "\n")
+
+    return "".join(out)
+
+
+# --- entry-text extraction ------------------------------------------------
+#
+# Both emit scripts need to pull the text of a single committed entry by
+# slug — the same brace-depth walk the splice already does, but yielding
+# the entry text instead of skipping past it.
+
+
+_ENTRY_OPEN_RE = re.compile(r'^\s*"(?P<slug>[^"]+)":\s*\{\s*$')
+
+
+def overlay_committed_overrides(
+    source: str, fresh_entries: dict[str, str]
+) -> dict[str, str]:
+    """Return a copy of `fresh_entries` with committed overrides preserved.
+
+    For each slug in `fresh_entries`, looks up the entry's existing text
+    in `source`, scans it for `eye-read override` cells, and overlays
+    those cells onto the freshly-emitted literal. Slugs not yet present
+    in `source` (new lenses being added) pass through unchanged.
+
+    This is the single seam both `emit_ttartisan_tier2` and
+    `emit_fuji_tier2` use to gate `--write` on existing overrides
+    without each script knowing about the override grammar.
+    """
+    out: dict[str, str] = {}
+    for slug, fresh_literal in fresh_entries.items():
+        committed = extract_entry_text(source, slug)
+        if committed is None:
+            out[slug] = fresh_literal
+            continue
+        overrides = parse_overrides(committed)
+        out[slug] = apply_overrides(fresh_literal, overrides)
+    return out
+
+
+def extract_entry_text(source: str, slug: str) -> str | None:
+    """Return the multi-line text of one entry's literal, or None.
+
+    Walks `source` line by line; on hitting the entry-open line for
+    `slug`, consumes lines until brace depth returns to zero. Returns
+    the entry's text with trailing newlines preserved on each line.
+
+    Returns None if the slug is not present (a new lens being added),
+    in which case the caller has nothing to preserve.
+    """
+    lines = source.splitlines(keepends=True)
+    n = len(lines)
+    i = 0
+    while i < n:
+        m = _ENTRY_OPEN_RE.match(lines[i])
+        if m and m.group("slug") == slug:
+            collected: list[str] = []
+            brace_depth = 0
+            while i < n:
+                cur = lines[i]
+                collected.append(cur)
+                brace_depth += cur.count("{") - cur.count("}")
+                i += 1
+                if brace_depth <= 0:
+                    break
+            return "".join(collected)
+        i += 1
+    return None

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -46,6 +46,7 @@ from mtfdigitizer.referenceset.charts import (
     PlotBoxCoords,
     ReferenceChart,
 )
+from mtfdigitizer.scripts._emit_overrides import overlay_committed_overrides
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -497,6 +498,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.write:
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        entries = overlay_committed_overrides(source, entries)
         patched = _splice_entries(source, entries)
         MTF_READINGS_PATH.write_text(patched, encoding="utf-8", newline="\n")
         print(
@@ -509,6 +511,7 @@ def main(argv: list[str] | None = None) -> int:
         from mtfdigitizer.scripts._emit_check import report_drift  # noqa: PLC0415
 
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        entries = overlay_committed_overrides(source, entries)
         patched = _splice_entries(source, entries)
         return report_drift(
             MTF_READINGS_PATH,

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -37,6 +37,7 @@ from mtfdigitizer.autotriage import _run_pipeline
 from mtfdigitizer.emit import format_source_line
 from mtfdigitizer.pipeline.types import SampledReading
 from mtfdigitizer.referenceset.charts import REFERENCE_CHARTS, ReferenceChart
+from mtfdigitizer.scripts._emit_overrides import overlay_committed_overrides
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -347,6 +348,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.write:
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        entries = overlay_committed_overrides(source, entries)
         patched = _splice_entries(source, entries)
         MTF_READINGS_PATH.write_text(patched, encoding="utf-8", newline="\n")
         print(
@@ -359,6 +361,7 @@ def main(argv: list[str] | None = None) -> int:
         from mtfdigitizer.scripts._emit_check import report_drift  # noqa: PLC0415
 
         source = MTF_READINGS_PATH.read_text(encoding="utf-8")
+        entries = overlay_committed_overrides(source, entries)
         patched = _splice_entries(source, entries)
         return report_drift(
             MTF_READINGS_PATH,

--- a/tools/mtfdigitizer/tests/test_emit_check.py
+++ b/tools/mtfdigitizer/tests/test_emit_check.py
@@ -84,16 +84,16 @@ def test_report_drift_fail_message_points_to_write(
 # test failure — that is the signal to remove the marker.
 
 
-@pytest.mark.xfail(
-    reason=(
-        "#1296: production mtf-readings.ts is stale for both TTartisan "
-        "and Fuji tier 2 entries. The --check gate correctly reports "
-        "drift; flip to a hard assertion after the bulk-refresh PRs."
-    ),
-    strict=True,
-)
 def test_ttartisan_check_passes_on_production_data() -> None:
-    """Production gate: TTartisan tier 2 entries match the extractor."""
+    """Production gate: TTartisan tier 2 entries match the extractor.
+
+    Flipped from xfail-strict to hard assertion in S187: the af-35
+    eye-read override (the only remaining cell of drift after S184's
+    bulk refresh) is now preserved across `--write` by the override-
+    respecting splice (#1301 fix-path-2). If this regresses, either
+    the splice's override detector broke or a new cell drifted that
+    has no override — investigate before flipping back.
+    """
     from mtfdigitizer.scripts.emit_ttartisan_tier2 import main
 
     assert main(["--check"]) == 0

--- a/tools/mtfdigitizer/tests/test_emit_overrides.py
+++ b/tools/mtfdigitizer/tests/test_emit_overrides.py
@@ -1,0 +1,383 @@
+"""Tests for the override-respecting splice helper (#1301, #1305).
+
+`_emit_overrides.parse_overrides` extracts eye-read override blocks
+from a committed entry's literal text; `apply_overrides` overlays
+those blocks back onto a freshly-emitted literal. The combination
+makes `emit_*_tier2 --write` non-destructive over hand-patched cells.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from mtfdigitizer.scripts._emit_overrides import (
+    OverrideBlock,
+    apply_overrides,
+    extract_entry_text,
+    parse_overrides,
+)
+
+
+# Shape mirrors the af-35 entry as it lives in mtf-readings.ts today
+# (lines 13510–13601). One override at position 12.6 on freq 30; every
+# other cell is plain extractor output.
+AF35_ENTRY = textwrap.dedent('''\
+      "ttartisan-af-35mm-f1-8": {
+        source: "https://www.ttartisan.com/?af-lens/AF-35-II.html",
+        mtfType: "computed",
+        charts: [
+          {
+            aperture: "f/1.8",
+            confidence: "HIGH",
+            readings: [
+              {
+                position: 0,
+                samples: {
+                  10: { S: 0.95, M: 0.95 },
+                  30: { S: 0.79, M: 0.79 },
+                },
+              },
+              {
+                position: 12.6,
+                samples: {
+                  10: { S: 0.71, M: 0.89 },
+                  // 30 M: eye-read override 0.58 (extractor produces 0.66 ---
+                  // ridge tracker still locks onto solid S30 at the right
+                  // corner crossing despite #1214 fixing pos 14). See
+                  // docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md.
+                  // WARN: emit_ttartisan_tier2 --write will overwrite this.
+                  30: { S: 0.31, M: 0.58 },
+                },
+              },
+              {
+                position: 14,
+                samples: {
+                  10: { S: 0.38, M: 0.88 },
+                  30: { S: 0.12, M: null },
+                },
+              },
+            ],
+          },
+        ],
+      },
+''')
+
+
+def test_parse_overrides_finds_marked_cell():
+    """A cell with `eye-read override` in the comment block above is
+    extracted, keyed by (aperture, position, freq)."""
+    overrides = parse_overrides(AF35_ENTRY)
+    assert ("f/1.8", 12.6, 30) in overrides
+    block = overrides[("f/1.8", 12.6, 30)]
+    assert block.aperture == "f/1.8"
+    assert block.position_mm == 12.6
+    assert block.freq == 30
+    # The override cell line is preserved verbatim.
+    assert "S: 0.31, M: 0.58" in block.cell_line
+    # The comment block is the 5 contiguous `//` lines above the cell.
+    assert len(block.comment_lines) == 5
+    assert "eye-read override 0.58" in block.comment_lines[0]
+    assert "WARN" in block.comment_lines[-1]
+
+
+def test_parse_overrides_skips_cells_without_marker():
+    """Cells without `eye-read override` in their comment block stay
+    out of the overrides map."""
+    overrides = parse_overrides(AF35_ENTRY)
+    # pos 0 / 14 have no comment block at all
+    assert ("f/1.8", 0.0, 10) not in overrides
+    assert ("f/1.8", 0.0, 30) not in overrides
+    assert ("f/1.8", 14.0, 10) not in overrides
+    assert ("f/1.8", 14.0, 30) not in overrides
+    # pos 12.6 / freq 10 has no comment block (just neighbouring cell did)
+    assert ("f/1.8", 12.6, 10) not in overrides
+
+
+def test_parse_overrides_ignores_unmarked_comment_block():
+    """A comment block above a cell that does NOT contain the marker
+    is NOT treated as an override."""
+    entry = textwrap.dedent('''\
+              {
+                position: 5.6,
+                samples: {
+                  // some unrelated commentary
+                  // about this cell
+                  10: { S: 0.5, M: 0.5 },
+                },
+              },
+    ''')
+    overrides = parse_overrides(entry)
+    assert overrides == {}
+
+
+def test_parse_overrides_handles_multiple_overrides_in_one_entry():
+    """Two overrides in the same entry both surface, keyed independently."""
+    entry = textwrap.dedent('''\
+              {
+                aperture: "f/1.2",
+                readings: [
+                  {
+                    position: 5.0,
+                    samples: {
+                      // eye-read override 0.4
+                      10: { S: 0.4, M: 0.4 },
+                    },
+                  },
+                  {
+                    position: 10.0,
+                    samples: {
+                      // eye-read override 0.6
+                      30: { S: 0.6, M: 0.6 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    overrides = parse_overrides(entry)
+    assert ("f/1.2", 5.0, 10) in overrides
+    assert ("f/1.2", 10.0, 30) in overrides
+    assert len(overrides) == 2
+
+
+def test_parse_overrides_isolates_per_aperture_panels():
+    """Two panels (apertures) on one lens — an override on one panel
+    MUST NOT apply to a same-(position, freq) cell on the other.
+
+    Regression: the first wiring of this helper keyed only on
+    (position, freq), so the af-35 f/1.8 override at pos 12.6 was
+    incorrectly overlaid onto the f/5.6 cell at the same position
+    during the splice smoke test.
+    """
+    entry = textwrap.dedent('''\
+              {
+                aperture: "f/1.8",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      // eye-read override 0.58
+                      30: { S: 0.31, M: 0.58 },
+                    },
+                  },
+                ],
+              },
+              {
+                aperture: "f/5.6",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      30: { S: 0.82, M: 0.67 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    overrides = parse_overrides(entry)
+    # Only the f/1.8 panel carries the override.
+    assert ("f/1.8", 12.6, 30) in overrides
+    assert ("f/5.6", 12.6, 30) not in overrides
+
+
+def test_apply_overrides_preserves_marker_block():
+    """`apply_overrides` substitutes the override block (comment + cell)
+    for the corresponding cell line in the fresh literal."""
+    fresh = textwrap.dedent('''\
+              {
+                aperture: "f/1.8",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      10: { S: 0.71, M: 0.89 },
+                      30: { S: 0.31, M: 0.66 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    block = OverrideBlock(
+        aperture="f/1.8",
+        position_mm=12.6,
+        freq=30,
+        comment_lines=(
+            "                      // 30 M: eye-read override 0.58",
+            "                      // WARN: ...",
+        ),
+        cell_line="                      30: { S: 0.31, M: 0.58 },",
+    )
+    out = apply_overrides(fresh, {("f/1.8", 12.6, 30): block})
+    # Override comment + cell line are present
+    assert "eye-read override 0.58" in out
+    assert "S: 0.31, M: 0.58" in out
+    # The extractor's wrong value is NOT
+    assert "S: 0.31, M: 0.66" not in out
+    # The non-overridden cell (freq 10) is unchanged
+    assert "10: { S: 0.71, M: 0.89 }" in out
+
+
+def test_apply_overrides_does_not_leak_across_apertures():
+    """An override scoped to one aperture MUST NOT overlay onto a
+    same-(position, freq) cell in a different aperture panel.
+
+    This regression test pins down the bug found in the first wiring:
+    the f/1.8 override at pos 12.6 / freq 30 was applied to the f/5.6
+    cell at the same position during the af-35 --check smoke test.
+    """
+    fresh = textwrap.dedent('''\
+              {
+                aperture: "f/1.8",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      30: { S: 0.31, M: 0.66 },
+                    },
+                  },
+                ],
+              },
+              {
+                aperture: "f/5.6",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      30: { S: 0.82, M: 0.67 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    block = OverrideBlock(
+        aperture="f/1.8",
+        position_mm=12.6,
+        freq=30,
+        comment_lines=("                      // eye-read override 0.58",),
+        cell_line="                      30: { S: 0.31, M: 0.58 },",
+    )
+    out = apply_overrides(fresh, {("f/1.8", 12.6, 30): block})
+    # f/1.8 panel: extractor value replaced
+    assert "M: 0.58" in out
+    # f/5.6 panel: extractor value still present (NOT clobbered)
+    assert "S: 0.82, M: 0.67" in out
+
+
+def test_apply_overrides_no_overrides_returns_input_unchanged():
+    """Empty overrides map → fresh literal returned verbatim."""
+    fresh = "hello\nworld\n"
+    assert apply_overrides(fresh, {}) == fresh
+
+
+def test_apply_overrides_skips_missing_position():
+    """Overrides whose (aperture, position, freq) is not present in the
+    fresh literal are silently skipped — the row may have been dropped
+    by the extractor (e.g. all-null row), nothing to overlay."""
+    fresh = textwrap.dedent('''\
+              {
+                aperture: "f/1.2",
+                readings: [
+                  {
+                    position: 1.4,
+                    samples: {
+                      10: { S: 0.9, M: 0.9 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    block = OverrideBlock(
+        aperture="f/1.2",
+        position_mm=99.0,  # not in fresh
+        freq=30,
+        comment_lines=("// orphaned",),
+        cell_line="                      30: { S: 0.1, M: 0.1 },",
+    )
+    out = apply_overrides(fresh, {("f/1.2", 99.0, 30): block})
+    # Fresh literal is unchanged (no insertion, no removal)
+    assert out == fresh
+
+
+def test_apply_overrides_skips_missing_freq_at_known_position():
+    """Override at a position present in fresh but with a freq the
+    fresh row does not carry — no overlay performed."""
+    fresh = textwrap.dedent('''\
+              {
+                aperture: "f/1.2",
+                readings: [
+                  {
+                    position: 5.0,
+                    samples: {
+                      10: { S: 0.9, M: 0.9 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    block = OverrideBlock(
+        aperture="f/1.2",
+        position_mm=5.0,
+        freq=40,  # fresh row has freq 10 only
+        comment_lines=("// orphaned",),
+        cell_line="                      40: { S: 0.1, M: 0.1 },",
+    )
+    out = apply_overrides(fresh, {("f/1.2", 5.0, 40): block})
+    assert out == fresh
+    assert "40:" not in out
+
+
+def test_extract_entry_text_returns_full_literal():
+    """Pulls one slug's entry text from a multi-entry source."""
+    source = textwrap.dedent('''\
+      const mtfReadings = {
+        "lens-a": {
+          source: "https://a/",
+          mtfType: "computed",
+          charts: [
+            { aperture: "f/1.2", confidence: "HIGH", readings: [] },
+          ],
+        },
+        "lens-b": {
+          source: "https://b/",
+          mtfType: "computed",
+          charts: [],
+        },
+      };
+    ''')
+    entry_a = extract_entry_text(source, "lens-a")
+    assert entry_a is not None
+    assert '"lens-a"' in entry_a
+    assert '"lens-b"' not in entry_a
+    assert "https://a/" in entry_a
+    assert "https://b/" not in entry_a
+
+
+def test_extract_entry_text_returns_none_when_slug_absent():
+    """A slug not present in source returns None (new lens being added)."""
+    source = '"other-lens": {\n  source: "https://x/",\n},\n'
+    assert extract_entry_text(source, "missing") is None
+
+
+def test_roundtrip_af35_override_survives_overlay():
+    """End-to-end on the af-35 shape: parse the committed entry, then
+    overlay onto a fresh literal where the override cell has the
+    extractor's wrong value — the override wins."""
+    overrides = parse_overrides(AF35_ENTRY)
+    fresh = textwrap.dedent('''\
+              {
+                aperture: "f/1.8",
+                readings: [
+                  {
+                    position: 12.6,
+                    samples: {
+                      10: { S: 0.71, M: 0.89 },
+                      30: { S: 0.31, M: 0.66 },
+                    },
+                  },
+                ],
+              },
+    ''')
+    out = apply_overrides(fresh, overrides)
+    assert "M: 0.58" in out
+    assert "M: 0.66" not in out
+    # WARN line carried over too
+    assert "WARN" in out


### PR DESCRIPTION
## Summary

- New `tools/mtfdigitizer/scripts/_emit_overrides.py` parses committed `mtf-readings.ts` entries for cells annotated with the literal marker `eye-read override` in the preceding comment block, keys them by `(aperture, position_mm, freq)`, and overlays them onto the freshly-emitted literal before splicing. Both `emit_fuji_tier2` and `emit_ttartisan_tier2` use the helper in their `--write` and `--check` paths so the two modes always agree.
- Applied to GF 55mm f/1.7 freq40 M at pos 10.76 (extractor 1.0 → 0.95) and pos 13.45 (1.0 → 0.92) — ridge tracker pins to plateau ceiling; chart reads documented in `docs/optical-specs/fujifilm-gf-55mm-f1-7-r-wr/eye-read.md`. Stale `WARN: --write will overwrite this` line dropped from the existing af-35 pos 12.6 override block.
- `test_ttartisan_check_passes_on_production_data` flipped from xfail-strict to hard assertion (last remaining drift cell now preserved by the override-respecting splice). 720 mtfdigitizer pytest pass, 0 xfailed.

## Why per-aperture keying

The first wiring keyed only on `(position, freq)`; the smoke test caught a real cross-panel leak — af-35's f/1.8 override at pos 12.6 / freq 30 was incorrectly overlaid onto the f/5.6 cell at the same position. Aperture is now part of the override key and a regression test pins the isolation.

## Issue closure

- **Closes #1305** — GF 55 freq40 M at pos 10.76 / 13.45 now reads from the eye-read values via the override block.
- **Related #1301** — fix-path-2 (per-cell override-respecting splice) is done in this PR; fix-path-1 (ridge-tracker fix for af-35 pos 12.6) remains open. The override is now durable across `--write`, so the urgency on the extractor fix is lower; #1301 stays open until someone takes the deeper ridge-tracker work.

## Test plan

- [x] `py -m pytest -n auto` from `tools/` — 720 passed, 0 xfailed (was 706 + 1 xfailed).
- [x] `py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check` → OK.
- [x] `py -m mtfdigitizer.scripts.emit_fuji_tier2 --check` → OK.
- [x] `npm run validate` → 462 pages built; format/lint/check/tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)