### PR TITLE
docs(mtf): redirect af-35 pos 12.6 override comments to #1224

### DIFF
--- a/docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md
+++ b/docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md
@@ -62,21 +62,33 @@ Read each cell at the intersection of the green vertical sample line and the cur
 | 12.6          | 0.95 | 0.91 | 0.82  | 0.67  |
 | 14.0          | 0.88 | 0.88 | 0.49! | 0.63! |
 
-## Manual artifact patches (#1201)
+## Manual artifact patches (#1201 → #1224)
 
-The extractor mistracks the dashed grey M30 F1.8 at the right corner
-(frac 0.9 reads as 0.66, frac 1.0 reads as 0.17 — actually the solid
-S30 silhouette inverted into M30). Until the ridge tracker is fixed,
-three downstream artifacts carry hand-patched M30 right-edge values
-matching the eye-read above (0.58 at frac 0.9, 0.50 at frac 1.0):
+The extractor still mistracks the dashed grey M30 F1.8 at the bend
+column (frac 0.9 reads as 0.66 — the ridge DP slides through an
+intermediate AA-halo band at col ~510 instead of staying on the
+dashed M30 ridge; see #1217 / S168 for the mechanism analysis).
+Deeper extractor fix tracked as #1224 (anchor-signal repair).
+
+frac 1.0 / pos 14.0 used to read as 0.17 (border-line contamination)
+but #1223 / ADR-060 stripped the plot-box border from the grey mask;
+the extractor now correctly returns None there because the chart's
+M30 dashed curve genuinely fades before x_right. The eye-read 0.50
+is extrapolation past where data exists.
+
+Until #1224 lands, three downstream artifacts carry hand-patched M30
+right-edge values matching the eye-read above (0.58 at frac 0.9,
+0.50 at frac 1.0):
 
 - `ttartisan-af-35mm-f1-8-mtf-max.svg` — points and dots at x=277.2 and x=304.0
 - `ttartisan-af-35mm-f1-8-mtf-max-overlay.png` — re-rendered with patched readings
-- `src/data/mtf-readings.ts` — position 12.6 M30 cell (also flagged with #1202)
+- `src/data/mtf-readings.ts` — position 12.6 M30 cell; durability across
+  `emit_ttartisan_tier2 --write` provided by the override-respecting
+  splice (#1305 / S187), not just the regression test (#1202).
 
 The auto-generated `digitization-log.md` correctly shows the extractor's
-actual reading (0.17 at frac 1.0) — do not patch it; it is the diagnostic
-record for the future ridge-tracker fix.
+actual reading (`—` at frac 1.0, 0.66 at frac 0.9) — do not patch it;
+it is the diagnostic record for #1224.
 
 ## Transcribing to GT
 

--- a/src/data/mtf-readings.ts
+++ b/src/data/mtf-readings.ts
@@ -13589,9 +13589,13 @@ const mtfReadings: Record<string, MtfData> = {
             samples: {
               10: { S: 0.71, M: 0.89 },
               // 30 M: eye-read override 0.58 (extractor produces 0.66 —
-              // ridge tracker still locks onto solid S30 at the right
-              // corner crossing despite #1214 fixing pos 14). See
-              // docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md.
+              // ridge DP slides through an intermediate AA-halo band at
+              // col ~510 instead of staying on the dashed M30 ridge;
+              // anchor-seed signal too noisy to fix at the cost-function
+              // layer per #1217 / S168). Deeper extractor fix tracked as
+              // #1224. Override is durable across emit_ttartisan_tier2
+              // --write via the override-respecting splice (#1305 / S187).
+              // See docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md.
               30: { S: 0.31, M: 0.58 },
             },
           },


### PR DESCRIPTION
## Summary

Two stale `#1214` / `#1201`-era references in the af-35 pos 12.6 M30 override block, corrected after S168's #1217 close-out:

1. **`src/data/mtf-readings.ts`** — the inline comment claimed "ridge tracker still locks onto solid S30 at the right corner crossing despite #1214 fixing pos 14." But:
   - #1214 was closed `wontdo`.
   - Pos 14 was actually fixed by #1223 / ADR-060 (plot-box border strip).
   - The residual mechanism per S168's raw-mask probe is **intermediate AA-halo band drift** at col ~510, not a direct ridge swap.
   - The durability claim is now correct: S187 / PR #1310 shipped the override-respecting splice (#1305).

2. **`docs/optical-specs/ttartisan-af-35mm-f1-8/eye-read.md`** "Manual artifact patches" section — still framed both frac 0.9 + frac 1.0 as needing hand-patches. After #1223 the extractor returns honest `None` at frac 1.0 (chart genuinely fades before x_right; maintainer GT 0.50 is eye-read extrapolation per S168). Section now matches current state and points readers at #1224 instead of #1214.

## Why

Surfaced while triaging #1301 — the issue effectively asked for fix-path-1 (deeper ridge-tracker fix) on top of fix-path-2 (override-respecting splice). Fix-path-2 shipped in S187. Fix-path-1 is the same residual cell that S168 spun off as #1224 (anchor-signal repair for noisy grey-mask charts). The codepath comments still pointed at #1214's closed framing.

## Test plan

- [x] `py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check` → OK (override marker `eye-read override` preserved in new comment so #1305's splice still detects it)
- [x] `npm test` → 224/224 pass (no data change)
- [x] `npm run validate` → 462 pages built; format/lint/check/build clean

## Issue closure

- **Closes #1301** as duplicate of #1224 (also marked `duplicate` label and explained on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)