### PR TITLE
fix(mtfdigitizer): recover Touit dashed M curves via split-mask sister presence (#1347)

### DIFF
--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -720,6 +720,31 @@ def _hue_masks_for_presence(
                 (dashed_sm, cv2.dilate(split.meridional.astype(np.uint8), bridge)),
             ):
                 out[curve_field(freq, sm)] = sub
+    elif profile.style_axis == "SPLIT_BY_DASH" and profile.dashed_split_presence:
+        # Single-hue B&W multifreq chart (Zeiss Touit): one neutral mask
+        # holds all 2N curves, separated only by y-band (frequency) and
+        # solid/dashed (S/M). There is no per-frequency hue to key on as
+        # in the GEODESIC_DP branch above, so split the whole neutral mask
+        # once into its solid (S) and dashed (M) sub-skeletons and
+        # broadcast each across every frequency. This is a coarse
+        # per-column presence signal — presence[freqNS] reads True where
+        # ANY solid curve has ink at that column — but the sister fallback
+        # fill VALUE still comes from the correctly band-assigned per-field
+        # sample, so a dashed curve that merges into its solid sibling in
+        # the interior is recovered from that sibling, while a diverging
+        # corner (sibling sample None) copies nothing. See #1347.
+        solid_sm, dashed_sm = ("M", "S") if profile.dashed_is_sagittal else ("S", "M")
+        bridge = cv2.getStructuringElement(
+            cv2.MORPH_RECT, (_DASH_PRESENCE_BRIDGE_W, 3)
+        )
+        for mask in curve_masks.values():  # one neutral hue
+            split = split_sm_by_cc_width(close_and_skeletonize(mask))
+            for sm, sub in (
+                (solid_sm, split.sagittal),
+                (dashed_sm, cv2.dilate(split.meridional.astype(np.uint8), bridge)),
+            ):
+                for freq in profile.frequencies_lpmm:
+                    out[curve_field(freq, sm)] = sub
     elif profile.style_axis == "HUE_IS_CURVE" and profile.hue_meaning == "CURVE_IDENTITY":
         # Each hue identifies one specific (frequency, S/M) curve via its
         # name (e.g. `10S-red`, `10M-pink`, `30S-dark-grey`,
@@ -800,6 +825,17 @@ def extract_chart(
         field: _sample_curve(skel, plot_box, raw_mask=presence_masks.get(field))
         for field, skel in skeletons.items()
     }
+    # Seed an all-None row for any field that has a presence mask but no
+    # skeleton (#1347). A dashed curve that merges into its solid sibling
+    # and is lost to the coverage floor produces no track, so it is absent
+    # from `skeletons` entirely — and sister fallback only visits fields
+    # present in `samples_per_field`. Seeding it here (scoped to the
+    # split-presence profiles) lets the M<-S fallback fill it from the
+    # solid sibling. Harmless for other profiles: their presence keys map
+    # 1:1 to skeletons, so nothing is seeded.
+    if profile.dashed_split_presence:
+        for field in presence_masks:
+            samples_per_field.setdefault(field, (None,) * len(SAMPLE_FRACTIONS))
     samples_before_fallback = {f: v for f, v in samples_per_field.items()}
 
     # Sister fallback: replace samples where the raw ink is absent
@@ -854,8 +890,18 @@ def extract_chart(
     # two near-1.0 strokes into one visible line, and the sister-fill
     # from the diverging M curve underestimates the true high-freq S
     # by a large margin.
+    #
+    # Skipped for `dashed_split_presence` profiles (#1347): the Touit's
+    # frequency bands are drawn as separate y-bands, never coincident at
+    # the top (10/20/40 sit ~0.06-0.14 MTF apart on every panel), so the
+    # anchor's merged-stroke assumption never holds. With split-mask
+    # sister presence now filling the dashed M curves from their correct
+    # same-frequency S sibling, letting the anchor run would wrongly
+    # overwrite a good same-freq fill (e.g. 20M 0.90) with the lower
+    # frequency (10M 0.96) whenever both are sister-filled and no clean
+    # cell exists to veto the pair.
     coincident_anchor_count: dict[str, int] = {}
-    if sister_filled:
+    if sister_filled and not profile.dashed_split_presence:
         samples_per_field, coincident_anchor_count = (
             _apply_coincident_top_anchor(samples_per_field, sister_filled)
         )

--- a/tools/mtfdigitizer/profiles/declared.py
+++ b/tools/mtfdigitizer/profiles/declared.py
@@ -416,6 +416,12 @@ ZEISS_TOUIT_BW_3FREQ: MtfProfile = MtfProfile(
     # Cluster the surviving tracks by their interior y-position instead,
     # where the frequency bands still separate cleanly.
     interior_anchored_bands=True,
+    # #1347: the dashed M curves merge into their solid S sibling in the
+    # interior and drop below the coverage floor, reading all-None. Wire
+    # the split-mask sister presence so the M<-S fallback recovers them
+    # from S where they coincide (interior) and stays honest-None at the
+    # diverging corner.
+    dashed_split_presence=True,
     notes=(
         "Zeiss Touit press kit: B&W, solid=S dashed=T, 3 frequencies "
         "(10/20/40 lp/mm) separated by y-band; dual-aperture stacked "

--- a/tools/mtfdigitizer/profiles/types.py
+++ b/tools/mtfdigitizer/profiles/types.py
@@ -269,6 +269,21 @@ class MtfProfile:
     # equal-split path unchanged. Default False.
     interior_anchored_bands: bool = False
 
+    # When True, build sister-fallback presence masks for this
+    # SPLIT_BY_DASH + RIDGE_TRACKING profile by splitting its single
+    # neutral mask into solid (S) and dashed (M) sub-skeletons and
+    # broadcasting each across every frequency. The dialect otherwise
+    # falls through to "no presence info", so the M<-S sister fallback
+    # never fires; a dashed curve that merges into its solid sibling in
+    # the interior and is lost to the coverage floor then reads all-None.
+    # With presence wired the fallback recovers it from the solid sibling
+    # where they coincide (the interior) and leaves an honest None at the
+    # diverging corner, where the sibling's own sample is also None so no
+    # wrong value is copied (#1347). Opt-in: only the multifreq-press-kit
+    # Touit family sets it; 2-freq RIDGE_TRACKING (Viltrox) stays on the
+    # legacy no-presence path. Default False.
+    dashed_split_presence: bool = False
+
     @property
     def hue_count(self) -> int:
         """How many distinct colors the profile expects in the chart.

--- a/tools/mtfdigitizer/tests/test_calibrate.py
+++ b/tools/mtfdigitizer/tests/test_calibrate.py
@@ -223,11 +223,11 @@ def test_readings_for_aperture_handles_dict_and_single(multi_aperture_chart):
 #     Spike attempt 1 (#1347, global gap-based band split) regressed
 #     exactly these (stopped freq20S 0.005 -> 0.118; freq20M/freq40M
 #     dropped to 0/11); this guard is what catches that class.
-#   * `test_touit_12mm_max_panel_m_curves_recovered` -- xfail(strict)
-#     on the broken max-panel cells (dashed M curves dropped, 20 lp/mm
-#     mis-filed under freq40). The interior-anchoring fix flips this to
-#     xpass; the strict marker then fails the run -- the signal to drop
-#     the marker and keep the body as a hard assertion.
+#   * `test_touit_12mm_max_panel_m_curves_recovered` -- a hard assertion
+#     that the dashed 10M/20M curves are recovered (paired >= 6 at low
+#     median). Was xfail(strict) while the M curves were floor-cut; the
+#     split-mask sister presence fix (#1347, `dashed_split_presence`)
+#     recovered them, so the marker was dropped and the body kept.
 # ---------------------------------------------------------------------------
 
 _TOUIT_12_SLUG = "zeiss-touit-12mm-f2-8"
@@ -312,9 +312,12 @@ def test_touit_12mm_stopped_panel_stays_calibrated(touit_12mm_deltas) -> None:
             fd.median_abs_delta is not None and fd.median_abs_delta <= max_med
         ), f"stopped/{field} med |d| {fd.median_abs_delta}"
 
-    # stopped panel: the sparse dashed M curves must still pair some
-    # cells and read low where they do (attempt 1 dropped these to 0/11).
-    for field, min_paired in (("freq10M", 3), ("freq20M", 4), ("freq40M", 8)):
+    # stopped panel: the dashed M curves. Attempt 1 dropped these to
+    # 0/11; the #1347 split-mask sister presence recovered them to
+    # 10/11/11 (freq10M/20M/40M) at med <= 0.005, so the floors are
+    # bumped from the S200 3/4/8 to lock that gain against a silent
+    # regression.
+    for field, min_paired in (("freq10M", 8), ("freq20M", 8), ("freq40M", 8)):
         fd = _cell(d, "stopped", field)
         assert fd.paired_count >= min_paired, f"stopped/{field} paired {fd.paired_count}"
         assert (
@@ -322,28 +325,31 @@ def test_touit_12mm_stopped_panel_stays_calibrated(touit_12mm_deltas) -> None:
         ), f"stopped/{field} med |d| {fd.median_abs_delta}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#1347: the freq mis-assignment is fixed (locked by the guard "
-    "test), but the dashed 10M/20M curves on the 12mm max panel are still "
-    "lost to the coverage floor -- they merge into their S sibling in the "
-    "interior and only fragment out sub-floor at the corner, so band "
-    "assignment cannot recover them. Recovering them needs an M-detection "
-    "/ sister-fallback change. When that lands this xpasses; drop the "
-    "marker and keep the body as a hard assertion.",
-)
 def test_touit_12mm_max_panel_m_curves_recovered(touit_12mm_deltas) -> None:
-    """Remaining target: the 12mm max panel recovers its dashed M curves.
+    """The 12mm max panel recovers its dashed 10M / 20M curves (#1347).
 
-    The interior-anchored fix (#1347) corrected the frequency
-    assignment -- freq20S/freq40S now read their own curve, locked by
-    `test_touit_12mm_stopped_panel_stays_calibrated`. But the dashed 10M
-    and 20M curves are still floor-cut: 10M merges into 10S across the
-    interior and both only fragment out sub-floor near the corner. This
-    pins the recovery target against the #1348 GT: both paired >= 6
-    (today freq10M 0/11, freq20M 3/11 partial from the corner fragment).
+    The dashed M curves merge into their solid S sibling across the
+    interior and drop below the coverage floor at the corner, producing
+    no track of their own (freq10M was 0/11, freq20M 3/11). Split-mask
+    sister presence (`dashed_split_presence`) gives the M<-S fallback the
+    signal it needs to recover each M curve from its solid sibling where
+    they coincide (the interior), while the diverging corner stays
+    honest-None because the sibling's own sample is None there.
+
+    Pins paired-count (recovery: the curve is present at >= 6 of 11
+    positions) AND median |d| (accuracy: the interior fills track the GT,
+    not a wrong lower-freq copy). Calibrated post-fix: freq10M 9/11 at
+    med 0.006, freq20M 10/11 at med 0.018 -- the 20M corner fragments
+    lift p95 to ~0.10 but not the median. If a legitimate extractor
+    change moves these, re-run `py -m mtfdigitizer.calibrate` and update
+    to the new floor; do not loosen to paper over a wrong-fill regression
+    (a garbage sister-fill pushes the median past 0.15, not nudges it).
     """
     d = touit_12mm_deltas
 
-    assert _cell(d, "max", "freq10M").paired_count >= 6
-    assert _cell(d, "max", "freq20M").paired_count >= 6
+    for field in ("freq10M", "freq20M"):
+        fd = _cell(d, "max", field)
+        assert fd.paired_count >= 6, f"max/{field} paired {fd.paired_count}"
+        assert (
+            fd.median_abs_delta is not None and fd.median_abs_delta <= 0.03
+        ), f"max/{field} med |d| {fd.median_abs_delta}"


### PR DESCRIPTION
## What

Recovers the dashed 10M/20M curves on the Zeiss Touit 12mm max panel (the literal remaining title of #1347), plus the stopped-panel M curves as a bonus.

## Root cause

The dashed M curves merge into their solid S sibling across the interior and drop below the coverage floor at the corner, so they produce no track and read all-`None` (10M 0/11, 20M 3/11). `_hue_masks_for_presence` had no branch for the single-hue `SPLIT_BY_DASH + RIDGE_TRACKING` dialect (the Touit is B&W — one neutral hue, curves separated only by y-band + solid/dashed), so the M←S sister fallback got no presence signal and never fired.

## Fix (opt-in `dashed_split_presence`, Touit only — Viltrox byte-identical)

1. **Presence**: split the neutral mask into solid (S) / dashed (M) sub-skeletons and broadcast each across all frequencies. Coarse per-column signal, but the fill *value* comes from the correctly band-assigned per-field sample — so an interior-coincident curve is recovered from its sibling and a diverging corner (sibling sample `None`) copies nothing.
2. **Seed** an all-`None` row for a field that has presence but no skeleton, so a fully floor-cut curve is visible to the sister fallback (it only visits fields already in `samples_per_field`).
3. **Skip the coincident-top anchor** (#1269): the Touit's frequency bands sit ~0.06–0.14 MTF apart on every panel (never coincident), so the anchor would wrongly overwrite a good same-freq fill (20M 0.90) with the lower frequency (10M 0.96).

## Results (12mm max GT, #1348)

| field | before | after |
|---|---|---|
| freq10M | 0/11 | **9/11**, med 0.006 |
| freq20M | 3/11 | **10/11**, med 0.018 |

Diverging-corner cells stay honest-`None` (a sister-fill there would be wrong by up to 0.20 — "honest absence beats a recovered wrong value"). Stopped-panel M also recovered (10M/20M 3/4 → 10/11 at med ≤0.005).

Aggregate: **1153 → 1197 paired, median |d| 0.0052 → 0.0059** (flat, purely additive).

## Verification

- Flips the `xfail(strict)` `test_touit_12mm_max_panel_m_curves_recovered` to a hard assertion pinning both recovery (paired ≥ 6) and accuracy (median ≤ 0.03).
- Guard test `test_touit_12mm_stopped_panel_stays_calibrated` still passes; stopped-M floors bumped 3/4/8 → 8/8/8 to lock the gain.
- Full `mtfdigitizer` pytest **451 pass** (incl. the Viltrox end-to-end and both samyang coincident-anchor tests — the anchor still fires for them, is only skipped for the Touit).
- Full `py -m mtfdigitizer.calibrate` aggregate confirmed no cross-lens regression.

No ADR — an implementation detail applying existing patterns (per-config opt-in, sister fallback, split-by-dash presence), consistent with the sibling `interior_anchored_bands` (#1359).

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)