### PR TITLE
test: gate Samyang and TTartisan plot-box detectors (#950)

### DIFF
--- a/tools/mtfdigitizer/tests/test_samyang_plotbox.py
+++ b/tools/mtfdigitizer/tests/test_samyang_plotbox.py
@@ -1,0 +1,122 @@
+"""Tests for the Samyang two-panel plot-box detector (`samyang_plotbox.py`).
+
+`detect_samyang_plotbox()` finds both stacked panels (max on top, stopped
+below) for one Samyang chart and returns their boxes plus the fail-loud
+`SamyangPlotBoxError`. Until #950 the detector shipped untested — it was
+exercised only by `scripts/scaffold_samyang_tier2.py` in production, so a
+regression could rot silently. This suite promotes it into the gated tier.
+
+What each assertion pins:
+
+- `test_detect_reproduces_recorded_box` — the detector reproduces every
+  recorded box in the reference set on both panels. For the two eye-read
+  anchors (`_EYE_READ_ANCHORS`, the S171 Tier 1 boxes measured by hand)
+  this is a correctness check against independent ground truth. For the
+  Tier 2 charts the recorded boxes were themselves written by this
+  detector via the scaffolder, so the match is a consistency guard —
+  it catches detector drift or a hand-edited Tier 2 box, not an
+  independent correctness claim. Exact equality is intended: a
+  legitimate detector change re-runs the scaffolder, which rewrites the
+  recorded boxes, so drift should fail loud here.
+- `test_eye_read_anchors_present` — guards that the correctness anchors
+  are still in the reference set, so the suite above cannot silently
+  degrade into a pure consistency check if an anchor is removed.
+- `test_refuses_blank_image` — a frameless image raises rather than
+  guessing (ADR-038 §4 B1 fail-loud).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
+from mtfdigitizer.samyang_plotbox import (
+    SamyangPlotBoxError,
+    detect_samyang_plotbox,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The two Samyang Tier 1 anchors whose boxes are independent, hand
+# eye-read ground truth (S171). Every other Samyang box in the reference
+# set was written by the detector itself via the Tier 2 scaffolder.
+_EYE_READ_ANCHORS = frozenset(
+    {
+        "samyang-85mm-f1-4-as-if-umc",
+        "samyang-300mm-f6-3-ed-umc-cs-reflex",
+    }
+)
+
+
+def _samyang_charts() -> list:
+    return [
+        c
+        for c in REFERENCE_CHARTS
+        if c.slug.startswith("samyang-") and c.plot_box is not None
+    ]
+
+
+def _coords(pb) -> tuple[int, int, int, int]:
+    return (pb.x_left, pb.x_right, pb.y_top, pb.y_bottom)
+
+
+def _stopped_box(chart) -> tuple[int, int, int, int] | None:
+    stopped = [v for v in chart.additional_views if v.aperture == "stopped"]
+    return _coords(stopped[0].plot_box) if stopped else None
+
+
+@pytest.mark.parametrize(
+    "chart",
+    _samyang_charts(),
+    ids=lambda c: c.slug,
+)
+def test_detect_reproduces_recorded_box(chart) -> None:
+    """The detector reproduces both recorded panel boxes exactly.
+
+    Correctness for the eye-read anchors; consistency guard for the
+    scaffolded Tier 2 charts (see module docstring).
+    """
+    path = REPO_ROOT / chart.chart_path
+    if not path.exists():
+        pytest.skip(f"chart image missing: {path}")
+
+    result = detect_samyang_plotbox(path)
+
+    assert result.plot_box == _coords(chart.plot_box), (
+        f"max panel: detected {result.plot_box}, recorded "
+        f"{_coords(chart.plot_box)}"
+    )
+    recorded_stopped = _stopped_box(chart)
+    assert recorded_stopped is not None, (
+        f"{chart.slug} has no stopped panel view — the Samyang template "
+        "always stacks a second panel"
+    )
+    assert result.stopped_box == recorded_stopped, (
+        f"stopped panel: detected {result.stopped_box}, recorded "
+        f"{recorded_stopped}"
+    )
+
+
+def test_eye_read_anchors_present() -> None:
+    """The independent eye-read anchors stay in the reference set.
+
+    Without this guard, removing an anchor would quietly turn the
+    reproduce test into a pure detector-vs-scaffolder consistency check
+    with no correctness ground truth left.
+    """
+    slugs = {c.slug for c in _samyang_charts()}
+    missing = _EYE_READ_ANCHORS - slugs
+    assert not missing, f"eye-read anchors missing from reference: {missing}"
+
+
+def test_refuses_blank_image(tmp_path) -> None:
+    """A frameless white image has no panel axes — detection must raise."""
+    blank = tmp_path / "blank.png"
+    Image.fromarray(np.full((1200, 462, 3), 255, dtype=np.uint8)).save(blank)
+    with pytest.raises(SamyangPlotBoxError, match="bottom axis missing"):
+        detect_samyang_plotbox(blank)

--- a/tools/mtfdigitizer/tests/test_ttartisan_plotbox.py
+++ b/tools/mtfdigitizer/tests/test_ttartisan_plotbox.py
@@ -1,0 +1,107 @@
+"""Tests for the TTartisan plot-box detector (`ttartisan_plotbox.py`).
+
+`detect_ttartisan_plotbox()` classifies one chart as APS-C or GFX/full-
+frame by counting two-digit x-axis tick labels, then returns the template
+plot box and image height for that scheme. Until #950 the detector shipped
+untested — it ran only inside `scripts/scaffold_ttartisan_tier2.py`, so a
+regression in the label-width classifier could rot silently. This suite
+promotes it into the gated tier.
+
+What each assertion pins:
+
+- `test_detect_reproduces_scheme_and_box` — for every TTartisan chart in
+  the reference set the detector returns the recorded box and image
+  height. The image height (14.0 mm APS-C vs 20.5 mm GFX) is the visible
+  output of the scheme classifier, so this pins the fragile part: the
+  two-digit-label count. The box constants and recorded values were
+  eye-verified across the 19-chart survey before the detector was
+  committed; the boxes themselves are template lookups, so exact equality
+  here is a scheme-classification + template-constant regression guard.
+- `test_reference_set_covers_both_schemes` — the reference set exercises
+  both classifier branches (at least one APS-C and one GFX chart), so the
+  suite above cannot pass while leaving one branch untested.
+- `test_refuses_blank_image` — a frameless image yields zero tick-label
+  clusters and raises rather than guessing (ADR-038 §4 B1 fail-loud).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
+from mtfdigitizer.ttartisan_plotbox import (
+    TTartisanPlotBoxError,
+    detect_ttartisan_plotbox,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Image height (mm) each scheme must report — the observable output of the
+# tick-label classifier.
+_SCHEME_IMAGE_HEIGHT_MM = {"aps-c": 14.0, "gfx-or-ff": 20.5}
+
+
+def _ttartisan_charts() -> list:
+    return [
+        c
+        for c in REFERENCE_CHARTS
+        if c.slug.startswith("ttartisan-") and c.plot_box is not None
+    ]
+
+
+def _coords(pb) -> tuple[int, int, int, int]:
+    return (pb.x_left, pb.x_right, pb.y_top, pb.y_bottom)
+
+
+@pytest.mark.parametrize(
+    "chart",
+    _ttartisan_charts(),
+    ids=lambda c: c.slug,
+)
+def test_detect_reproduces_scheme_and_box(chart) -> None:
+    """The detector reproduces the recorded box and image height.
+
+    The image height is the observable output of the two-digit-label
+    scheme classifier — this is the assertion that pins it.
+    """
+    path = REPO_ROOT / chart.chart_path
+    if not path.exists():
+        pytest.skip(f"chart image missing: {path}")
+
+    result = detect_ttartisan_plotbox(path)
+
+    assert result.plot_box == _coords(chart.plot_box), (
+        f"detected box {result.plot_box}, recorded {_coords(chart.plot_box)}"
+    )
+    assert result.image_height_mm == pytest.approx(chart.image_height_mm), (
+        f"detected image height {result.image_height_mm} mm "
+        f"(scheme {result.scheme}), recorded {chart.image_height_mm} mm"
+    )
+    assert (
+        _SCHEME_IMAGE_HEIGHT_MM[result.scheme]
+        == pytest.approx(result.image_height_mm)
+    ), f"scheme {result.scheme} disagrees with its own image height"
+
+
+def test_reference_set_covers_both_schemes() -> None:
+    """Both classifier branches (APS-C, GFX) appear in the reference set.
+
+    Guards against the reproduce test passing while silently exercising
+    only one branch of the two-digit-label classifier.
+    """
+    heights = {c.image_height_mm for c in _ttartisan_charts()}
+    assert 14.0 in heights, "no APS-C (14.0 mm) TTartisan reference chart"
+    assert 20.5 in heights, "no GFX (20.5 mm) TTartisan reference chart"
+
+
+def test_refuses_blank_image(tmp_path) -> None:
+    """A frameless white image has no tick labels — detection must raise."""
+    blank = tmp_path / "blank.png"
+    Image.fromarray(np.full((600, 800, 3), 255, dtype=np.uint8)).save(blank)
+    with pytest.raises(TTartisanPlotBoxError, match="x-axis label clusters"):
+        detect_ttartisan_plotbox(blank)


### PR DESCRIPTION
Closes #950.

## Context

#950 asked for auto plot-box detection (its body describes state as of #935, when the box was caller-supplied). The detection work shipped incrementally across later PRs but the issue was never updated. This PR closes the last remaining acceptance-criteria gap.

## AC scorecard (all met)

| AC | Status | Where |
|----|--------|-------|
| detect_plot_box per panel for **Sigma + Samyang** | done | `detect_sigma_plot_box` (#1036), `detect_samyang_plotbox` |
| Multi-panel charts return a tuple of boxes | done | `SamyangBoxResult.plot_box` + `.stopped_box` |
| Detection failures raise, never guess | done | `ValueError` / `SamyangPlotBoxError` / `TTartisanPlotBoxError` |
| Tests on reference charts (succeed / fail-loud / deferred per chart) | **done here** | this PR |

Detector coverage before this PR: Sigma (`test_plotbox_detect.py`) and Fujifilm (`test_fuji_plotbox.py`) were gated; **Samyang and TTartisan were exercised only by the Tier 2 scaffold scripts** — a regression could rot silently. This PR promotes both into the gated pytest tier (the "promote an ungated case to a gated tier" pattern).

## What

- **`test_samyang_plotbox.py`** — reproduces both stacked-panel boxes (max + stopped) across all 20 Samyang reference charts. The two S171 Tier 1 anchors (85mm, 300mm) are independent eye-read correctness ground truth; the rest are detector-vs-scaffolder consistency guards (documented as such — their recorded boxes were written by the detector, so they are not an independent correctness claim). An anchor-presence guard stops the suite silently degrading to pure consistency. Fail-loud on a frameless image.
- **`test_ttartisan_plotbox.py`** — reproduces box + image height (the observable output of the two-digit-label scheme classifier) across all 19 reference charts; both APS-C (14.0 mm) and GFX (20.5 mm) classifier branches are covered, with a guard asserting both stay represented. Fail-loud on a frameless image.

## Design deviation (deliberate)

#950's AC literally named a single `detect_plot_box(image)` auto-classifier. The project instead shipped **per-brand detectors dispatched by declared style family**. This is the better design and is kept: a unified auto-classifier would have to *guess* the brand from pixels, the exact "global auto-detect misclassifies silently" trap that `base/core/quality.md` ("per-config opt-in over global auto-detect") warns against. The declared-profile dispatch (ADR-038 and the per-brand ADRs) already captures the human-known classification directly. No unified dispatcher was built.

## Verification

- 43 new tests pass.
- Full `mtfdigitizer/` suite: **515 passed** (`py -m pytest mtfdigitizer/` from `tools/`).
- `tools/` is outside the front-end CI gate; verified locally per CLAUDE.md §1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)