### PR TITLE
ci: add annotated release tag guard

### DIFF
--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -3,7 +3,7 @@ name: Release tag guard
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: read

--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -1,0 +1,27 @@
+name: Release tag guard
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  annotated-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Require annotated release tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
+          type="$(git cat-file -t "${tag}")"
+          if [ "${type}" != "tag" ]; then
+            echo "::error::Release tag ${tag} is lightweight (${type})." \
+                 "Tags MUST be annotated: git tag -a ${tag} -m '${tag}'." \
+                 "See Imbra-Ltd/imbra-explore#100."
+            exit 1
+          fi
+          echo "Release tag ${tag} is annotated. OK."


### PR DESCRIPTION
Adds `.github/workflows/tag-guard.yml` — a CI check that runs on any pushed `v*` tag and **fails if the tag is lightweight** (`git tag` instead of `git tag -a`).

## Why

Lightweight tags are invisible to `git describe`, which reports a stale version to consumers. wuseria's `v0.1.0`–`v0.7.0` were all lightweight and have just been retagged annotated (tracked in `Imbra-Ltd/imbra-explore#100`). This guard prevents the regression from recurring, since releases here are cut by hand.

## What it does

- Triggers only on `push` of `v*` tags
- `contents: read` (least privilege)
- Passes when the tag is annotated; fails with a clear message otherwise

Mirrors the guard already merged into `braboj/solid-ai-templates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)