### PR TITLE
fix(mtfdigitizer): drop emit-side source field after #1342 removed it

### DIFF
--- a/tools/mtfdigitizer/emit.py
+++ b/tools/mtfdigitizer/emit.py
@@ -200,28 +200,8 @@ ChartPanel = tuple[
 ]
 
 
-def format_source_line(source: str) -> str:
-    """Render the `    source: "<url>",` line for a top-level entry.
-
-    Matches Prettier's default printWidth=80 wrap: single line when the
-    full `    source: "<url>",` fits in 80 chars, otherwise wrapped as
-
-        source:
-          "<url>",
-
-    Without this, the bulk-emit output drifts under lint-staged's
-    Prettier pass and the --check gate (#1296/#1299) reports false
-    positives on every long-URL entry.
-    """
-    single = f'    source: "{source}",'
-    if len(single) <= 80:
-        return single + "\n"
-    return f'    source:\n      "{source}",\n'
-
-
 def _format_entry(
     slug: str,
-    source: str,
     mtf_type: str,
     panels: tuple[ChartPanel, ...],
 ) -> str:
@@ -237,7 +217,6 @@ def _format_entry(
     )
     return (
         f"  \"{slug}\": {{\n"
-        f"{format_source_line(source)}"
         f"    mtfType: \"{mtf_type}\",\n"
         "    charts: [\n"
         f"{chart_blocks}\n"
@@ -282,7 +261,6 @@ def _verdict_for_panel(
 
 def emit_lens(
     chart: ReferenceChart,
-    source_url: str,
     mtf_type: str = "measured",
     aperture: str | None = None,
     focal_lengths: tuple[int, ...] | None = None,
@@ -290,8 +268,6 @@ def emit_lens(
 ) -> EmitResult:
     """Extract one reference chart and serialize to a TS object literal.
 
-    `source_url` becomes the `source` field on the emitted entry — the
-    canonical attribution URL that the lens page renders below the chart.
     `mtf_type` becomes the `mtfType` field — "computed" for manufacturer
     charts derived from optical design (Sigma, Fujifilm, Nikon), "measured"
     for review-lab charts from a tested sample (LensTip, Optical Limits).
@@ -303,6 +279,11 @@ def emit_lens(
     focal length), omitted for primes. When supplied, its length must
     match `chart.views`; values are zipped in primary-then-additional
     order.
+
+    Attribution URL: the lens page renders the URL below the chart from
+    `lens.officialUrl` at render time (see
+    `src/pages/lenses/[slug].astro`). No `source` field is emitted here
+    (removed in #1342 to eliminate the URL-duplication drift class).
     """
     if chart.plot_box is None:
         raise ValueError(
@@ -371,76 +352,12 @@ def emit_lens(
         slug=chart.slug,
         ts_literal=_format_entry(
             slug=chart.slug,
-            source=source_url,
             mtf_type=mtf_type,
             panels=tuple(panels),
         ),
         positions_emitted=total_positions,
         null_counts=null_counts,
     )
-
-
-# Mapping from reference chart slug to the source URL the lens page
-# should cite. Kept here rather than on ReferenceChart because
-# attribution is an emit-step concern, not a calibration concern.
-_DEFAULT_SOURCES: dict[str, str] = {
-    "sigma-12mm-f1-4-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c025_12_14/"
-    ),
-    "sigma-15mm-f1-4-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c026_15_14/"
-    ),
-    "sigma-23mm-f1-4-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c023_23_14/"
-    ),
-    "sigma-56mm-f1-4-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c018_56_14/"
-    ),
-    "samyang-85mm-f1-4-as-if-umc": (
-        "https://www.lksamyang.com/en/product/product-view.php?seq=311"
-    ),
-    "samyang-300mm-f6-3-ed-umc-cs-reflex": (
-        "https://www.lksamyang.com/en/product/product-view.php?seq=355"
-    ),
-    "viltrox-af-75mm-f1-2-pro": (
-        "https://viltrox.com/products/75mm-f12-xf-lens"
-    ),
-    "tokina-atx-m-23mm-f1-4-x": (
-        "https://www.lenstip.com/665.1-Lens_review-Tokina_atx-m_23_mm_f_1.4_X-Introduction.html"
-    ),
-    "tokina-atx-m-33mm-f1-4-x": (
-        "https://tokinalens.com/product/atx_m_33mm_f1_4_x/"
-    ),
-    "tokina-atx-m-56mm-f1-4-x": (
-        "https://tokinalens.com/product/atx_m_56mm_f1_4_x/"
-    ),
-    "tokina-atx-m-11-18mm-f2-8-x-at-11mm": (
-        "https://tokinalens.com/product/atx_m_11_18mm_f2_8_x/"
-    ),
-    "tokina-atx-m-11-18mm-f2-8-x-at-18mm": (
-        "https://tokinalens.com/product/atx_m_11_18mm_f2_8_x/"
-    ),
-    "7artisans-50mm-f1-2-mark-ii": (
-        "https://7artisans.store/products/7artisans-50mm-f-1-2-mark-ii-prime-lens"
-    ),
-    # Sigma zooms — #793. Two-panel diffraction MTF (wide + tele) per
-    # ADR-033; see _DEFAULT_FOCAL_LENGTHS below for the mm values.
-    "sigma-10-18mm-f2-8-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c023_10_28/"
-    ),
-    "sigma-16-300mm-f3-5-6-7-dc-os-c": (
-        "https://www.sigma-global.com/en/lenses/c025_16_300/"
-    ),
-    "sigma-17-40mm-f1-8-dc-art": (
-        "https://www.sigma-global.com/en/lenses/a025_17_40/"
-    ),
-    "sigma-18-50mm-f2-8-dc-dn-c": (
-        "https://www.sigma-global.com/en/lenses/c021_18_50/"
-    ),
-    "sigma-100-400mm-f5-6-3-dg-dn-os-c": (
-        "https://www.sigma-global.com/en/lenses/c020_100_400/"
-    ),
-}
 
 
 # Focal length (mm) per emitted panel, in primary-then-additional view
@@ -482,14 +399,6 @@ def main(argv: list[str] | None = None) -> int:
         if chart is None:
             print(f"ERROR: unknown slug {slug!r}", file=sys.stderr)
             return 1
-        source = _DEFAULT_SOURCES.get(slug)
-        if source is None:
-            print(
-                f"ERROR: no default source URL for {slug!r}; "
-                f"add to _DEFAULT_SOURCES",
-                file=sys.stderr,
-            )
-            return 1
         focal_lengths = _DEFAULT_FOCAL_LENGTHS.get(slug)
         if len(chart.views) > 1 and focal_lengths is None:
             print(
@@ -501,7 +410,6 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         result = emit_lens(
             chart,
-            source_url=source,
             mtf_type=args.mtf_type,
             focal_lengths=focal_lengths,
         )

--- a/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_fuji_tier2.py
@@ -21,9 +21,9 @@ script appends each entry to `src/data/mtf-readings.ts` at the
 sentinel position just before the closing `};` of the `mtfReadings`
 record. Entries already present (matching slug) are replaced in place.
 
-`source` URL is derived from the lens slug:
-`https://fujifilm-x.com/global/products/lenses/<slug-without-fujifilm->/`.
-The maintainer can adjust per-lens after the bulk emission.
+Attribution URL: the lens page reads the chart's source URL from
+`lens.officialUrl` at render time (see `src/pages/lenses/[slug].astro`).
+No `source` field is emitted here (removed in #1342).
 """
 
 from __future__ import annotations
@@ -35,7 +35,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from mtfdigitizer.emit import format_source_line
 from mtfdigitizer.family_profile import profile_for_chart
 from mtfdigitizer.per_frequency import parse_filename_frequency
 from mtfdigitizer.pipeline import extract_chart
@@ -51,19 +50,9 @@ from mtfdigitizer.scripts._emit_overrides import overlay_committed_overrides
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MTF_READINGS_PATH = REPO_ROOT / "src" / "data" / "mtf-readings.ts"
-LENSES_PATH = REPO_ROOT / "src" / "data" / "lenses.ts"
 
 
 _VIEW_INFIX_RE = re.compile(r"-(?P<view>wide|tele)-\d+lp\.png$", re.IGNORECASE)
-
-# Match a single top-level lens entry: from `^  {` to the matching `^  },`.
-_LENS_BLOCK_RE = re.compile(r"^  \{$.*?^  \},?$", re.DOTALL | re.MULTILINE)
-_BRAND_RE = re.compile(r'^\s*brand:\s*"([^"]+)"', re.MULTILINE)
-_MODEL_RE = re.compile(r'^\s*model:\s*"([^"]+)"', re.MULTILINE)
-# `officialUrl:` may have the value on the same line or wrapped to the next.
-_OFFICIAL_URL_RE = re.compile(
-    r'^\s*officialUrl:\s*(?:\n\s*)?"([^"]+)"', re.MULTILINE
-)
 
 
 def _to_plotbox(
@@ -254,57 +243,7 @@ def _format_chart_block(
     )
 
 
-_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
-
-
-def _to_slug(brand_model: str) -> str:
-    """Port of src/utils/slug.ts:toSlug — must stay byte-equivalent.
-
-    "Fujifilm GF 23mm f/4 R LM WR" → "fujifilm-gf-23mm-f4-r-lm-wr"
-    """
-    lowered = brand_model.lower().replace("/", "")
-    return _NON_ALNUM_RE.sub("-", lowered).strip("-")
-
-
-def _load_official_urls() -> dict[str, str]:
-    """Parse `src/data/lenses.ts` into a slug → officialUrl mapping.
-
-    Lenses without an officialUrl field are omitted; the caller decides
-    what to do (we fail loud in `_source_url` rather than emit a 404).
-    """
-    text = LENSES_PATH.read_text(encoding="utf-8")
-    mapping: dict[str, str] = {}
-    for block_match in _LENS_BLOCK_RE.finditer(text):
-        block = block_match.group(0)
-        brand_match = _BRAND_RE.search(block)
-        model_match = _MODEL_RE.search(block)
-        url_match = _OFFICIAL_URL_RE.search(block)
-        if not (brand_match and model_match and url_match):
-            continue
-        slug = _to_slug(f"{brand_match.group(1)} {model_match.group(1)}")
-        mapping[slug] = url_match.group(1)
-    return mapping
-
-
-def _source_url(slug: str, official_urls: dict[str, str]) -> str:
-    """Return the verified Fujifilm product URL for `slug`.
-
-    Reads from `lenses.ts`'s `officialUrl` field rather than deriving
-    from the slug — Fujifilm's URL pattern uses a region segment
-    (`/en-us/`) and hyphenated suffixes that simple slug-mangling
-    cannot reconstruct. See issue #1062.
-    """
-    if slug not in official_urls:
-        raise KeyError(
-            f"No officialUrl found in lenses.ts for {slug!r}. Add the "
-            f"field to the lens entry before re-running this script."
-        )
-    return official_urls[slug]
-
-
-def _emit_one_lens(
-    chart: ReferenceChart, official_urls: dict[str, str]
-) -> tuple[str, int, int]:
+def _emit_one_lens(chart: ReferenceChart) -> tuple[str, int, int]:
     """Build the TS object literal for one Fuji lens.
 
     Returns (literal, panel_count, total_positions). Lenses with zoom
@@ -359,10 +298,8 @@ def _emit_one_lens(
         total_positions += len(merged)
 
     chart_blocks = "\n".join(blocks)
-    source_url = _source_url(chart.slug, official_urls)
     literal = (
         f'  "{chart.slug}": {{\n'
-        f"{format_source_line(source_url)}"
         '    mtfType: "computed",\n'
         "    charts: [\n"
         f"{chart_blocks}\n"
@@ -481,12 +418,11 @@ def main(argv: list[str] | None = None) -> int:
         print("No Fujifilm Tier 2 lenses found.", file=sys.stderr)
         return 1
 
-    official_urls = _load_official_urls()
     entries: dict[str, str] = {}
     total_positions = 0
     total_panels = 0
     for chart in lenses:
-        literal, panels, positions = _emit_one_lens(chart, official_urls)
+        literal, panels, positions = _emit_one_lens(chart)
         entries[chart.slug] = literal
         total_panels += panels
         total_positions += positions

--- a/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/scripts/emit_ttartisan_tier2.py
@@ -21,9 +21,9 @@ Without `--write` the literals print to stdout for review. With it, the
 script splices each entry into `src/data/mtf-readings.ts` using the
 same shape as `emit_fuji_tier2._splice_entries`.
 
-`source` URL comes from each lens's `officialUrl` field in
-`src/data/lenses.ts` — never re-derived from the slug (per #1062 the
-TTartisan brand URL pattern is not slug-mangle-recoverable).
+Attribution URL: the lens page reads the chart's source URL from
+`lens.officialUrl` at render time (see `src/pages/lenses/[slug].astro`).
+No `source` field is emitted here (removed in #1342).
 """
 
 from __future__ import annotations
@@ -34,7 +34,6 @@ import sys
 from pathlib import Path
 
 from mtfdigitizer.autotriage import _run_pipeline
-from mtfdigitizer.emit import format_source_line
 from mtfdigitizer.pipeline.types import SampledReading
 from mtfdigitizer.referenceset.charts import REFERENCE_CHARTS, ReferenceChart
 from mtfdigitizer.scripts._emit_overrides import overlay_committed_overrides
@@ -42,16 +41,6 @@ from mtfdigitizer.scripts._emit_overrides import overlay_committed_overrides
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MTF_READINGS_PATH = REPO_ROOT / "src" / "data" / "mtf-readings.ts"
-LENSES_PATH = REPO_ROOT / "src" / "data" / "lenses.ts"
-
-
-# Match a single top-level lens entry: from `^  {` to the matching `^  },`.
-_LENS_BLOCK_RE = re.compile(r"^  \{$.*?^  \},?$", re.DOTALL | re.MULTILINE)
-_BRAND_RE = re.compile(r'^\s*brand:\s*"([^"]+)"', re.MULTILINE)
-_MODEL_RE = re.compile(r'^\s*model:\s*"([^"]+)"', re.MULTILINE)
-_OFFICIAL_URL_RE = re.compile(
-    r'^\s*officialUrl:\s*(?:\n\s*)?"([^"]+)"', re.MULTILINE
-)
 
 
 def _format_value(v: float | None) -> str:
@@ -127,49 +116,7 @@ def _format_chart_block(
     )
 
 
-_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
-
-
-def _to_slug(brand_model: str) -> str:
-    """Port of src/utils/slug.ts:toSlug — must stay byte-equivalent."""
-    lowered = brand_model.lower().replace("/", "")
-    return _NON_ALNUM_RE.sub("-", lowered).strip("-")
-
-
-def _load_official_urls() -> dict[str, str]:
-    """Parse `src/data/lenses.ts` into a slug → officialUrl mapping."""
-    text = LENSES_PATH.read_text(encoding="utf-8")
-    mapping: dict[str, str] = {}
-    for block_match in _LENS_BLOCK_RE.finditer(text):
-        block = block_match.group(0)
-        brand_match = _BRAND_RE.search(block)
-        model_match = _MODEL_RE.search(block)
-        url_match = _OFFICIAL_URL_RE.search(block)
-        if not (brand_match and model_match and url_match):
-            continue
-        slug = _to_slug(f"{brand_match.group(1)} {model_match.group(1)}")
-        mapping[slug] = url_match.group(1)
-    return mapping
-
-
-def _source_url(slug: str, official_urls: dict[str, str]) -> str:
-    """Return the verified TTartisan product URL for `slug`.
-
-    Reads from `lenses.ts`'s `officialUrl` field rather than deriving
-    from the slug — TTartisan's URL pattern is not slug-mangle-
-    recoverable (different paths for AF / Tilt / GFX product lines).
-    """
-    if slug not in official_urls:
-        raise KeyError(
-            f"No officialUrl found in lenses.ts for {slug!r}. Add the "
-            f"field to the lens entry before re-running this script."
-        )
-    return official_urls[slug]
-
-
-def _emit_one_lens(
-    chart: ReferenceChart, official_urls: dict[str, str]
-) -> tuple[str, int, int]:
+def _emit_one_lens(chart: ReferenceChart) -> tuple[str, int, int]:
     """Build the TS object literal for one TTartisan lens.
 
     Returns ``(literal, panel_count, total_positions)``. Every TTartisan
@@ -224,10 +171,8 @@ def _emit_one_lens(
         total_positions += len(pass_result.extracted.readings)
 
     chart_blocks = "\n".join(blocks)
-    source_url = _source_url(chart.slug, official_urls)
     literal = (
         f'  "{chart.slug}": {{\n'
-        f"{format_source_line(source_url)}"
         '    mtfType: "computed",\n'
         "    charts: [\n"
         f"{chart_blocks}\n"
@@ -331,12 +276,11 @@ def main(argv: list[str] | None = None) -> int:
         print("No TTartisan multi-aperture lenses found.", file=sys.stderr)
         return 1
 
-    official_urls = _load_official_urls()
     entries: dict[str, str] = {}
     total_positions = 0
     total_panels = 0
     for chart in lenses:
-        literal, panels, positions = _emit_one_lens(chart, official_urls)
+        literal, panels, positions = _emit_one_lens(chart)
         entries[chart.slug] = literal
         total_panels += panels
         total_positions += positions

--- a/tools/mtfdigitizer/tests/test_emit.py
+++ b/tools/mtfdigitizer/tests/test_emit.py
@@ -8,48 +8,8 @@ from mtfdigitizer.emit import (
     _format_reading,
     _format_value,
     _has_any_data,
-    format_source_line,
 )
 from mtfdigitizer.pipeline.types import SampledReading
-
-
-# --- format_source_line --------------------------------------------------
-# Matches Prettier's printWidth=80 wrap. Without this, lint-staged
-# rewraps long-URL entries and the --check gate (#1296/#1299) reports
-# false positives.
-
-
-def test_format_source_line_single_line_when_under_80() -> None:
-    """Short URL fits on one line."""
-    out = format_source_line("https://example.com/short")
-    assert out == '    source: "https://example.com/short",\n'
-
-
-def test_format_source_line_wraps_when_over_80() -> None:
-    """Long URL wraps onto two lines per Prettier's default."""
-    url = "https://fujifilm-x.com/en-us/products/lenses/gf100-200mmf56-r-lm-ois-wr/"
-    out = format_source_line(url)
-    assert out == f'    source:\n      "{url}",\n'
-
-
-def test_format_source_line_boundary_at_exactly_80() -> None:
-    """A URL that makes the single-line form exactly 80 chars stays
-    single (Prettier wraps strictly >80, not ≥80)."""
-    # Build a URL such that `    source: "<url>",` is exactly 80 chars.
-    # Prefix length: 4 + 8 + 1 + (url) + 2 = 15 + len(url) = 80 → url = 65.
-    url = "https://example.com/" + "a" * (65 - len("https://example.com/"))
-    assert len(url) == 65
-    out = format_source_line(url)
-    assert out == f'    source: "{url}",\n'
-    assert len(out.rstrip("\n")) == 80
-
-
-def test_format_source_line_boundary_at_81_wraps() -> None:
-    """One char over the boundary forces the wrap."""
-    url = "https://example.com/" + "a" * (66 - len("https://example.com/"))
-    assert len(url) == 66
-    out = format_source_line(url)
-    assert out == f'    source:\n      "{url}",\n'
 
 
 def _r(
@@ -158,12 +118,13 @@ def test_format_entry_wraps_a_lens_block() -> None:
     rows = (_r(pos=0), _r(pos=5.0))
     out = _format_entry(
         slug="test-lens",
-        source="https://example.com/lens",
         mtf_type="measured",
         panels=(("f/2.8", None, rows, "HIGH", None),),
     )
     assert '"test-lens":' in out
-    assert 'source: "https://example.com/lens",' in out
+    # `source` field was removed in #1342; the lens page reads
+    # `officialUrl` from lenses.ts at render time instead.
+    assert "source:" not in out
     assert 'mtfType: "measured",' in out
     assert 'aperture: "f/2.8",' in out
     assert 'confidence: "HIGH",' in out
@@ -174,7 +135,6 @@ def test_format_entry_wraps_a_lens_block() -> None:
 def test_format_entry_emits_computed_mtf_type_when_requested() -> None:
     out = _format_entry(
         slug="sigma-lens",
-        source="https://sigma-global.com/x",
         mtf_type="computed",
         panels=(("f/1.4", None, (_r(pos=0),), "HIGH", None),),
     )
@@ -185,7 +145,6 @@ def test_format_entry_emits_computed_mtf_type_when_requested() -> None:
 def test_format_entry_empty_readings_block_is_valid_ts() -> None:
     out = _format_entry(
         slug="test-lens",
-        source="https://x",
         mtf_type="measured",
         panels=(("f/2", None, (), "HIGH", None),),
     )
@@ -196,7 +155,6 @@ def test_format_entry_emits_two_panels_for_zoom() -> None:
     """ADR-033: a zoom emits one chart entry per published focal length."""
     out = _format_entry(
         slug="sigma-10-18mm-f2-8-dc-dn-c",
-        source="https://sigma-global.com/x",
         mtf_type="computed",
         panels=(
             ("f/2.8", 10, (_r(pos=0), _r(pos=14.0)), "HIGH", None),
@@ -213,7 +171,6 @@ def test_format_entry_prime_emits_no_focal_length_line() -> None:
     """Primes have focal_length=None — emitted TS must not include the key."""
     out = _format_entry(
         slug="sigma-56mm-f1-4-dc-dn-c",
-        source="https://sigma-global.com/x",
         mtf_type="computed",
         panels=(("f/1.4", None, (_r(pos=0),), "HIGH", None),),
     )
@@ -224,7 +181,6 @@ def test_format_entry_emits_low_confidence_with_reason() -> None:
     """ADR-053 + #1134: LOW pass carries confidence + confidenceReason."""
     out = _format_entry(
         slug="ttartisan-50mm-f1-2",
-        source="https://x",
         mtf_type="computed",
         panels=(
             ("f/5.6", None, (_r(pos=0),), "LOW", "prior_failed_center_ge_edge"),

--- a/tools/mtfdigitizer/tests/test_emit_overrides.py
+++ b/tools/mtfdigitizer/tests/test_emit_overrides.py
@@ -18,12 +18,13 @@ from mtfdigitizer.scripts._emit_overrides import (
 )
 
 
-# Shape mirrors the af-35 entry as it lives in mtf-readings.ts today
-# (lines 13510–13601). One override at position 12.6 on freq 30; every
-# other cell is plain extractor output.
+# Shape mirrors the af-35 entry as it lives in mtf-readings.ts today.
+# One override at position 12.6 on freq 30; every other cell is plain
+# extractor output. The `source:` field was removed from MtfData in
+# #1342 (the lens page reads officialUrl at render time), so this
+# fixture matches the current entry shape.
 AF35_ENTRY = textwrap.dedent('''\
       "ttartisan-af-35mm-f1-8": {
-        source: "https://www.ttartisan.com/?af-lens/AF-35-II.html",
         mtfType: "computed",
         charts: [
           {

--- a/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
+++ b/tools/mtfdigitizer/tests/test_emit_ttartisan_tier2.py
@@ -1,24 +1,18 @@
 """Unit tests for `emit_ttartisan_tier2` (ADR-044 emit pipeline).
 
 Targets the pure formatting helpers — string emission, lens-tuple
-shape, slug-to-URL resolution. The end-to-end extractor pipeline
-(extract_chart → SampledReading) is exercised by the live runner;
-this module verifies that the TS-literal output shape is correct.
+shape. The end-to-end extractor pipeline (extract_chart →
+SampledReading) is exercised by the live runner; this module verifies
+that the TS-literal output shape is correct.
 """
 
 from __future__ import annotations
-
-import re
-
-import pytest
 
 from mtfdigitizer.pipeline.types import SampledReading
 from mtfdigitizer.scripts.emit_ttartisan_tier2 import (
     _format_chart_block,
     _format_reading,
     _format_value,
-    _source_url,
-    _to_slug,
     _ttartisan_lenses,
 )
 
@@ -133,20 +127,6 @@ def test_format_chart_block_drops_intermediate_all_null_rows():
     assert "position: 0," in out
     assert "position: 14," in out
     assert "position: 5," not in out
-
-
-def test_to_slug_matches_typescript_port():
-    """Port of src/utils/slug.ts:toSlug must be byte-equivalent."""
-    assert _to_slug("TTartisan 50mm f/1.2") == "ttartisan-50mm-f1-2"
-    assert _to_slug("TTartisan 11mm f/2.8 Fisheye GFX") == "ttartisan-11mm-f2-8-fisheye-gfx"
-    assert _to_slug("TTartisan AF 75mm f/2") == "ttartisan-af-75mm-f2"
-
-
-def test_source_url_fails_loud_on_missing_official_url():
-    """A slug not in the lenses.ts officialUrl mapping is a fail-loud
-    event — masks a missing field otherwise (per #1062)."""
-    with pytest.raises(KeyError, match="officialUrl"):
-        _source_url("ttartisan-nonexistent-1mm-f0", {})
 
 
 def test_ttartisan_lenses_returns_19_entries():


### PR DESCRIPTION
## Summary

- Drop the `source:` field from the mtfdigitizer emit path so producer and consumer agree after #1342 removed the field from the `MtfData` schema and stripped 115 lines from `mtf-readings.ts`
- Delete 3 URL-loader machineries (`_load_official_urls`, `_source_url`, `_to_slug` + 4 regexes) that only existed to feed the now-gone field
- Delete `format_source_line` (unused) and `_DEFAULT_SOURCES` (18-entry mapping, unused)
- -275 net lines across 3 emit modules + 3 test modules

Closes #1345

## Root cause

#1342 removed `source` at the consumer side (schema, data file, render site) but the producer (emit scripts) was not updated. The `--check` gate then reported brand-wide drift on every re-emit, and any `--write` pass would re-insert the removed field. Three producer call sites (`emit.py`, `emit_fuji_tier2.py`, `emit_ttartisan_tier2.py`) all fixed here.

## Verified

- `py -m pytest mtfdigitizer/tests/` — 449 passed, 0 failed
- `py -m mtfdigitizer.scripts.emit_ttartisan_tier2 --check` — clean
- `py -m mtfdigitizer.scripts.emit_fuji_tier2 --check` — clean
- `npm test` — 129 passed

## Test plan

- [x] Full mtfdigitizer pytest suite green
- [x] `emit_*_tier2 --check` reports no drift against production `mtf-readings.ts`
- [x] Front-end vitest green
- [x] No `format_source_line` / `_source_url` / `_to_slug` / `_DEFAULT_SOURCES` callers remain (grep-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)