### PR TITLE
refactor(mtfdigitizer): remove three dead imports flagged in #1430 (#1414)

### DIFF
--- a/tools/mtfdigitizer/pipeline/dispatch.py
+++ b/tools/mtfdigitizer/pipeline/dispatch.py
@@ -66,7 +66,6 @@ from .dp_extract import (
 from .masks import masks_by_curve_name, strip_plot_box_borders
 from .ridge import (
     ridge_tracks_for_hue_freq_split,
-    ridge_tracks_to_fields,
     ridge_tracks_to_fields_multifreq,
 )
 from .skeleton import close_and_skeletonize

--- a/tools/mtfdigitizer/pipeline/pipeline.py
+++ b/tools/mtfdigitizer/pipeline/pipeline.py
@@ -52,7 +52,7 @@ from .sampling import (
 from .types import ExtractedChart, PlotBox, SampledReading
 
 if TYPE_CHECKING:
-    from ..diagnostic import DiagnosticSink, FileDiagnosticSink
+    from ..diagnostic import DiagnosticSink
 
 
 SAMPLE_POINTS: tuple[float, ...] = SAMPLE_FRACTIONS  # re-export

--- a/tools/mtfdigitizer/pipeline/ridge.py
+++ b/tools/mtfdigitizer/pipeline/ridge.py
@@ -98,7 +98,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import cv2
 import numpy as np
 
 from .types import PlotBox


### PR DESCRIPTION
## What

Removes the three pre-existing dead imports flagged in #1430:
`dispatch.py::ridge_tracks_to_fields`, `ridge.py::cv2`, and
`pipeline.py::FileDiagnosticSink` (TYPE_CHECKING-only). All confirmed
unused by `pyflakes`; import smoke passes.

## Why this is all of sub-task 2

#1414 sub-task 2 proposed a "central registry for the ~135 scattered
tuned constants." A probe refuted the premise:

- The tuned constants are **already grouped by concern with provenance
  comments next to the code they tune** (e.g. dp_extract's `_ALPHA`/
  `_MAX_JUMP`/`_DILATE_KERNEL_*` block; ridge's `# --- Per-column ridge
  DP (#1100)` group). Centralizing would move them away from their use
  and orphan the rationale comments — a cohesion regression.
- The one apparent cross-module duplicate — ridge `_RIDGE_DP_ALPHA` vs
  dp_extract `_ALPHA` (both `0.30`) — is **not** shared knowledge to
  dedup: ridge's alpha is a calibrated *pair* with ridge's `_RIDGE_DP_
  GAMMA` (gamma's comment sizes itself against "the 0.30*|dy| smoothness
  cost"). Unifying it would silently couple two independent DP
  algorithms (mask-DP vs per-column-ridge-DP). The existing cross-
  reference comments are the correct representation.

So the genuine output-neutral cleanup available under this sub-task is
the dead-import removal above. The broader package-wide unused-import
backlog (`emit`, `extract`, `log`, `masks`, `sampling`) and an F821 in
`scaffold_anchor_helpers.py` are unrelated to constants and are filed
separately: #1431 (backlog) and #1432 (bug).

ADR-081 lists "constant registry" only as one enumerated fidelity-
neutral idea; its core thesis is untouched, so this is a refinement of
that idea, not a supersession.

## Verification

- `py -m pyflakes mtfdigitizer/` — the three targeted warnings are gone,
  no new warnings introduced
- `py -m mtfdigitizer.calibrate` — byte-identical to baseline (zero GT
  delta)
- Import smoke passes; full pytest runs in CI

Part of #1414.
