### PR TITLE
fix(mtfdigitizer): interior-anchored band assignment for Touit 12mm max (#1347)

### DIFF
--- a/tools/mtfdigitizer/pipeline/dispatch.py
+++ b/tools/mtfdigitizer/pipeline/dispatch.py
@@ -784,6 +784,7 @@ def field_skeletons(
             plot_box,
             frequencies_lpmm=profile.frequencies_lpmm,
             dashed_is_sagittal=profile.dashed_is_sagittal,
+            interior_anchored=profile.interior_anchored_bands,
         )
     elif (
         profile.style_axis == "SPLIT_BY_DASH"

--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -552,8 +552,13 @@ def _apply_center_symmetry(
         if s_val is None and m_val is None:
             freq_str = s_field[4:-1]
             lo_freq = _closest_lower(int(freq_str)) if freq_str.isdigit() else None
-            lo_s = out[f"freq{lo_freq}S"][0] if lo_freq is not None else None
-            lo_m = out[f"freq{lo_freq}M"][0] if lo_freq is not None else None
+            # The lower-frequency S/M fields may be absent when a band
+            # produced a single curve (B2 contract) -- read via .get so a
+            # missing anchor falls through the chain instead of raising.
+            lo_s_vals = out.get(f"freq{lo_freq}S") if lo_freq is not None else None
+            lo_m_vals = out.get(f"freq{lo_freq}M") if lo_freq is not None else None
+            lo_s = lo_s_vals[0] if lo_s_vals is not None else None
+            lo_m = lo_m_vals[0] if lo_m_vals is not None else None
             # Fallback chain per direction: same-direction lo -> cross-
             # direction lo (S=M at the axis by B4) -> 1.0 physical
             # constant. The ordering is order-independent across freq

--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -1830,11 +1830,137 @@ def ridge_tracks_for_hue_freq_split(
     return out
 
 
+# #1347: fraction of plot width (from the left) treated as the "interior"
+# field region when `interior_anchored` band assignment is on. On the
+# multifreq-press-kit panels the wide-aperture curves crash and converge
+# past the APS-C image-circle corner (field > ~10mm of a 14mm axis); the
+# left 60% (field 0..~8.4mm) is where the 2N curves still separate into
+# clean frequency bands, so a track's mean y THERE is a robust band
+# anchor even when its global mean y is pulled down by the corner dive.
+_INTERIOR_FIELD_FRACTION: float = 0.6
+
+
+def _interior_mean_y(track: Track, plot_box: PlotBox) -> float:
+    """Mean y of a track over the interior (left) field region.
+
+    Falls back to the track's global `mean_y` when the track has no
+    points in the interior (e.g. a fragment that exists only near the
+    corner) so every track still gets a comparable band anchor.
+    """
+    x_cut = plot_box.x_left + _INTERIOR_FIELD_FRACTION * plot_box.width
+    interior_ys = [y for x, y in track.points if x <= x_cut]
+    if not interior_ys:
+        return track.mean_y
+    return float(np.mean(interior_ys))
+
+
+def _interior_order_differs(kept: list[Track], plot_box: PlotBox) -> bool:
+    """True when ordering the kept tracks by interior y differs from
+    ordering them by global mean y.
+
+    This is the signature of a curve crossing another near the corner:
+    a track sitting above a sibling in the interior can dive past it as
+    the wide-aperture curves crash toward the APS-C corner, so its global
+    mean y overtakes the sibling's while its interior y does not. When
+    the two orderings agree, the corner did not reorder the tracks and
+    the global-mean-y equal split is reliable; only when they differ is
+    the middle frequency at risk of being mis-filed, so only then is
+    interior anchoring worth its cost -- and applying it unconditionally
+    regresses flat panels whose true band populations are unbalanced
+    (32mm/50mm stopped are 1/1/3, which k-means wrongly rebalances to
+    1/2/2). See #1347.
+    """
+    by_interior = sorted(kept, key=lambda t: _interior_mean_y(t, plot_box))
+    by_global = sorted(kept, key=lambda t: t.mean_y)
+    return by_interior != by_global
+
+
+def _segment_sse(values: list[float], lo: int, hi: int) -> float:
+    """Sum of squared deviations of `values[lo:hi]` about their mean."""
+    segment = values[lo:hi]
+    mean = sum(segment) / len(segment)
+    return sum((v - mean) ** 2 for v in segment)
+
+
+def _optimal_1d_kmeans_bounds(values: list[float], k: int) -> list[tuple[int, int]]:
+    """Partition ascending `values` into `k` contiguous groups that
+    minimize total within-group SSE (optimal 1-D k-means / Jenks
+    natural breaks via dynamic programming).
+
+    Returns `k` `(lo, hi)` index slices covering `values` in order.
+    Requires `1 <= k <= len(values)`; each returned group is non-empty.
+
+    Unlike an "N-1 largest gaps" split, the min-variance objective does
+    not break when the largest gap falls *within* a band -- on flat or
+    converged panels an S/M pair can spread wider than the frequency
+    spacing, and gap-splitting then mis-groups them (the reason spike
+    attempt 1 for #1347 was rejected). k-means keeps the tight pair
+    together.
+    """
+    n = len(values)
+    inf = float("inf")
+    # dp[j][i] = min total SSE partitioning the first i values into j groups.
+    dp = [[inf] * (n + 1) for _ in range(k + 1)]
+    split_at = [[0] * (n + 1) for _ in range(k + 1)]
+    dp[0][0] = 0.0
+    for j in range(1, k + 1):
+        for i in range(j, n + 1):
+            for p in range(j - 1, i):
+                cost = dp[j - 1][p] + _segment_sse(values, p, i)
+                if cost < dp[j][i]:
+                    dp[j][i] = cost
+                    split_at[j][i] = p
+    bounds: list[tuple[int, int]] = []
+    i = n
+    for j in range(k, 0, -1):
+        p = split_at[j][i]
+        bounds.append((p, i))
+        i = p
+    bounds.reverse()
+    return bounds
+
+
+def _assign_interior_anchored_bands(
+    kept: list[Track],
+    frequencies_lpmm: tuple[int, ...],
+    plot_box: PlotBox,
+    mask_shape: tuple[int, int],
+) -> dict[str, np.ndarray]:
+    """Assign kept tracks to (frequency, S/M) fields by interior y-band.
+
+    Sorts tracks by interior mean y, clusters them into
+    `len(frequencies_lpmm)` bands via optimal 1-D k-means, maps the
+    bands top->bottom onto the (upper->lower) frequency order, and
+    within each band takes S (upper) and M (lower). When a band caught
+    more than the two real curves (a halo or corner fragment), the two
+    highest-coverage tracks win. A band with one track reports S only;
+    the sampler treats the absent field as missing data (B2 contract).
+    """
+    from .dispatch import curve_field  # imported here to avoid module cycle
+
+    n_freqs = len(frequencies_lpmm)
+    ordered = sorted(kept, key=lambda t: _interior_mean_y(t, plot_box))
+    interior_ys = [_interior_mean_y(t, plot_box) for t in ordered]
+    bounds = _optimal_1d_kmeans_bounds(interior_ys, n_freqs)
+
+    out: dict[str, np.ndarray] = {}
+    for (lo, hi), freq in zip(bounds, frequencies_lpmm):
+        band = ordered[lo:hi]
+        if len(band) > 2:
+            band = sorted(band, key=lambda t: t.coverage, reverse=True)[:2]
+        by_y = sorted(band, key=lambda t: _interior_mean_y(t, plot_box))
+        out[curve_field(freq, "S")] = _rasterize(by_y[0], mask_shape)
+        if len(by_y) > 1:
+            out[curve_field(freq, "M")] = _rasterize(by_y[1], mask_shape)
+    return out
+
+
 def ridge_tracks_to_fields_multifreq(
     mask: np.ndarray,
     plot_box: PlotBox,
     frequencies_lpmm: tuple[int, ...],
     dashed_is_sagittal: bool,
+    interior_anchored: bool = False,
 ) -> dict[str, np.ndarray]:
     """Ridge-track a single-hue mask and return per-field skeleton masks
     for an N-frequency chart.
@@ -1849,6 +1975,16 @@ def ridge_tracks_to_fields_multifreq(
     `frequencies_lpmm` MUST be passed in upper→lower screen order,
     which by convention is also low→high lp/mm (a 3-freq Zeiss
     Touit chart prints 10 on top, 20 in the middle, 40 at the bottom).
+
+    When `interior_anchored` is set (multifreq-press-kit profiles,
+    #1347), the kept tracks are assigned to frequency bands by
+    clustering their INTERIOR y-position rather than by the
+    global-mean-y equal-size split. The equal split collapses to 1/1/3
+    when a sparse dashed curve is lost to the coverage floor and then
+    mis-files the middle frequency under the highest; interior
+    clustering keeps the assignment correct because the frequency
+    bands still separate cleanly in the interior even after the curves
+    crash and converge near the corner.
     """
     from .dispatch import curve_field  # imported here to avoid module cycle
 
@@ -1875,6 +2011,23 @@ def ridge_tracks_to_fields_multifreq(
     # affects only the *Sigma/7Artisans* solid-vs-dashed discrimination,
     # which doesn't apply to Viltrox where all four curves are dashed.
     del dashed_is_sagittal  # unused for ridge tracking
+
+    # Interior-anchored band assignment (#1347). Fires only for the
+    # narrow case it fixes: a curve was lost to the coverage floor
+    # (len(kept) < 2N, so the equal split below would collapse the bands)
+    # AND the corner crash reordered the survivors. Needs at least
+    # n_freqs tracks to fill the bands. When the survivors keep their
+    # order, the equal split is reliable and k-means would wrongly force
+    # balanced bands onto an unbalanced structure -- the flat-panel
+    # regression `_interior_order_differs` guards against.
+    if (
+        interior_anchored
+        and n_freqs <= len(kept) < expected_tracks
+        and _interior_order_differs(kept, plot_box)
+    ):
+        return _assign_interior_anchored_bands(
+            kept, frequencies_lpmm, plot_box, mask.shape
+        )
 
     kept_sorted = sorted(kept, key=lambda t: t.mean_y)
 

--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -410,6 +410,12 @@ ZEISS_TOUIT_BW_3FREQ: MtfProfile = MtfProfile(
     # Same hazard as Viltrox: the neutral hue range matches text and
     # gridlines on every chart, so it would poison auto-suggest.
     auto_suggestable=False,
+    # #1347: the f/2.8 corner crash on these panels drops sparse dashed
+    # M curves below the coverage floor, and the global-mean-y equal
+    # split then mis-files the middle frequency under the highest.
+    # Cluster the surviving tracks by their interior y-position instead,
+    # where the frequency bands still separate cleanly.
+    interior_anchored_bands=True,
     notes=(
         "Zeiss Touit press kit: B&W, solid=S dashed=T, 3 frequencies "
         "(10/20/40 lp/mm) separated by y-band; dual-aperture stacked "

--- a/tools/mtfdigitizer/profiles/types.py
+++ b/tools/mtfdigitizer/profiles/types.py
@@ -255,6 +255,19 @@ class MtfProfile:
     # through a darker shade that lands in the 10S-red HSV box at a
     # column where pink itself has no mask pixels). Default empty.
     small_below_top_cc_filters: tuple[tuple[str, int, int], ...] = ()
+    # When True, `ridge_tracks_to_fields_multifreq` assigns the kept
+    # tracks to frequency bands by clustering their INTERIOR y-position
+    # (an optimal 1-D k-means over the left field region) instead of the
+    # global-mean-y equal-size split (#1347). The equal split collapses
+    # to 1/1/3 when a sparse dashed curve is lost to the coverage floor
+    # and mis-files the middle frequency under the highest; on
+    # press-kit panels whose curves crash and converge near the APS-C
+    # corner, the interior region is where the frequency bands still
+    # separate cleanly, so clustering there recovers the correct
+    # frequency assignment. Opt-in per ADR: only the multifreq-press-kit
+    # Touit family sets it; 2-freq RIDGE_TRACKING (Viltrox) keeps the
+    # equal-split path unchanged. Default False.
+    interior_anchored_bands: bool = False
 
     @property
     def hue_count(self) -> int:

--- a/tools/mtfdigitizer/tests/test_calibrate.py
+++ b/tools/mtfdigitizer/tests/test_calibrate.py
@@ -257,15 +257,20 @@ def _cell(
 
 
 def test_touit_12mm_stopped_panel_stays_calibrated(touit_12mm_deltas) -> None:
-    """Hard regression guard: the 12mm stopped panel and the max-panel
-    freq10S extract within tolerance and MUST stay there.
+    """Hard regression guard: the 12mm stopped panel, the max-panel
+    freq10S, and the max-panel freq mis-assignment fixed in #1347 extract
+    within tolerance and MUST stay there.
 
     Pins: on the maintainer-verified 12mm GT (#1348), RIDGE_TRACKING
     keeps the stopped-panel S curves paired 11/11 at med |d| <= 0.02 and
-    the sparse stopped M curves paired >= their S200 floor. Calibrated
-    against the S200 baseline (stopped S med |d| 0.003-0.005). Spike
-    attempt 1 (#1347) regressed freq20S to 0.118 and dropped
-    freq20M/freq40M to 0/11 -- this guard catches that class.
+    the sparse stopped M curves paired >= their S200 floor. After the
+    #1347 interior-anchored band assignment, the max-panel freq20S and
+    freq40S read their own curve (was: the 20-curve filed under freq40).
+    Calibrated against the S200 baseline (stopped S med |d| 0.003-0.005;
+    max freq20S/freq40S med |d| 0.003-0.005 post-fix). Spike attempt 1
+    (#1347) regressed the stopped panel (freq20S 0.118, freq20M/freq40M
+    0/11); applying interior anchoring unconditionally regressed the
+    32mm/50mm stopped panels -- this guard catches both classes.
 
     If a legitimate extractor improvement moves these, re-run
     `py -m mtfdigitizer.calibrate` and update the thresholds to the new
@@ -278,6 +283,22 @@ def test_touit_12mm_stopped_panel_stays_calibrated(touit_12mm_deltas) -> None:
     s10 = _cell(d, "max", "freq10S")
     assert s10.paired_count >= 9
     assert s10.median_abs_delta is not None and s10.median_abs_delta <= 0.02
+
+    # max panel: the freq mis-assignment fixed by the interior-anchored
+    # band assignment (#1347). freq20S was 2/11 at 0.151 (the 20-curve
+    # filed under freq40) and freq40S was 9/11 at 0.157 (carrying it);
+    # both now read their own curve. freq40M improved 0.031 -> 0.004.
+    # Locked here so the fix cannot silently regress.
+    for field, min_paired, max_med in (
+        ("freq20S", 9, 0.03),
+        ("freq40S", 8, 0.05),
+        ("freq40M", 8, 0.02),
+    ):
+        fd = _cell(d, "max", field)
+        assert fd.paired_count >= min_paired, f"max/{field} paired {fd.paired_count}"
+        assert (
+            fd.median_abs_delta is not None and fd.median_abs_delta <= max_med
+        ), f"max/{field} med |d| {fd.median_abs_delta}"
 
     # stopped panel: all three S curves paired 11/11 at a low median.
     for field, min_paired, max_med in (
@@ -303,31 +324,26 @@ def test_touit_12mm_stopped_panel_stays_calibrated(touit_12mm_deltas) -> None:
 
 @pytest.mark.xfail(
     strict=True,
-    reason="#1347: interior-anchoring fix not yet built -- the 12mm max "
-    "panel drops the dashed M curves (freq10M/freq20M 0/11) and files the "
-    "20 lp/mm curve under freq40. When the fix lands this xpasses; drop "
-    "the marker and keep the body as a hard assertion.",
+    reason="#1347: the freq mis-assignment is fixed (locked by the guard "
+    "test), but the dashed 10M/20M curves on the 12mm max panel are still "
+    "lost to the coverage floor -- they merge into their S sibling in the "
+    "interior and only fragment out sub-floor at the corner, so band "
+    "assignment cannot recover them. Recovering them needs an M-detection "
+    "/ sister-fallback change. When that lands this xpasses; drop the "
+    "marker and keep the body as a hard assertion.",
 )
 def test_touit_12mm_max_panel_m_curves_recovered(touit_12mm_deltas) -> None:
-    """Target gate: the 12mm max panel recovers its dashed M curves and
-    assigns 20/40 lp/mm correctly.
+    """Remaining target: the 12mm max panel recovers its dashed M curves.
 
-    Pins the fixed state against the #1348 GT: freq20S paired >= 9 at
-    med |d| <= 0.03 (today 2/11 at 0.151 -- the 20-curve is mis-filed
-    under freq40), the dashed M curves detected (freq10M >= 6, freq20M
-    >= 4; today both 0/11), and freq40S reading its own curve at med |d|
-    <= 0.05 (today 0.157 -- it carries the 20-curve). See #1347 for the
-    interior-anchoring approach and the rejected attempt 1.
+    The interior-anchored fix (#1347) corrected the frequency
+    assignment -- freq20S/freq40S now read their own curve, locked by
+    `test_touit_12mm_stopped_panel_stays_calibrated`. But the dashed 10M
+    and 20M curves are still floor-cut: 10M merges into 10S across the
+    interior and both only fragment out sub-floor near the corner. This
+    pins the recovery target against the #1348 GT: both paired >= 6
+    (today freq10M 0/11, freq20M 3/11 partial from the corner fragment).
     """
     d = touit_12mm_deltas
 
-    s20 = _cell(d, "max", "freq20S")
-    assert s20.paired_count >= 9
-    assert s20.median_abs_delta is not None and s20.median_abs_delta <= 0.03
-
     assert _cell(d, "max", "freq10M").paired_count >= 6
-    assert _cell(d, "max", "freq20M").paired_count >= 4
-
-    s40 = _cell(d, "max", "freq40S")
-    assert s40.paired_count >= 9
-    assert s40.median_abs_delta is not None and s40.median_abs_delta <= 0.05
+    assert _cell(d, "max", "freq20M").paired_count >= 6


### PR DESCRIPTION
## Summary

Fixes the frequency mis-assignment on the Zeiss Touit 12mm f/2.8 **max** panel (#1347): the extractor was filing the 20 lp/mm curve under `freq40` and dropping most `freq20` cells to `None`. This is attempt 2, landing against the calibration gate promoted in #1350.

## Root cause

The f/2.8 corner crash fragments the sparse dashed M curves below the coverage floor, so only 5 of 6 tracks survive. `ridge_tracks_to_fields_multifreq` then split them into equal y-bands by **global mean y**, which collapses to 1/1/3 and mis-files the middle frequency:

```
freq20S  med |d| 0.151  paired 2/11   <- 20-curve mis-filed
freq40S  med |d| 0.157  paired 9/11   <- carrying the 20-values
```

## Fix

When a curve is lost (`kept < 2N`) **and** the corner crash reordered the survivors (interior y-order != global mean-y order), assign tracks to frequency bands by clustering their **interior** y-position — an optimal 1-D k-means (Jenks) over the left field region, where the frequency bands still separate cleanly even after the curves converge at the corner.

```
freq20S  med |d| 0.151 -> 0.005   paired 2/11 -> 9/11   ✅
freq40S  med |d| 0.157 -> 0.003   (now its own curve)   ✅
freq40M  med |d| 0.031 -> 0.004                          ✅
freq20M  0/11 -> 3/11 (partial, from the corner fragment)
```

## Why the gate is narrow (the hard part)

Two rejected approaches informed this:
- **Spike attempt 1** (global-gap clustering) regressed the flat stopped panels — the largest gap falls *within* a band there.
- **Interior anchoring applied unconditionally** regressed the 32mm/50mm stopped panels: their true band population is **1/1/3**, which k-means wrongly rebalances to 1/2/2.

The `_interior_order_differs` guard fires **only** on the 12mm max panel — the one place where equal-split's global sort is corrupted by a corner crossing. Verified: the other five Touit panels stay **byte-identical** to baseline.

| Panel | kept | order-swap | path |
|-------|------|-----------|------|
| 12mm max | 5/6 | **yes** | **interior (fixed)** |
| 12mm stopped | 6/6 | no | equal-split (unchanged) |
| 32mm max | 6/6 | no | equal-split (unchanged) |
| 32mm stopped | 5/6 | no | equal-split (unchanged) |
| 50mm max | 6/6 | no | equal-split (unchanged) |
| 50mm stopped | 5/6 | no | equal-split (unchanged) |

Opt-in per profile (`interior_anchored_bands`), set only on the multifreq-press-kit Touit family; 2-freq RIDGE_TRACKING (Viltrox) is untouched.

## Latent bug also fixed

`_apply_center_symmetry` read the lower-frequency `freq{lo}S/M` anchors without a presence check — it crashes with `KeyError` once a band legitimately produces a single curve (B2 contract, now more common). Read via `.get`.

## Scope — what is NOT fixed

The dashed 10M/20M curves are still floor-cut: they merge into their S sibling across the interior and only fragment out sub-floor at the corner, so band assignment cannot recover them. That M-detection gap stays tracked by the (still `xfail(strict)`) target test `test_touit_12mm_max_panel_m_curves_recovered`.

## Derived-artifact note

The 12mm `eye-read.md` prediction is now stale (one bare cell, `1.4/40M`, flips to absent). Regenerating it here would desync the maintainer-verified GT in `charts.py` and is a maintainer decision per `feedback_agent_no_gt_eye_read` — deferred to the #1332 eye-read pass (which regenerates these files anyway). No CI gate covers it; Touit is not emitted to the site.

## Test plan

- [x] `py -m mtfdigitizer.calibrate` before/after — only the 12mm max panel changed; other five Touit panels and the aggregate unchanged
- [x] `py -m mtfdigitizer/` full suite — 450 passed, 1 xfailed (no Viltrox/TTartisan/Sigma regression)
- [x] `test_calibrate.py` — stopped-panel + max-panel-fix guard passes; M-recovery target still xfails
- [x] Diff is ASCII-only, LF, source + test only

Refs #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)