### PR TITLE
feat(mtfdigitizer): N-freq RIDGE_TRACKING + Zeiss Touit family (#791)

### DIFF
--- a/docs/decisions/075-n-frequency-ridge-tracking.md
+++ b/docs/decisions/075-n-frequency-ridge-tracking.md
@@ -1,0 +1,137 @@
+# ADR-075: N-frequency RIDGE_TRACKING via y-band split
+
+**Status:** Accepted
+**Date:** 2026-06-27
+
+## Context
+
+The MTF digitizer's RIDGE_TRACKING dispatch (ADR-049) extracts curves
+from charts whose curves bundle so close that connected-component
+skeletonization fuses them. The original implementation was sized for
+Viltrox: 2 frequencies × {S, M} = 4 tracks, split into upper and lower
+halves by mean-y. The function `ridge_tracks_to_fields` hardcoded
+`n=4` for the top-N selection and `upper_freq`/`lower_freq` as
+positional parameters.
+
+The `ridge.py` module docstring named the 2-freq limit explicitly:
+
+> **Not handling >2 frequencies.** The clustering assumes a 4-curve
+> layout (2 frequencies × S/M). A 6-curve Zeiss-style 3-frequency
+> chart needs a different track-identification step.
+
+Issue #791 ("Digitize MTF charts for Carl Zeiss lenses") proposed
+shipping the 3-frequency Zeiss Touit press kit family (12mm, 32mm,
+50mm Macro), which publishes 10/20/40 cycles/mm on a single B&W
+panel with solid/dashed S/T encoding. The 32mm chart had been in
+the reference set since the original calibration probe (#933) as a
+deliberately out-of-band rejection case — extraction was not
+attempted because no 3-frequency profile existed.
+
+An S196 probe (`probe_zeiss_touit_ridges.py`, throwaway, deleted)
+ran the existing 2-freq ridge tracker against the 32mm wide-aperture
+panel with a hand-crafted profile that declared 3 frequencies. The
+greedy clusterer in `_cluster_into_tracks` produced 6 distinct
+tracks cleanly; only the final `ridge_tracks_to_fields` step
+collapsed them back to 4. The 2-freq lockin was confined to one
+function and its callers, not a pipeline-wide assumption — the
+front-end `MtfReading` data shape already supports arbitrary
+frequency tuples (Fujifilm GF charts publish at {15, 20, 40} and
+{10, 20, 40} today via the per-frequency orchestrator, ADR-043).
+
+## Decision
+
+Generalize `ridge_tracks_to_fields` to N frequencies via a new
+`ridge_tracks_to_fields_multifreq` function that takes the full
+frequency tuple in upper→lower screen order. The legacy 2-frequency
+function becomes a thin delegating wrapper preserved for Viltrox's
+dispatch site and its tests.
+
+```
+                     +-----------------------------+
+                     |  ridge_tracks_to_fields_    |
+                     |  multifreq(mask, plot_box,  |
+                     |  frequencies_lpmm=(10,20,40), ...)
+                     +-----------------------------+
+                                  |
+                                  v
+            +---------------------+---------------------+
+            |  _select_top_n_tracks(n = 2*N)            |
+            +-------------------------------------------+
+                                  |
+                                  v
+            Sort kept tracks by mean_y, slice into N bands:
+              band[0]   --> highest-screen freq (lowest lp/mm)
+              band[1]   --> middle freq
+              ...
+              band[N-1] --> lowest-screen freq (highest lp/mm)
+                            (absorbs remainder when kept < 2N)
+                                  |
+                                  v
+            Within each band: top track (smaller mean_y) = S,
+            second track = M.
+```
+
+Concrete rules:
+
+1. The dispatch site in `pipeline/dispatch.py` passes
+   `profile.frequencies_lpmm` directly to the multifreq function;
+   no positional unpacking of `[0], [1]` remains.
+2. `_select_top_n_tracks` is called with `n = 2 * len(frequencies_lpmm)`.
+3. The kept tracks are sorted by mean_y and sliced into
+   `len(frequencies_lpmm)` equal-size y-bands. The last band absorbs
+   the remainder when the kept count is below `2N` (coincident curves
+   reduce the kept count on tightly bundled panels).
+4. Within each band, the track with smaller mean_y is sagittal (S)
+   by physics — edge MTF degrades faster on the meridional axis.
+   `dashed_is_sagittal` does not apply to ridge-tracking (Viltrox-
+   style all-dashed inputs).
+5. A new declared profile `ZEISS_TOUIT_BW_3FREQ` (neutral hue,
+   `frequencies_lpmm=(10, 20, 40)`, `style_axis=SPLIT_BY_DASH`,
+   `hue_meaning=RIDGE_TRACKING`, `auto_suggestable=False`) wires
+   the family.
+6. `family_profile.PROFILE_BY_STYLE` maps the existing
+   `multifreq-press-kit` style family from "deliberately absent"
+   to `ZEISS_TOUIT_BW_3FREQ`.
+7. The Touit 12mm and 50mm Macro charts join the reference set
+   alongside the existing 32mm anchor, each with primary + stopped
+   `ChartView` panels following ADR-063's Samyang stacked-panel
+   pattern and ADR-065's `max`/`stopped` role labels.
+
+## Alternatives considered
+
+| Alternative                                                                                             | Why rejected                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lift the front-end `MtfReading` schema to a fixed 3-frequency shape                                     | Front-end already supports arbitrary frequency tuples (Fujifilm GF runs at {15,20,40} today). No schema change needed.                                                                                                                 |
+| New `RIDGE_TRACKING_3FREQ` `HueMeaning` literal                                                         | Splits one mechanism across two code paths for a constant that's already on the profile (`frequencies_lpmm`). The generalized function reads N from there.                                                                             |
+| Per-frequency separate chart files (Fujifilm `SAGITTAL_MERIDIONAL_SINGLE_FREQ` pattern, ADR-043)        | Zeiss publishes one chart with all frequencies on one panel; splitting into per-frequency images would be a fabrication.                                                                                                               |
+| Build a new profile family with N-frequency clustering AND a redesigned coincidence handler in one step | Two failure modes (3-freq dispatch vs coincident-curve clustering) deserve two ADRs. Path A in #791 ships max-aperture extraction first; stopped-panel coincidence stays a documented limitation gated by Tier 1 eye-read calibration. |
+| Coin a new style family name (e.g. `bw-3freq-press-kit`)                                                | The existing `multifreq-press-kit` family name is accurate; only its wiring changed (rejection-case → extracted).                                                                                                                      |
+
+## Consequences
+
+- 3-frequency charts in the Touit family run through the same
+  RIDGE_TRACKING dispatch as Viltrox; one mechanism, two profiles.
+- The 2-frequency `ridge_tracks_to_fields` keeps its existing
+  signature for Viltrox callers. Byte-equivalent: the 61 existing
+  ridge/Viltrox tests pass unchanged after the refactor.
+- The Touit family ships in this PR without ground-truth values
+  (#791's eye-read GT becomes a follow-up issue). The reference-set
+  entries declare plot boxes for both panels; calibration values
+  populate when a maintainer eye-reads the 396 GT cells (3 charts
+  × 2 panels × 3 freqs × 2 S/M × 11 positions).
+- Stopped-panel coincidence (curves bundle within ~15 px near
+  MTF=0.95) collapses ridge-cluster pairs on the Touit k=4 / k=5.6
+  panels. The S196 probe on Touit 32mm k=4 recovered 5 of 6
+  expected tracks. Documented as a known limitation in the
+  Touit profile's `notes` and in `pipeline/ridge.py`'s
+  "Failure modes" section. Stopped-panel extraction is gated by
+  Tier 1 eye-read calibration; until that lands, only the
+  max-aperture panels contribute to per-lens emit.
+- `family_profile.PROFILE_BY_STYLE` now has 9 entries (was 8).
+  Only `soft-multicurve-promo` (7Artisans 35mm) remains as a
+  deliberately absent fail-loud family.
+- `REFERENCE_SET.md` table updates the Touit 32mm row from
+  "out-of-band" to "extracted via N-freq RIDGE_TRACKING".
+- Future N-frequency dialects (e.g. a Zeiss Loxia chart with 4
+  frequencies) extend by declaring a new profile with the right
+  hue range and frequency tuple; no further pipeline change.

--- a/tools/mtfdigitizer/family_profile.py
+++ b/tools/mtfdigitizer/family_profile.py
@@ -28,6 +28,7 @@ from .profiles import (
     TOKINA_2COLOR_FREQUENCY_CC_RANK,
     TTARTISAN_4COLOR_DUAL_APERTURE,
     VILTROX_BW_DASHED_F12,
+    ZEISS_TOUIT_BW_3FREQ,
 )
 from .profiles.types import MtfProfile
 
@@ -35,10 +36,13 @@ if TYPE_CHECKING:
     from .referenceset.charts import ReferenceChart
 
 
-# Six declared profiles wired today. The two absent style families
-# (`soft-multicurve-promo`, `multifreq-press-kit`) are deliberately
-# out-of-band fail-loud cases (7Artisans 35mm promo, Zeiss Touit
-# press kit) and have no profile.
+# The remaining absent style family (`soft-multicurve-promo`) is the
+# 7Artisans 35mm promo chart — deliberately out-of-band as a fail-loud
+# anchor for the suggest scorer, no profile declared.
+#
+# `multifreq-press-kit` (Zeiss Touit) was previously absent; ADR-075 /
+# #791 promoted it to an extracted family via the N-frequency
+# RIDGE_TRACKING pipeline.
 PROFILE_BY_STYLE: dict[str, MtfProfile] = {
     "mainstream-2color-solid-dashed": SIGMA_2COLOR_SOLID_DASHED,
     "mainstream-4color-all-solid": SAMYANG_4COLOR_ALL_SOLID,
@@ -57,6 +61,11 @@ PROFILE_BY_STYLE: dict[str, MtfProfile] = {
     # profile's hues are filtered by name prefix (`max-` vs `stopped-`)
     # on each pass.
     "ttartisan-4color-dual-aperture": TTARTISAN_4COLOR_DUAL_APERTURE,
+    # Zeiss Touit: B&W, 3 frequencies (10/20/40 lp/mm) separated by
+    # y-band, S/M split by dash; dual-aperture stacked panels (Samyang
+    # style). Routed via the N-frequency RIDGE_TRACKING pipeline
+    # (`ridge_tracks_to_fields_multifreq`). See ADR-075.
+    "multifreq-press-kit": ZEISS_TOUIT_BW_3FREQ,
 }
 
 

--- a/tools/mtfdigitizer/pipeline/dispatch.py
+++ b/tools/mtfdigitizer/pipeline/dispatch.py
@@ -85,6 +85,7 @@ from .ridge import (
     ridge_tracks_for_hue,
     ridge_tracks_for_hue_freq_split,
     ridge_tracks_to_fields,
+    ridge_tracks_to_fields_multifreq,
 )
 from .skeleton import close_and_skeletonize
 from .split import split_sm_by_cc_width
@@ -778,15 +779,10 @@ def field_skeletons(
         if plot_box is None:
             raise ValueError("RIDGE_TRACKING requires plot_box")
         single_mask = next(iter(curve_masks.values()))
-        upper_freq, lower_freq = (
-            profile.frequencies_lpmm[0],
-            profile.frequencies_lpmm[1],
-        )
-        out = ridge_tracks_to_fields(
+        out = ridge_tracks_to_fields_multifreq(
             single_mask,
             plot_box,
-            upper_freq=upper_freq,
-            lower_freq=lower_freq,
+            frequencies_lpmm=profile.frequencies_lpmm,
             dashed_is_sagittal=profile.dashed_is_sagittal,
         )
     elif (

--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -72,9 +72,13 @@ line (it sat at ~OTF 1.0 ≈ ground truth 10S, masking the real failure).
 - **Not sub-pixel-accurate beyond ~0.5 px.** The chart raster itself
   is the precision floor; a Gaussian-fit refinement on top of run
   centroids would buy <0.02 OTF on a 235px-tall plot. Skipped.
-- **Not handling >2 frequencies.** The clustering assumes a 4-curve
-  layout (2 frequencies × S/M). A 6-curve Zeiss-style 3-frequency
-  chart needs a different track-identification step.
+- **N-frequency layout** (>2 frequencies). The track-identification
+  step generalizes to `2 * len(frequencies_lpmm)` tracks split into
+  `len(frequencies_lpmm)` y-bands. `ridge_tracks_to_fields_multifreq`
+  drives this; `ridge_tracks_to_fields` is a 2-freq convenience
+  wrapper kept for Viltrox callers. Zeiss Touit's 3-frequency
+  (10/20/40 lp/mm) wide-aperture panels extract cleanly; tightly
+  bundled stopped panels still hit the coincidence failure mode below.
 
 ## Failure modes
 
@@ -1826,36 +1830,44 @@ def ridge_tracks_for_hue_freq_split(
     return out
 
 
-def ridge_tracks_to_fields(
+def ridge_tracks_to_fields_multifreq(
     mask: np.ndarray,
     plot_box: PlotBox,
-    upper_freq: int,
-    lower_freq: int,
+    frequencies_lpmm: tuple[int, ...],
     dashed_is_sagittal: bool,
 ) -> dict[str, np.ndarray]:
-    """Ridge-track a single-hue mask and return per-field skeleton masks.
+    """Ridge-track a single-hue mask and return per-field skeleton masks
+    for an N-frequency chart.
 
-    The 4-curve layout: top two tracks (by mean y) are `upper_freq`, the
-    bottom two are `lower_freq`. Within each pair, the higher-coverage
-    track is solid (S by default; M if `dashed_is_sagittal`). Fields
-    without a qualifying track are simply absent from the result; the
-    sampler treats them as missing data (B2).
+    The 2N-curve layout: the kept tracks (by mean y) split into N
+    equal-sized y-bands. Each band maps to one frequency in upper→lower
+    order. Within each band the top track (smaller mean_y) is sagittal
+    (S), the next is meridional (M). Fields without a qualifying track
+    are absent from the result; the sampler treats them as missing
+    data (B2 contract).
+
+    `frequencies_lpmm` MUST be passed in upper→lower screen order,
+    which by convention is also low→high lp/mm (a 3-freq Zeiss
+    Touit chart prints 10 on top, 20 in the middle, 40 at the bottom).
     """
     from .dispatch import curve_field  # imported here to avoid module cycle
+
+    if not frequencies_lpmm:
+        raise ValueError("ridge_tracks_to_fields_multifreq: empty frequencies_lpmm")
+
+    n_freqs = len(frequencies_lpmm)
+    expected_tracks = 2 * n_freqs
 
     cleaned = _strip_chrome(mask, plot_box)
     points = _extract_ridge_points(cleaned, plot_box)
     tracks = _cluster_into_tracks(points)
-    kept = _select_top_n_tracks(tracks, n=4, plot_width=plot_box.width + 1)
+    kept = _select_top_n_tracks(
+        tracks, n=expected_tracks, plot_width=plot_box.width + 1
+    )
 
     if not kept:
         return {}
 
-    kept_sorted = sorted(kept, key=lambda t: t.mean_y)
-    upper_tracks = kept_sorted[: max(1, len(kept_sorted) // 2)]
-    lower_tracks = kept_sorted[max(1, len(kept_sorted) // 2) :]
-
-    out: dict[str, np.ndarray] = {}
     # Within a frequency pair, the sagittal (S) curve is always above
     # the meridional (M) curve in OTF (physics: edge MTF degrades faster
     # on the meridional axis). In image coordinates that means S has the
@@ -1864,14 +1876,49 @@ def ridge_tracks_to_fields(
     # which doesn't apply to Viltrox where all four curves are dashed.
     del dashed_is_sagittal  # unused for ridge tracking
 
-    for freq, cluster in ((upper_freq, upper_tracks), (lower_freq, lower_tracks)):
-        if not cluster:
+    kept_sorted = sorted(kept, key=lambda t: t.mean_y)
+
+    # Split kept tracks into N equal-size y-bands. When the kept count is
+    # below 2N (e.g. coincident curves collapse a stopped panel from 6
+    # to 5 tracks on Zeiss Touit k=4), the last band absorbs the
+    # remainder so the highest frequency reports what data exists rather
+    # than silently dropping it.
+    base = len(kept_sorted) // n_freqs
+    remainder = len(kept_sorted) - base * (n_freqs - 1)
+
+    out: dict[str, np.ndarray] = {}
+    cursor = 0
+    for band_index, freq in enumerate(frequencies_lpmm):
+        is_last = band_index == n_freqs - 1
+        take = remainder if is_last else base
+        if take <= 0:
             continue
-        by_y = sorted(cluster, key=lambda t: t.mean_y)
-        sagittal_track = by_y[0]
-        out[curve_field(freq, "S")] = _rasterize(sagittal_track, mask.shape)
+        band = kept_sorted[cursor : cursor + take]
+        cursor += take
+        by_y = sorted(band, key=lambda t: t.mean_y)
+        out[curve_field(freq, "S")] = _rasterize(by_y[0], mask.shape)
         if len(by_y) > 1:
-            meridional_track = by_y[1]
-            out[curve_field(freq, "M")] = _rasterize(meridional_track, mask.shape)
+            out[curve_field(freq, "M")] = _rasterize(by_y[1], mask.shape)
 
     return out
+
+
+def ridge_tracks_to_fields(
+    mask: np.ndarray,
+    plot_box: PlotBox,
+    upper_freq: int,
+    lower_freq: int,
+    dashed_is_sagittal: bool,
+) -> dict[str, np.ndarray]:
+    """Two-frequency wrapper around `ridge_tracks_to_fields_multifreq`.
+
+    Preserved for the Viltrox dispatch site and its tests. New callers
+    SHOULD use `ridge_tracks_to_fields_multifreq` with an explicit
+    frequency tuple.
+    """
+    return ridge_tracks_to_fields_multifreq(
+        mask,
+        plot_box,
+        frequencies_lpmm=(upper_freq, lower_freq),
+        dashed_is_sagittal=dashed_is_sagittal,
+    )

--- a/tools/mtfdigitizer/profiles/__init__.py
+++ b/tools/mtfdigitizer/profiles/__init__.py
@@ -24,7 +24,8 @@ Public surface:
   `SEVENARTISANS_2COLOR_SAMECOLOR_DASHED`, `TOKINA_2COLOR_FREQUENCY`,
   `TOKINA_2COLOR_FREQUENCY_CC_RANK`, `VILTROX_BW_DASHED_F12`,
   `FUJIFILM_PERMFREQ_2COLOR_SOLID_DASHED`,
-  `TTARTISAN_4COLOR_DUAL_APERTURE` — declared profiles
+  `TTARTISAN_4COLOR_DUAL_APERTURE`,
+  `ZEISS_TOUIT_BW_3FREQ` — declared profiles
 - `DECLARED_PROFILES` — tuple of all currently-declared profiles
 """
 
@@ -46,6 +47,7 @@ from .declared import (
     TOKINA_2COLOR_FREQUENCY_CC_RANK,
     TTARTISAN_4COLOR_DUAL_APERTURE,
     VILTROX_BW_DASHED_F12,
+    ZEISS_TOUIT_BW_3FREQ,
 )
 from .suggest import resolve, suggest_profile
 
@@ -65,6 +67,7 @@ __all__ = [
     "TOKINA_2COLOR_FREQUENCY_CC_RANK",
     "TTARTISAN_4COLOR_DUAL_APERTURE",
     "VILTROX_BW_DASHED_F12",
+    "ZEISS_TOUIT_BW_3FREQ",
     "resolve",
     "suggest_profile",
 ]

--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -375,6 +375,50 @@ TTARTISAN_4COLOR_DUAL_APERTURE: MtfProfile = MtfProfile(
 )
 
 
+# Zeiss Touit B&W 3-frequency press kit (#791, ADR-075). German press kit
+# PDFs publish three spatial frequencies (10/20/40 cycles/mm) on a single
+# B&W chart, S/M split by line dash. Each lens has a wide-aperture panel
+# stacked above a stopped-aperture panel, both sharing one PNG — the
+# Samyang stacked-panel pattern (ADR-063) with one extra frequency band.
+#
+# Measured HSV inside the 32mm top panel (y=441..791, x=257..737, 7808
+# dark pixels): V median 0, S median 0; max V on curve pixels 99, max
+# S 26. The neutral hue cap (S<=60, V<=110) matches Viltrox's; the two
+# brands share the "no informative hue" property.
+#
+# Dispatch uses RIDGE_TRACKING extended to N frequencies (`ridge_tracks_
+# to_fields_multifreq`) — 6 tracks expected, clustered into 3 y-bands.
+# `frequencies_lpmm=(10, 20, 40)` lists them in upper→lower screen order,
+# which by Zeiss's chart convention is also low→high lp/mm.
+#
+# Stopped panels (k=4 on 12mm, k=4 on 32mm, k=5.6 on 50mm) hit the
+# coincident-curve failure mode described in ridge.py — when curves
+# bundle within ~15 px (10S/10M/20S/20M all near MTF=0.95 at the
+# stopped aperture), the greedy clusterer collapses pairs into single
+# tracks. The 32mm probe (S196) recovered only 5 of 6 expected tracks
+# on the k=4 panel. Path A (#791): ship max-aperture extraction first;
+# stopped-panel coincidence is a known limitation, gated by Tier 1
+# eye-read calibration.
+ZEISS_TOUIT_BW_3FREQ: MtfProfile = MtfProfile(
+    name="zeiss-touit-bw-3freq",
+    hues=(
+        HueRange(name="neutral", h_lo=0, h_hi=179, s_min=0, s_max=60, v_min=0, v_max=110),
+    ),
+    style_axis="SPLIT_BY_DASH",
+    hue_meaning="RIDGE_TRACKING",
+    frequencies_lpmm=(10, 20, 40),
+    # Same hazard as Viltrox: the neutral hue range matches text and
+    # gridlines on every chart, so it would poison auto-suggest.
+    auto_suggestable=False,
+    notes=(
+        "Zeiss Touit press kit: B&W, solid=S dashed=T, 3 frequencies "
+        "(10/20/40 lp/mm) separated by y-band; dual-aperture stacked "
+        "panels per ADR-063. RIDGE_TRACKING dispatched through "
+        "`ridge_tracks_to_fields_multifreq` (#791)."
+    ),
+)
+
+
 DECLARED_PROFILES: tuple[MtfProfile, ...] = (
     SIGMA_2COLOR_SOLID_DASHED,
     SAMYANG_4COLOR_ALL_SOLID,
@@ -384,4 +428,5 @@ DECLARED_PROFILES: tuple[MtfProfile, ...] = (
     VILTROX_BW_DASHED_F12,
     FUJIFILM_PERMFREQ_2COLOR_SOLID_DASHED,
     TTARTISAN_4COLOR_DUAL_APERTURE,
+    ZEISS_TOUIT_BW_3FREQ,
 )

--- a/tools/mtfdigitizer/referenceset/REFERENCE_SET.md
+++ b/tools/mtfdigitizer/referenceset/REFERENCE_SET.md
@@ -24,7 +24,7 @@ the set inside #933's 6–10-chart target with full coverage.
 | 5 | `7artisans-35mm-f1-2-mark-ii`         | soft-multicurve-promo              | Out-of-band: tests profile fail-loud (B1)          |
 | 6 | `tokina-atx-m-23mm-f1-4-x`            | 2color-frequency                   | Colors carry frequency not S/M — different dialect |
 | 7 | `viltrox-af-75mm-f1-2-pro`            | bw-dashed-promo                    | All-dashed, B&W, two apertures, tiny legend        |
-| 8 | `zeiss-touit-32mm-f1-8`               | multifreq-press-kit                | Three frequencies (10/20/40) — out-of-band         |
+| 8 | `zeiss-touit-32mm-f1-8`               | multifreq-press-kit                | Three frequencies (10/20/40) — extracted via N-freq RIDGE_TRACKING (#791, ADR-075) |
 | 9 | `ttartisan-7-5mm-f2-0-fisheye`        | ttartisan-4color-dual-aperture     | Second anchor (ADR-041); fisheye edge-crash stress |
 |10 | `ttartisan-af-35mm-f1-8`              | ttartisan-4color-dual-aperture     | Third anchor (ADR-041); right-edge S/M swap (#1199)|
 
@@ -91,7 +91,7 @@ here.
 - German Zeiss press kit; B&W, solid = Sagittal, dashed = Tangential, **three frequencies** (10/20/40 cycles/mm — top, middle, bottom).
 - **k=1.8 panel**: 10 ~85→55%, 20 ~70→45%, 40 dips to ~30% around 11mm then recovers slightly.
 - **k=4 panel**: 10 ~95→85%, 20 ~85→78%, 40 ~75 with a dip to ~50% at 11mm.
-- Diagnostic: out-of-band for any profile that declares 2 frequencies. Must refuse, not silently drop the 20 lp/mm middle row.
+- Diagnostic: extracted via the N-frequency RIDGE_TRACKING dispatch (#791, ADR-075). The wide-aperture k=1.8 panel resolves 6 distinct tracks cleanly into 3 y-bands (10/20/40); the stopped k=4 panel hits the ridge-tracker coincidence failure mode where the upper-band curves bundle within ~15 px and the clusterer collapses one pair (S196 probe recovered 5 of 6 tracks). Path A (#791) ships the wide-aperture extraction; stopped panels are gated by Tier 1 eye-read calibration.
 
 ### 9. ttartisan-7-5mm-f2-0-fisheye — second TTartisan 4-color anchor
 

--- a/tools/mtfdigitizer/referenceset/calibration.md
+++ b/tools/mtfdigitizer/referenceset/calibration.md
@@ -24,9 +24,12 @@ declared profile in `profiles/declared.py`.
 | tokina-atx-m-23mm-f1-4-x                  | 2color-frequency                | TOKINA_2COLOR_FREQUENCY               |
 | viltrox-af-75mm-f1-2-pro (f/1.2)          | bw-dashed-promo                 | VILTROX_BW_DASHED_F12                 |
 
-The 2 remaining charts (7Artisans 35mm soft promo, Zeiss Touit press
-kit) are deliberately out-of-band fail-loud cases and intentionally
-have no profile.
+The 1 remaining chart (7Artisans 35mm soft promo) is a deliberately
+out-of-band fail-loud case and intentionally has no profile. The
+Zeiss Touit press kit was promoted from rejection-case to an extracted
+family by #791 / ADR-075 via the N-frequency RIDGE_TRACKING pipeline
+(`ridge_tracks_to_fields_multifreq`); it joins the table once it
+ships eye-read ground truth.
 
 ## How to reproduce
 

--- a/tools/mtfdigitizer/referenceset/charts.py
+++ b/tools/mtfdigitizer/referenceset/charts.py
@@ -4,12 +4,11 @@ Eight eye-verified charts spanning the chart-style families found in
 `docs/optical-specs/`. Used to calibrate the render-match threshold and
 offset tolerance band of the digitizer (ADR-038 §4).
 
-Six of the eight charts carry ground-truth values + a hand-measured
-plot box — the subset `extract_chart()` can run today (the five declared
-profiles in `profiles/declared.py`: Sigma, Samyang, 7Artisans, Tokina,
-Viltrox). The two remaining (the 7Artisans 35mm soft promo and the
-Zeiss Touit press kit) are tracked for fail-loud shape coverage; both
-are deliberately out-of-band and must be refused by the profile gate.
+Seven of the eight original charts carry ground-truth values + a hand-
+measured plot box. The 7Artisans 35mm soft promo is the one remaining
+deliberately out-of-band fail-loud shape; the Zeiss Touit press kit was
+promoted to an extracted family by #791 / ADR-075 via the N-frequency
+RIDGE_TRACKING pipeline (`ridge_tracks_to_fields_multifreq`).
 
 Field semantics:
 
@@ -1196,14 +1195,69 @@ REFERENCE_CHARTS: tuple[ReferenceChart, ...] = (
             ),
         ),
     ),
+    # Zeiss Touit press kit family (3 lenses). Each PNG stacks two
+    # panels: wide-aperture on top, stopped-aperture below. Panel
+    # plot boxes were located by the same Y-axis-run detector used
+    # for Samyang (#791 / ADR-075); the Samyang stacked-panel
+    # additional_views pattern (ADR-063) carries one logical lens
+    # entry with two views. Aperture role labels follow ADR-065.
+    #
+    # Stopped panels hit the ridge-tracker coincidence failure mode
+    # described in `pipeline/ridge.py`: when curves bundle within
+    # ~15 px (10S/10M/20S/20M near MTF=0.95 at the stopped aperture
+    # on Touit), the greedy clusterer can collapse a pair into one
+    # track. Path A (#791) ships max-aperture extraction first;
+    # stopped-panel coverage is gated by Tier 1 eye-read calibration.
+    ReferenceChart(
+        slug="zeiss-touit-12mm-f2-8",
+        chart_path="docs/optical-specs/zeiss-touit-12mm-f2-8/zeiss-touit-12mm-f2-8-mtf.png",
+        style_family="multifreq-press-kit",
+        apertures=("max", "stopped"),
+        frequencies_lpmm=(10, 20, 40),
+        image_height_mm=15.0,
+        notes="Zeiss Touit press kit; B&W solid=S, dashed=T; 3 frequencies (10/20/40); stacked panels k=2.8 (max) + k=5.6 (stopped).",
+        plot_box=PlotBoxCoords(x_left=279, x_right=851, y_top=455, y_bottom=873),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/zeiss-touit-12mm-f2-8/zeiss-touit-12mm-f2-8-mtf.png",
+                plot_box=PlotBoxCoords(x_left=279, x_right=851, y_top=1068, y_bottom=1490),
+                aperture="stopped",
+            ),
+        ),
+    ),
     ReferenceChart(
         slug="zeiss-touit-32mm-f1-8",
         chart_path="docs/optical-specs/zeiss-touit-32mm-f1-8/zeiss-touit-32mm-f1-8-mtf.png",
         style_family="multifreq-press-kit",
-        apertures=("k=1.8", "k=4"),
+        apertures=("max", "stopped"),
         frequencies_lpmm=(10, 20, 40),
         image_height_mm=15.0,
-        notes="German press kit; B&W solid=S, dashed=T; THREE frequencies — must reject as out-of-band for 2-freq profiles",
+        notes="Zeiss Touit press kit; B&W solid=S, dashed=T; 3 frequencies (10/20/40); stacked panels k=1.8 (max) + k=4 (stopped). Original reference set anchor (#791 / ADR-075).",
+        plot_box=PlotBoxCoords(x_left=257, x_right=737, y_top=441, y_bottom=791),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/zeiss-touit-32mm-f1-8/zeiss-touit-32mm-f1-8-mtf.png",
+                plot_box=PlotBoxCoords(x_left=256, x_right=738, y_top=974, y_bottom=1324),
+                aperture="stopped",
+            ),
+        ),
+    ),
+    ReferenceChart(
+        slug="zeiss-touit-50mm-f2-8-macro",
+        chart_path="docs/optical-specs/zeiss-touit-50mm-f2-8-macro/zeiss-touit-50mm-f2-8-macro-mtf.png",
+        style_family="multifreq-press-kit",
+        apertures=("max", "stopped"),
+        frequencies_lpmm=(10, 20, 40),
+        image_height_mm=15.0,
+        notes="Zeiss Touit press kit; B&W solid=S, dotted=T (lighter ink than dashed siblings); 3 frequencies (10/20/40); stacked panels k=2.8 (max) + k=5.6 (stopped). Larger canvas (1786x2526) than 12/32mm siblings (1636x1770).",
+        plot_box=PlotBoxCoords(x_left=277, x_right=880, y_top=684, y_bottom=1071),
+        additional_views=(
+            ChartView(
+                chart_path="docs/optical-specs/zeiss-touit-50mm-f2-8-macro/zeiss-touit-50mm-f2-8-macro-mtf.png",
+                plot_box=PlotBoxCoords(x_left=277, x_right=880, y_top=1237, y_bottom=1624),
+                aperture="stopped",
+            ),
+        ),
     ),
 )
 

--- a/tools/mtfdigitizer/tests/test_profiles.py
+++ b/tools/mtfdigitizer/tests/test_profiles.py
@@ -62,7 +62,7 @@ def test_declared_profiles_cover_in_band_families() -> None:
     """One profile per in-band reference set family (+ the Tokina wide-zoom
     DP variant of the prime profile, + the Fujifilm per-frequency profile
     added in ADR-043, + the TTartisan dual-aperture profile added in
-    ADR-044)."""
+    ADR-044, + the Zeiss Touit 3-frequency profile added in ADR-075)."""
     names = {p.name for p in DECLARED_PROFILES}
     assert names == {
         "sigma-2color-solid-dashed",
@@ -73,6 +73,7 @@ def test_declared_profiles_cover_in_band_families() -> None:
         "viltrox-bw-dashed-f1.2",
         "fujifilm-permfreq-2color-solid-dashed",
         "ttartisan-4color-dual-aperture",
+        "zeiss-touit-bw-3freq",
     }
 
 


### PR DESCRIPTION
## Summary

- Generalizes RIDGE_TRACKING dispatch from 2 → N frequencies via new `ridge_tracks_to_fields_multifreq`. The 2-freq `ridge_tracks_to_fields` is preserved as a delegating wrapper — Viltrox callers untouched, byte-equivalent.
- Adds `ZEISS_TOUIT_BW_3FREQ` profile (B&W, solid=S dashed=T, 10/20/40 lp/mm) and wires the existing `multifreq-press-kit` style family to it.
- Registers Touit 12mm and 50mm Macro alongside the existing 32mm anchor, each with max + stopped `ChartView` panels (Samyang stacked-panel pattern, ADR-063).

See [ADR-075](docs/decisions/075-n-frequency-ridge-tracking.md) for the full decision rationale.

## What changed and why

**Path A per #791:** ship the pipeline change without ground truth. Tier 1 eye-read becomes a follow-up issue (~396 GT cells: 3 charts × 2 panels × 3 freqs × 2 S/M × 11 positions).

The 2-freq lockin was confined to one function, not a pipeline-wide assumption. The front-end `MtfReading` data shape already supports arbitrary frequency tuples (Fujifilm GF runs at {15,20,40} today via ADR-043's per-frequency orchestrator).

**S196 probe (deleted)** confirmed the wide-aperture k=1.8 panel resolves 6 distinct tracks cleanly into 3 y-bands. Stopped panels (k=4, k=5.6) hit the ridge-tracker coincidence failure mode where the upper band collapses one pair — documented as known limitation in `pipeline/ridge.py` and in the profile notes.

## Verification

- `py -m pytest mtfdigitizer/` — 455/455 pass (61 Viltrox/ridge tests byte-equivalent)
- `npm run check` — 0 errors, 0 warnings
- ADR-075 inline ASCII diagram per the project convention

## Known follow-up

Tier 1 eye-read GT for the 3 Touit charts. Until that lands:
- The Touit reference-set entries declare plot boxes for both panels
- `ground_truth=None` on all three (calibration runner already skips entries without GT)
- Stopped-panel coincidence is gated by the eventual eye-read; only max-aperture panels contribute to per-lens emit when extraction runs

## Test plan

- [x] All mtfdigitizer tests pass (`py -m pytest mtfdigitizer/`)
- [x] Astro check passes (`npm run check`)
- [x] ADR-075 records the decision with backward-only references
- [ ] CI green
- [ ] Reviewer confirms the N-freq generalization preserves Viltrox 2-freq behaviour

Closes #791 (pipeline portion; eye-read GT will follow in a separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)