### PR TITLE
chore(ci): gate production-log staleness with extract --check (#1427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       lighthouse: ${{ steps.filter.outputs.lighthouse }}
       tools: ${{ steps.filter.outputs.tools }}
+      staleness: ${{ steps.filter.outputs.staleness }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -45,6 +46,16 @@ jobs:
             # teeth when this job runs on PRs that could affect them.
             tools:
               - 'tools/**'
+              - '.github/workflows/**'
+            # `extract --check` re-renders every committed production log
+            # and fails on drift (#1427, quality-gates-staleness). Its
+            # inputs are the pipeline code, the source chart PNGs, and the
+            # committed logs — so the filter must enumerate tools/** AND
+            # docs/optical-specs/**; gating on tools/** alone would miss a
+            # source-chart edit or a hand-edited log.
+            staleness:
+              - 'tools/**'
+              - 'docs/optical-specs/**'
               - '.github/workflows/**'
 
   # Prettier checks ALL tracked files, so a format violation in any
@@ -127,14 +138,41 @@ jobs:
         working-directory: tools
         run: python -m pytest -n auto
 
+  # Real-tree production-log staleness gate. Runs the same command a
+  # maintainer runs locally, so CI mirrors it exactly. Kept separate from
+  # `pytest` (which unit-tests one tmp-dir slug) so it runs in parallel and
+  # fires on docs/optical-specs/** changes too, not only tools/**. See
+  # #1386 (the drift this prevents) and #1427.
+  staleness:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.staleness == 'true'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: tools/requirements.txt
+
+      - name: Install tools dependencies
+        run: pip install -r tools/requirements.txt
+
+      - name: Check production-log staleness
+        working-directory: tools
+        run: python -m mtfdigitizer.extract --check
+
   gate:
     runs-on: ubuntu-latest
-    needs: [format, build, lighthouse, pytest]
+    needs: [format, build, lighthouse, pytest, staleness]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.format.result }}" == "failure" || "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" || "${{ needs.pytest.result }}" == "failure" ]]; then
+          if [[ "${{ needs.format.result }}" == "failure" || "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" || "${{ needs.pytest.result }}" == "failure" || "${{ needs.staleness.result }}" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi


### PR DESCRIPTION
## What

Add a dedicated `staleness` CI job that runs the real-tree
`py -m mtfdigitizer.extract --check` (re-renders all 103 committed
digitization logs and fails on drift), wired into the `gate` aggregator
as a required check.

## Why

`extract --check` ran only manually — no CI job invoked it over the
committed tree. The one pytest guard
(`test_extract_check_passes_after_fresh_write`) checks a single
sigma-16mm slug in a `tmp_path`, not the committed logs. Per
`quality-gates-staleness` the `--check` invocation MUST be wired into CI
as a required status check.

This gate-by-omission is what let the two Samyang logs drift on `main`
after the multifreq pipeline PRs (#1382/#1385/#1293) — surfaced only by
manual S209 verification (#1386).

## Design notes

- **Separate job, not a pytest test.** Runs the exact command a
  maintainer runs locally (CI mirrors local), in parallel with `pytest`,
  and covers `docs/optical-specs/**` changes that pytest's `tools`-only
  filter skips.
- **Filter enumerates the check's real inputs.** `--check` reads the
  pipeline code AND the source chart PNGs AND the committed logs, so the
  `staleness` filter is `tools/**` + `docs/optical-specs/**` +
  `.github/workflows/**`. Gating on `tools/**` alone (as the issue's
  literal wording suggested) would reopen the enumeration gap
  `quality-gates-scope-agreement` warns about — a source-chart or
  log-only change wouldn't run the check.
- **Skipped-is-not-failure is correct here.** A PR touching neither
  `tools/**` nor `docs/optical-specs/**` cannot change the check's
  result, so a skipped `staleness` job is a legitimate skip-equivalent,
  not gate-by-omission.

## Verification

- `ci.yml` parses; `gate.needs` includes `staleness`; job `if` gates on
  the new filter
- Teeth proven: a deliberately perturbed committed log made `--check`
  report `STALE` and exit 1 → the CI step fails the job → `gate` blocks
  the PR. Reverted clean.
- Prettier-clean (the always-run `format` job checks YAML)

Closes #1427