### PR TITLE
fix(data): refresh 5 Sigma MTF source URLs after slug rename (#1339)

### DIFF
--- a/src/data/mtf-readings.ts
+++ b/src/data/mtf-readings.ts
@@ -391,7 +391,7 @@ const mtfReadings: Record<string, MtfData> = {
     ],
   },
   "sigma-10-18mm-f2-8-dc-dn-c": {
-    source: "https://www.sigma-global.com/en/lenses/c023_10_28/",
+    source: "https://www.sigma-global.com/en/lenses/c023_10_18_28/",
     mtfType: "computed",
     charts: [
       {
@@ -565,7 +565,7 @@ const mtfReadings: Record<string, MtfData> = {
     ],
   },
   "sigma-16-300mm-f3-5-6-7-dc-os-c": {
-    source: "https://www.sigma-global.com/en/lenses/c025_16_300/",
+    source: "https://www.sigma-global.com/en/lenses/c025_16_300_35_67/",
     mtfType: "computed",
     charts: [
       {
@@ -739,7 +739,7 @@ const mtfReadings: Record<string, MtfData> = {
     ],
   },
   "sigma-17-40mm-f1-8-dc-art": {
-    source: "https://www.sigma-global.com/en/lenses/a025_17_40/",
+    source: "https://www.sigma-global.com/en/lenses/a025_17_40_18/",
     mtfType: "computed",
     charts: [
       {
@@ -913,7 +913,7 @@ const mtfReadings: Record<string, MtfData> = {
     ],
   },
   "sigma-18-50mm-f2-8-dc-dn-c": {
-    source: "https://www.sigma-global.com/en/lenses/c021_18_50/",
+    source: "https://www.sigma-global.com/en/lenses/c021_18_50_28/",
     mtfType: "computed",
     charts: [
       {
@@ -1087,7 +1087,7 @@ const mtfReadings: Record<string, MtfData> = {
     ],
   },
   "sigma-100-400mm-f5-6-3-dg-dn-os-c": {
-    source: "https://www.sigma-global.com/en/lenses/c020_100_400/",
+    source: "https://www.sigma-global.com/en/lenses/c020_100_400_5_63/",
     mtfType: "computed",
     charts: [
       {


### PR DESCRIPTION
## Summary

Sigma rewrote lens slugs on `sigma-global.com/en/lenses/` to embed the aperture suffix, breaking the scheduled External Link Check on `main` (run [28364975938](https://github.com/Imbra-Ltd/wuseria/actions/runs/28364975938), 2026-06-29). `lenses.ts` `officialUrl` fields were already correct; `mtf-readings.ts` held stale duplicates.

5 one-line `source:` updates:

| Slug change |
|---|
| `c023_10_28` -> `c023_10_18_28` |
| `c025_16_300` -> `c025_16_300_35_67` |
| `a025_17_40` -> `a025_17_40_18` |
| `c021_18_50` -> `c021_18_50_28` |
| `c020_100_400` -> `c020_100_400_5_63` |

## Test plan
- [x] All 5 new URLs return 200 (verified with curl)
- [x] `npm run validate` passes (lint + format + check + test + build)
- [ ] CI green
- [ ] Next scheduled External Link Check passes

Closes #1339

Same drift class as #1062. Architectural follow-up (look up `officialUrl` from `lenses.ts` instead of duplicating in `mtf-readings.ts`) is noted in #1339's body but not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)