### PR TITLE
fix: exclude eye-read.md from prettier (#1336)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,7 @@ downloaded_files/
 docs/optical-specs/**/*-review.html
 docs/optical-specs/**/*-mtf*.svg
 docs/optical-specs/**/digitization-log.md
+docs/optical-specs/**/eye-read.md
 
 # Python tooling — own pytest suites, not part of the front-end gate
 tools/


### PR DESCRIPTION
## Summary
- Add `docs/optical-specs/**/eye-read.md` to `.prettierignore`, mirroring the existing `digitization-log.md` exclusion
- Closes #1336

The scaffolder (`mtfdigitizer.scripts.scaffold_anchor_helpers`) owns the table formatting in `eye-read.md`. Prettier touching it on commit produces silent staleness — `scaffold_anchor_helpers --check` then reports drift on a clean checkout. This is the `quality-gates-scope-agreement` trap ("ignore lists and CI path-filter MUST agree").

Scope-tight: ignore line only. The 6 existing eye-read.md files on main are already in drift-state from prior prettier passes; re-emitting them is a separate follow-up that would surface as a noisy diff (and risks overwriting maintainer `!`/`?` marks if the preservation logic has edge cases). This PR prevents future drift; a follow-up can re-emit the 6 existing files if/when CI wires `--check` as a staleness gate.

## Test plan
- [x] Reproduce: `cd tools && py -m mtfdigitizer.scripts.scaffold_anchor_helpers fujifilm-gf-23mm-f4-r-lm-wr --check` reports `differ` on main
- [x] Confirm prettier now ignores: `npx prettier --check docs/optical-specs/fujifilm-gf-23mm-f4-r-lm-wr/eye-read.md` reports clean (file matches Prettier-ignored set)
- [ ] CI green (lint/format/check/test/build, gitleaks, CodeQL, links)

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)