### PR TITLE
chore(submodule): bump solid-ai-templates 962a134 → ba2843d (60 commits)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,22 @@ score row. This keeps one home for audit history (avoids the two-locations
 split a separate history file creates) and preserves the reasoning behind
 each score. Do NOT re-create `docs/360-audit.md`. Deviation flagged upstream.
 
+### 5.4 Dev journal format (upstream deviation)
+
+`base/core/docs.md` now mandates reverse-chronological dev journals
+(newest first) with `## YYYY-MM-DD — Short theme` headings and
+bold-labelled `**Tool**` / `**Key changes**` / `**PRs merged**` /
+`**Issues**` / `**Lesson**` fields. This project deliberately deviates:
+`docs/dev-journal.md` is chronological (oldest first) with
+`### Session N — Theme` headings and a `Date: · Tool:` byline + free-form
+`#### PRs` / `#### Issues opened / closed` / `#### Key technical findings` /
+`#### Key changes` / `#### Verification` / `#### Key decisions` /
+`#### Process patterns observed` / `#### Follow-ups for next session` /
+`#### State of the project` subsections. 188 entries deep; migration is
+expensive and the chronological order matches how sessions are written
+and read. Deviation flagged upstream. Match prior-entry skeleton when
+appending (see [[feedback_match_doc_convention]]).
+
 ## 6. Session Protocol
 
 Follow `docs/solid-ai-templates/templates/base/workflow/scope.md` for scope guard and end-of-session audit.
@@ -382,7 +398,7 @@ execution prevents missed steps.
 [ ] 9. ONBOARDING.md — for each new tool, prerequisite, or setup step, is it documented? Name the section.
 [ ] 10. PLAYBOOK.md — first list every new command and script introduced this session. Then check: is each one documented? Name the section. Do not batch-dismiss.
 [ ] 11. Submodules — check if upstream needs update
-[ ] 12. Flag conventions for solid-ai-templates upstream — list each new convention/decision by name and evaluate individually. No blanket "nothing reusable." For each: state project-specific or reusable; if reusable, name the upstream template file and create an issue
+[ ] 12. Flag conventions for solid-ai-templates upstream — list each new convention/decision by name and evaluate individually. No blanket "nothing reusable." For each: state project-specific or reusable; if reusable, name the upstream template file AND file the issue on github.com/braboj/solid-ai-templates this session — per `base/workflow/scope.md` end-of-session step 11, naming a candidate is not contributing it
 [ ] 13. Review sources — list every new external link used this session for tech specs, optical specs, or lab/field reviews. For each: is it already in `src/data/reviews.ts` or `docs/bookmarks.md`? If not, bookmark it and evaluate whether it should be added as a review source.
 [ ] 14. Summarize what was done and what's next
 ```


### PR DESCRIPTION
## Summary

Brings the `docs/solid-ai-templates` submodule from v2.9.0 (`962a134`) to current main (`ba2843d`) — 60 upstream commits. 12 of the 19 MANDATORY STARTUP templates have material rule changes; many are direct upstreams of wuseria's own lessons (probe-first workflow, `--check` on bulk-emit scripts, generator/formatter fixed-point, same-day ADR supersession, etc.).

## Already-aligned with upstream (no wuseria action needed)

- **Startup checklist 9→10 steps** (deploy-health on main): CLAUDE.md §6.1 already does this.
- **Probe-before-acting, --check on bulk emit scripts, calibration-aid rules, fail-loud auto-derivation, ADR same-day supersession**: already wuseria practice (S168/S182/S184/S185/S187 sessions all demonstrate the patterns).

## Real deviations flagged in this PR

1. **§5.4 added** — dev journal format. Upstream `base/core/docs.md` now mandates reverse-chronological + `## YYYY-MM-DD — Short theme` + bold-labelled fields. Wuseria is chronological + `### Session N — Theme` with `Date: · Tool:` byline and `#### PRs` / `#### Key changes` / etc. subsections. 188 entries deep; migration cost is high and chronological matches how sessions are written and read. Deviation flagged upstream — will file an issue during S189 wrap-up per step 12.
2. **§6.3 step 12 strengthened** — to match upstream `base/workflow/scope.md` step 11's new requirement: upstream candidates must be FILED as github.com/braboj/solid-ai-templates issues this session, not just named.

## New every-turn rules absorbed (no CLAUDE.md change needed; live in submodule)

- MUST scan in-source audit comments before editing a file (`[ai-workflow-read-edit-site]`)
- MUST repeat closing keyword per issue number in PR bodies (`Closes #a, closes #b` not `Closes #a, #b`)
- MUST file upstream issue for each reusable convention (encoded in §6.3 step 12 above)

## Test plan

- [x] `npm run validate` clean: 462 pages built, links checked, format/lint/check pass
- [x] 224/224 vitest pass
- [x] Submodule pointer correctly tracks `origin/main` of `braboj/solid-ai-templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)