### PR TITLE
feat(mtfdigitizer): add extract --debug per-stage diagnostic bundle (#1412)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -286,23 +286,54 @@ as supplementary data on the same log. (#1037)
 
 **Write a per-stage diagnostic bundle for one chart (ADR-050):**
 
+Two entry points produce the same bundle:
+
 ```bash
+# Production-faithful path — routes through extract's own view/aperture
+# orchestration, so what you debug is byte-identical to what extract ships.
+cd tools && py -m mtfdigitizer.extract <lens-slug> --debug                  # one Tier 2 lens
+cd tools && py -m mtfdigitizer.extract <slug> --anchor-artifacts --debug    # one Tier 1 anchor
+
+# Reference-set path — also takes cohort / corpus batches.
 cd tools && py -m mtfdigitizer.diagnose <lens-slug>             # one chart
 cd tools && py -m mtfdigitizer.diagnose --brand <prefix>        # whole brand cohort (e.g. `ttartisan`)
 cd tools && py -m mtfdigitizer.diagnose --all                   # whole corpus (slow)
 ```
 
-Runs `extract_chart` with a `DiagnosticSink` that writes one named PNG
-per pipeline stage (source, plotbox, hue masks, skeletons, presence
+Both run `extract_chart` with a `DiagnosticSink` that writes one named
+PNG per pipeline stage (source, plotbox, hue masks, skeletons, presence
 masks, sampling overlay, fallback diff, symmetry diff, emit) plus a
-`manifest.json` into `docs/optical-specs/<slug>/diagnostic/`. Multi-
-aperture charts get one subdirectory per aperture (`max/`, `stopped/`).
-The bundle is gitignored — regenerate on demand when a chart looks
-wrong. Use the stage-to-symptom mapping in ADR-050 to jump from a
-maintainer's failure description ("30lpmm completely wrong", "missing
-segments", "edge too low") to the first PNG to inspect. Extraction
-values are byte-identical with or without the sink — `py -m
-mtfdigitizer.svg --check` MUST pass after every diagnose run.
+`manifest.json` into `docs/optical-specs/<slug>/diagnostic/`. Multi-pass
+charts get one subdirectory per pass. The bundle is gitignored —
+regenerate on demand. Prefer `extract --debug` for a lens you are
+digitizing: it uses the exact profile `extract` commits, including
+ADR-063 per-view aperture overrides that `diagnose` cannot see (it omits
+the view). Use `diagnose` for cohort sweeps or Tier 1 reference charts.
+Extraction values are byte-identical with or without the sink — `py -m
+mtfdigitizer.svg --check` MUST pass after any run.
+
+**Triage a wrong-looking chart — scan the stages in order, find the first divergence:**
+
+1. Regenerate the bundle for the lens: `py -m mtfdigitizer.extract <slug> --debug`.
+2. Open `diagnostic/` and scan the numbered PNGs in pipeline order (01
+   → 09). The first stage whose overlay diverges from the printed curves
+   is the culprit; every later stage inherits its error, so stop at the
+   first divergence rather than chasing the wrong output at stage 09.
+3. Jump straight to the likely stage using the failure-description map
+   (from ADR-050):
+
+   | Symptom                   | First stage to inspect | Then                                         |
+   | ------------------------- | ---------------------- | -------------------------------------------- |
+   | "missing segments"        | 03 (hue mask)          | 04 (skeleton)                                |
+   | "30lpmm completely wrong" | 03 (hue mask)          | 04 (skeleton, freq-split dispatch)           |
+   | "edge too low"            | 04 (skeleton)          | 06 (sampling at fraction 1.0)                |
+   | "corner crossing swapped" | 04 (skeleton)          | 07 (sister fallback flipped labels)          |
+   | "max wrong stopped ok"    | 03 (per-aperture mask) | 04 (skeleton with stopped curves masked out) |
+   | "overlay not refreshed"   | 09 (emit)              | provenance only — committed SVG vs bundle    |
+
+4. Fix that stage, re-run `--debug`, and confirm the divergence is gone
+   at that stage's PNG. The bundle identifies which stage broke; it does
+   not fix it (ADR-050 "What this does not do").
 
 **Refresh per-lens calibration-tier digitization logs (Tier 1 per ADR-041):**
 

--- a/tools/mtfdigitizer/README.md
+++ b/tools/mtfdigitizer/README.md
@@ -43,7 +43,10 @@ library entry point. Two CLIs sit on top:
   per ADR-041. `--accept` bypasses the gate after an overlay glance;
   `--all` runs every pending Tier 2 lens, stopping on the first HOLD;
   `--check` re-renders every committed production log and fails on
-  staleness.
+  staleness; `--debug` also writes the ADR-050 per-stage diagnostic
+  bundle for the lens (gitignored) through extract's own view/aperture
+  orchestration — the production-faithful counterpart to
+  `py -m mtfdigitizer.diagnose`.
 
 ## Layout
 

--- a/tools/mtfdigitizer/extract.py
+++ b/tools/mtfdigitizer/extract.py
@@ -50,6 +50,7 @@ from .aperture_passes import (
     _parse_filename_frequency,
     aperture_passes_for_view as _aperture_passes_for_view,
 )
+from .diagnostic import FileDiagnosticSink
 from .family_profile import profile_for_chart
 from .pipeline import PlotBox, extract_chart, score_chart
 from .pipeline.rendermatch import DEFAULT_DILATION_RADIUS_PX
@@ -182,13 +183,26 @@ def _profile_for_view(chart: ReferenceChart, image_path: Path) -> MtfProfile:
 
 
 def _run_view_passes(
-    chart: ReferenceChart, view: ChartView
+    chart: ReferenceChart,
+    view: ChartView,
+    *,
+    debug_dir: Path | None = None,
+    debug_multi: bool = False,
 ) -> list[ExtractRun]:
     """Run one chart view through one or more extract → score → priors → triage
     passes (one per aperture). Returns one ExtractRun per pass.
 
     No I/O beyond reading the chart raster — even for multi-aperture
     profiles, the raster is read once and reused across passes.
+
+    When `debug_dir` is set, each pass also drives an ADR-050
+    `FileDiagnosticSink`, writing the per-stage diagnostic bundle for the
+    exact profile/plot-box/image this pass extracts. The sink is
+    side-effect-only: `ExtractedChart` is byte-identical with or without
+    it (ADR-050 contract). `debug_multi` puts each pass in its own
+    `<stem>/` subdirectory so multi-aperture / multi-view passes do not
+    overwrite each other; a single-pass lens writes the bundle flat under
+    `debug_dir` (mirrors `diagnose`'s layout).
     """
     assert view.plot_box is not None, (
         f"chart {chart.slug!r} view {view.chart_path!r} has no plot_box — "
@@ -200,8 +214,17 @@ def _run_view_passes(
 
     runs: list[ExtractRun] = []
     for aperture, profile in passes:
+        sink: FileDiagnosticSink | None = None
+        if debug_dir is not None:
+            stem = _stem_for(chart, view, image_path, aperture)
+            out_dir = debug_dir / stem if debug_multi else debug_dir
+            sink = FileDiagnosticSink(out_dir=out_dir)
         extracted = extract_chart(
-            image_path, profile, plot_box, image_height_mm=chart.image_height_mm
+            image_path,
+            profile,
+            plot_box,
+            image_height_mm=chart.image_height_mm,
+            diagnostic_sink=sink,
         )
         score = score_chart(
             image_path,
@@ -213,26 +236,48 @@ def _run_view_passes(
         )
         violations = check_all(extracted.readings)
         verdict = triage(score, violations)
-        runs.append(
-            ExtractRun(
-                chart=chart,
-                view=view,
-                image_path=image_path,
-                plot_box=plot_box,
-                extracted=extracted,
-                verdict=verdict,
-                aperture=aperture,
-            )
+        run = ExtractRun(
+            chart=chart,
+            view=view,
+            image_path=image_path,
+            plot_box=plot_box,
+            extracted=extracted,
+            verdict=verdict,
+            aperture=aperture,
         )
+        if sink is not None:
+            _write_debug_bundle(sink, run, profile.name)
+        runs.append(run)
     return runs
 
 
-def _run_all_views(chart: ReferenceChart) -> list[ExtractRun]:
+def _run_all_views(
+    chart: ReferenceChart, *, debug: bool = False
+) -> list[ExtractRun]:
     """Run every view this lens publishes. Each view contributes one or
     more panels to the lens's single digitization-log.md — one panel per
     aperture pass per view (single-aperture charts: one panel per view).
+
+    When `debug` is set, each pass also writes its ADR-050 per-stage
+    diagnostic bundle under `<lens-dir>/diagnostic/`. Whether the bundle
+    lands flat or in a per-pass subdirectory is decided once here from
+    the lens's total pass count so every pass agrees.
     """
-    return [run for view in chart.views for run in _run_view_passes(chart, view)]
+    if not debug:
+        return [run for view in chart.views for run in _run_view_passes(chart, view)]
+    debug_dir = _lens_dir_for(chart) / "diagnostic"
+    total_passes = sum(
+        len(_aperture_passes_for_view(chart, _resolve_view_image(chart, v), v))
+        for v in chart.views
+    )
+    debug_multi = total_passes > 1
+    return [
+        run
+        for view in chart.views
+        for run in _run_view_passes(
+            chart, view, debug_dir=debug_dir, debug_multi=debug_multi
+        )
+    ]
 
 
 # --- Acceptance decision --------------------------------------------------
@@ -271,8 +316,10 @@ def _lens_dir_for(chart: ReferenceChart) -> Path:
     return (REPO_ROOT / chart.chart_path).parent
 
 
-def _artifact_stem(run: ExtractRun) -> str:
-    """Stem for one ExtractRun's inspection artifacts.
+def _stem_for(
+    chart: ReferenceChart, view: ChartView, image_path: Path, aperture: str
+) -> str:
+    """Artifact stem for one extraction pass, from its components.
 
     Single-aperture charts use the source raster's stem unchanged —
     every Sigma / 7Artisans / Tokina / Viltrox / Fujifilm lens keeps
@@ -290,13 +337,67 @@ def _artifact_stem(run: ExtractRun) -> str:
     (``"max"`` / ``"stopped"``), not an f-number — keeps the filename
     short and cohort-stable across lenses. The f-stop literal lives in
     ``src/data/mtf-readings.ts`` as the display label.
+
+    Split from `_artifact_stem` so the diagnostic-bundle path (#1412)
+    can derive a pass's subdirectory before extraction produces the
+    full `ExtractRun`.
     """
-    profile = profile_for_chart(run.chart)
+    profile = profile_for_chart(chart)
     if profile.apertures_per_chart is not None:
-        return f"{run.image_path.stem}-{run.aperture}"
-    if run.view.aperture is not None:
-        return f"{run.image_path.stem}-{run.aperture}"
-    return run.image_path.stem
+        return f"{image_path.stem}-{aperture}"
+    if view.aperture is not None:
+        return f"{image_path.stem}-{aperture}"
+    return image_path.stem
+
+
+def _artifact_stem(run: ExtractRun) -> str:
+    """Stem for one ExtractRun's inspection artifacts (see `_stem_for`)."""
+    return _stem_for(run.chart, run.view, run.image_path, run.aperture)
+
+
+def _write_debug_bundle(
+    sink: FileDiagnosticSink, run: ExtractRun, profile_name: str
+) -> None:
+    """Finish one pass's ADR-050 diagnostic bundle: the per-stage PNGs are
+    written by the sink during `extract_chart`; here we add the emit SVG
+    (stage 09) and the scalar `manifest.json`.
+
+    The manifest mirrors `diagnose.py`'s chart-centric fields and adds the
+    production gate verdict — the diagnostic bundle for a production lens
+    should record why the gate held it, not just the extracted samples.
+    """
+    sink.record_emit(render_svg(run.extracted))
+    verdict = run.verdict
+    sink.record_manifest(
+        {
+            "slug": run.chart.slug,
+            "chart_path": str(run.image_path.relative_to(REPO_ROOT))
+            if run.image_path.is_relative_to(REPO_ROOT)
+            else str(run.image_path),
+            "aperture": run.aperture,
+            "profile": profile_name,
+            "style_family": run.chart.style_family,
+            "plot_box": {
+                "x_left": run.plot_box.x_left,
+                "x_right": run.plot_box.x_right,
+                "y_top": run.plot_box.y_top,
+                "y_bottom": run.plot_box.y_bottom,
+            },
+            "image_height_mm": run.chart.image_height_mm,
+            "frequencies_lpmm": list(run.chart.frequencies_lpmm),
+            "sister_fallback_count": run.extracted.sister_fallback_count,
+            "gate_verdict": verdict.verdict,
+            "render_match_precision": verdict.render_match_precision,
+            "render_match_iou": verdict.render_match_iou,
+            "prior_violations": len(verdict.prior_violations),
+            "samples": {
+                field: [r.samples.get(field) for r in run.extracted.readings]
+                for field in sorted(
+                    {f for r in run.extracted.readings for f in r.samples}
+                )
+            },
+        }
+    )
 
 
 def _write_inspection_artifacts(run: ExtractRun) -> tuple[Path, Path, Path]:
@@ -364,12 +465,17 @@ def _log_path_for(chart: ReferenceChart) -> Path:
 # --- Top-level commands ---------------------------------------------------
 
 
-def extract_lens(slug: str, *, accept_override: bool) -> int:
+def extract_lens(slug: str, *, accept_override: bool, debug: bool = False) -> int:
     """Extract one lens. Returns 0 on success, non-zero on error.
 
     A lens with N views produces N × (SVG + overlay + review.html) plus
     one digitization-log.md with N panels. The gate aggregates verdicts
     across views — a single LOW holds the entire lens.
+
+    When `debug` is set, each pass also writes its ADR-050 per-stage
+    diagnostic bundle under `<lens-dir>/diagnostic/` (gitignored) — the
+    bundle is written regardless of the gate decision, since it is
+    precisely the failing/held lens a maintainer wants to inspect.
     """
     chart = _chart_by_slug(slug)
     if chart is None:
@@ -388,7 +494,7 @@ def extract_lens(slug: str, *, accept_override: bool) -> int:
     n_views = len(chart.views)
     suffix = "" if n_views == 1 else f" — {n_views} views"
     print(f"Extracting {slug} ({chart.style_family}){suffix}...")
-    runs = _run_all_views(chart)
+    runs = _run_all_views(chart, debug=debug)
 
     rel = lambda p: p.relative_to(REPO_ROOT)
     for run in runs:
@@ -408,6 +514,10 @@ def extract_lens(slug: str, *, accept_override: bool) -> int:
             f"prior_violations={len(run.verdict.prior_violations)})"
         )
 
+    if debug:
+        rel_diag = rel(_lens_dir_for(chart) / "diagnostic")
+        print(f"  wrote per-stage diagnostic bundle under {rel_diag}/ (ADR-050)")
+
     write, reason = _should_write_log(
         [r.verdict for r in runs], accept_override=accept_override
     )
@@ -424,7 +534,7 @@ def extract_lens(slug: str, *, accept_override: bool) -> int:
     return 0
 
 
-def extract_anchor_artifacts(slug: str) -> int:
+def extract_anchor_artifacts(slug: str, *, debug: bool = False) -> int:
     """Regenerate inspection artifacts for a Tier 1 anchor lens.
 
     Tier 1 anchors carry maintainer-eye-read ground truth in
@@ -467,7 +577,7 @@ def extract_anchor_artifacts(slug: str) -> int:
     n_views = len(chart.views)
     suffix = "" if n_views == 1 else f" - {n_views} views"
     print(f"Extracting Tier 1 anchor {slug} ({chart.style_family}){suffix}...")
-    runs = _run_all_views(chart)
+    runs = _run_all_views(chart, debug=debug)
 
     rel = lambda p: p.relative_to(REPO_ROOT)
     for run in runs:
@@ -485,6 +595,10 @@ def extract_anchor_artifacts(slug: str) -> int:
             f"(precision={p_str}, IoU={i_str}, "
             f"prior_violations={len(run.verdict.prior_violations)})"
         )
+
+    if debug:
+        rel_diag = rel(_lens_dir_for(chart) / "diagnostic")
+        print(f"  wrote per-stage diagnostic bundle under {rel_diag}/ (ADR-050)")
 
     print(
         f"  Tier 1 anchor: skipped production log write "
@@ -593,6 +707,14 @@ def main(argv: list[str] | None = None) -> int:
         "calibration log. Requires a slug; mutually exclusive with "
         "--accept (Tier 1 has no production log to accept).",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="also write the ADR-050 per-stage diagnostic bundle for "
+        "this lens under <lens-dir>/diagnostic/ (gitignored). Routes the "
+        "bundle through the same view/aperture orchestration extract "
+        "ships, so what you debug is what you commit. Requires a slug.",
+    )
     args = parser.parse_args(argv)
 
     mode_count = sum([bool(args.slug), args.all, args.check])
@@ -605,14 +727,19 @@ def main(argv: list[str] | None = None) -> int:
             "--anchor-artifacts is incompatible with --all, --check, "
             "and --accept"
         )
+    if args.debug and (args.all or args.check):
+        parser.error(
+            "--debug operates on a single lens; it is incompatible with "
+            "--all and --check"
+        )
 
     if args.check:
         return check_logs()
     if args.all:
         return extract_all(accept_override=args.accept)
     if args.anchor_artifacts:
-        return extract_anchor_artifacts(args.slug)
-    return extract_lens(args.slug, accept_override=args.accept)
+        return extract_anchor_artifacts(args.slug, debug=args.debug)
+    return extract_lens(args.slug, accept_override=args.accept, debug=args.debug)
 
 
 if __name__ == "__main__":

--- a/tools/mtfdigitizer/tests/test_extract.py
+++ b/tools/mtfdigitizer/tests/test_extract.py
@@ -14,6 +14,7 @@ Three layers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -449,6 +450,70 @@ def test_extract_check_passes_after_fresh_write(tmp_path, monkeypatch):
 
     assert extract_lens(_SIGMA_16_SLUG, accept_override=True) == 0
     assert check_logs() == 0
+
+
+# --- Diagnostic bundle via extract --debug (#1412, ADR-050) ---------------
+
+
+def _copy_sigma16_into(tmp_path) -> Path:
+    """Copy the real sigma-16mm chart into a tmp lens dir and return the
+    tmp lens directory. Shared setup for the --debug tests."""
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == _SIGMA_16_SLUG)
+    src_png = REPO_ROOT / chart.chart_path
+    dst_png = tmp_path / chart.chart_path
+    dst_png.parent.mkdir(parents=True, exist_ok=True)
+    dst_png.write_bytes(src_png.read_bytes())
+    return tmp_path / "docs" / "optical-specs" / _SIGMA_16_SLUG
+
+
+@pytest.mark.skipif(not _sigma_16_present(), reason="sigma-16mm not in reference set")
+def test_extract_debug_writes_per_stage_bundle(tmp_path, monkeypatch):
+    """`extract_lens(..., debug=True)` writes the ADR-050 per-stage bundle
+    under `<lens-dir>/diagnostic/`. Sigma-16mm is single-aperture, so the
+    bundle lands flat (no per-pass subdirectory)."""
+    lens_dir = _copy_sigma16_into(tmp_path)
+    monkeypatch.setattr(extract, "REPO_ROOT", tmp_path)
+
+    rc = extract_lens(_SIGMA_16_SLUG, accept_override=True, debug=True)
+    assert rc == 0
+
+    diag = lens_dir / "diagnostic"
+    assert diag.is_dir(), "debug run must create the diagnostic/ bundle dir"
+    # Anchor stages present regardless of which corrections fired.
+    for name in ("01-source.png", "02-plotbox.png", "06-sampling.png", "09-emit.svg"):
+        assert (diag / name).exists(), f"missing diagnostic stage {name}"
+    assert (diag / "manifest.json").exists()
+    # Per-field skeleton/presence PNGs are written for at least one field.
+    assert list(diag.glob("04-skeleton-*.png")), "no per-field skeleton stage"
+
+    manifest = json.loads((diag / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["slug"] == _SIGMA_16_SLUG
+    # The production manifest carries the gate verdict, unlike diagnose's.
+    assert "gate_verdict" in manifest
+    assert "samples" in manifest
+
+
+@pytest.mark.skipif(not _sigma_16_present(), reason="sigma-16mm not in reference set")
+def test_extract_debug_does_not_change_readings(tmp_path, monkeypatch):
+    """ADR-050 contract on the production path: the extracted readings are
+    byte-identical with and without `--debug`. The diagnostic sink is a
+    side-effect-only observer — it must never alter the values that get
+    committed to mtf-readings.ts."""
+    _copy_sigma16_into(tmp_path)
+    monkeypatch.setattr(extract, "REPO_ROOT", tmp_path)
+
+    chart = next(c for c in REFERENCE_CHARTS if c.slug == _SIGMA_16_SLUG)
+    plain = extract._run_all_views(chart, debug=False)
+    debugged = extract._run_all_views(chart, debug=True)
+
+    assert len(plain) == len(debugged)
+    for a, b in zip(plain, debugged):
+        plain_rows = [r.samples for r in a.extracted.readings]
+        debug_rows = [r.samples for r in b.extracted.readings]
+        assert plain_rows == debug_rows, (
+            "diagnostic sink changed the extracted readings — violates the "
+            "ADR-050 diagnostic-only contract"
+        )
 
 
 # --- Tier 1 anchor artifact regeneration (#1252) --------------------------


### PR DESCRIPTION
## What

Adds `--debug` to the production `extract` CLI. It writes the ADR-050 per-stage diagnostic bundle for a lens through extract's own view/aperture orchestration — reusing the existing `FileDiagnosticSink` rather than building a second implementation.

```
py -m mtfdigitizer.extract <slug> --debug                 # Tier 2 lens
py -m mtfdigitizer.extract <slug> --anchor-artifacts --debug   # Tier 1 anchor
```

## Why — scope correction on #1412

The per-stage bundle already shipped in **ADR-050** (June): `diagnostic.py` + the `diagnose` CLI + `extract_chart(diagnostic_sink=)`. The S213 spike that filed #1412 missed it, so the issue read as build-from-scratch. Intake probe caught the duplication (details in [#1412 comment](https://github.com/Imbra-Ltd/wuseria/issues/1412#issuecomment-5010403496)); scope narrowed to the genuine residual.

The residual is a correctness gap, not just discoverability: `diagnose.py` calls `aperture_passes_for_view(chart, image_path)` **without the view**, so on ADR-063 per-view aperture-override lenses (Samyang multi-panel) it debugs a different profile than `extract` ships. `extract --debug` routes through extract's real orchestration — what you debug is what you commit.

## Changes

- Thread an optional `FileDiagnosticSink` through `_run_view_passes` → `extract_chart`; write emit SVG + `manifest.json` per pass. Bundle written regardless of gate verdict (you want it precisely when a lens is held).
- Split `_artifact_stem` → component-based `_stem_for` so the bundle subdir is derived before extraction (flat `diagnostic/` single-pass; per-pass subdirs multi-aperture). No behavior change to existing artifact names.
- Manifest carries the production gate verdict, not just samples.
- PLAYBOOK: both entry points + the "scan stages in order, find first divergence" triage workflow with the stage→symptom map (satisfies AC #2).

## Verification

- Full `mtfdigitizer` suite: **517 passed**. New regression asserts readings are byte-identical with/without `--debug` (ADR-050 diagnostic-only contract) plus a bundle-shape test.
- **Live demo (AC #3)** on `sigma-16mm-f1-4-dc-dn-c` (LOW, precision 0.659): the bundle localizes the cause to **stage 04** — the dashed-M skeleton is a stair-stepped sparse trace (the documented sparse-polyline artifact), visible in `04-skeleton-freq30M.png` at a glance. Values themselves are fine; the LOW is the precision self-consistency metric, not a value error.
- Diagnostic bundles are gitignored (`.gitignore:21`); working tree carries only the 4 intended files.

Closes #1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)