### PR TITLE
feat(mtfdigitizer): unify plot-box detection behind a dispatch (#1413)

### DIFF
--- a/docs/decisions/084-unified-plot-box-detection-dispatch.md
+++ b/docs/decisions/084-unified-plot-box-detection-dispatch.md
@@ -1,0 +1,98 @@
+# ADR-084: Unified plot-box detection dispatch
+
+**Status:** Accepted
+**Date:** 2026-07-18
+
+## Context
+
+The digitizer ships four per-family plot-box detectors: Sigma
+(`pipeline.plotbox.detect_sigma_plot_box`, #950), Samyang, TTartisan,
+and Fuji (the top-level `*_plotbox.py` modules). ADR-064 formalized how
+each detector is _named_ but deliberately left them per-brand, with
+divergent signatures (a BGR array for Sigma, a path for the rest),
+return types (a bare `PlotBox` vs a `<Brand>BoxResult`), and failure
+modes (`ValueError`, a `<Brand>PlotBoxError`, or a None / sentinel
+result). Every caller that wants a box must therefore know which brand
+it is holding — the per-brand scaffolders each hard-code their own
+detector.
+
+Two gaps follow from having detectors but no router:
+
+1. No single entry point tries detection and falls back to the
+   hand-measured box. #1413's fidelity-neutral setup-automation goal
+   (ADR-081 §3) wants one: a new brand whose chart shares an existing
+   vendor's style should get detection for free (ADR-081 §5), and a
+   family with no detector should still resolve its committed box
+   through the same call.
+2. The four detectors' own regression tests (added in #950) already pin
+   detected-vs-committed accuracy per family; what is missing is the
+   routing, fallback, and fail-loud behaviour as a tested surface.
+
+Of the 11 style families in the reference set, five are covered by one
+of the four detectors (Sigma; Samyang, which also covers the
+`idealized-flat` template; TTartisan; Fuji), five carry a hand-measured
+box but no detector (Tokina ×2, Viltrox, Zeiss, 7Artisans), and one —
+`soft-multicurve-promo`, the deliberate out-of-band anchor — has
+neither. A router must do the right thing for all three cases.
+
+## Decision
+
+Add `plotbox_detect.detect_plot_box(chart)`, a thin routing adapter over
+the unchanged detectors, mirroring `family_profile.PROFILE_BY_STYLE`:
+
+```
+                chart.style_family
+                        |
+             _DETECTOR_BY_STYLE.get(family)
+                  /              \
+            detector found    no detector
+                |                  |
+           run detector       fall back to
+            /        \        chart.plot_box
+        success    raises /        |
+           |       None     +------+------+
+           |        |       |             |
+      "detected"    +---> hand box?    no box
+         box              (fallback)  (raise
+                                       PlotBoxUnavailable)
+```
+
+1. `_DETECTOR_BY_STYLE` maps a style family to a detector adapter. It
+   lists only validated mappings — Sigma, Samyang (plus `idealized-flat`,
+   the Samyang 4-color template under a distinct family name, mirroring
+   `PROFILE_BY_STYLE`), TTartisan, Fuji. An unproven mapping would let a
+   wrong-but-non-raising box silently override the hand-measured one.
+2. Each adapter normalizes its detector's result into a frozen
+   `DetectedPlotBox` — the primary `PlotBox`, `source`
+   (`"detected"` / `"fallback"`), the `detector` that ran, an optional
+   `secondary_box` (Samyang's stopped panel), an optional
+   `image_height_mm` (TTartisan, Fuji), and `notes`. Fuji's
+   None / sentinel failure is normalized to a raised error inside its
+   adapter, so a single except clause covers every detector.
+3. On a detector failure or an unmapped family, fall back to
+   `chart.plot_box` and record the reason in `notes`. When there is no
+   hand-measured box either, raise `PlotBoxUnavailable` — never return a
+   guessed box (ADR-081 §4, ADR-038 §4 B1).
+
+The four detector modules and their ADR-064 surfaces are untouched. The
+dispatch is read-only over the reference set, so routing a caller
+through it changes zero committed output.
+
+## Alternatives considered
+
+| Alternative                                                           | Why rejected                                                                                                                                                                                                                               |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Force the four detectors into one common return type and signature    | Fights ADR-064, which deliberately keeps brand-specific extras (scheme, `image_height_mm`, secondary box); a rewrite risks the tested detectors for zero output gain. A normalizing adapter gets the shared surface without touching them. |
+| A single generic detector across all families                         | Rejected by ADR-081's fidelity-first stance — a generic axis / gridline heuristic guesses where a per-family detector is exact, and the reproduction is the signature feature.                                                             |
+| Leave detection per-brand in each scaffolder                          | Keeps the #1413 gap: no fallback path, no reuse-by-style for new brands, and the routing stays untested.                                                                                                                                   |
+| Map only the four native families, leave `idealized-flat` on fallback | Under-routes a chart the Samyang detector reproduces exactly; `PROFILE_BY_STYLE` already treats it as Samyang, so the detector map should agree.                                                                                           |
+
+## Consequences
+
+| Consequence                    | Detail                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Output-neutral                 | New module plus one test file; no committed box changes. The four detector suites and the calibrate zero-delta gate remain the regression oracle.                                                                         |
+| Single entry point             | `detect_plot_box(chart)` resolves a box for all 11 reference families — detect, fall back, or fail loud — the reuse layer ADR-081 §5 calls for.                                                                           |
+| Fail-loud preserved            | A silent wrong box stays impossible: a detection failure with no hand-measured box raises rather than guessing.                                                                                                           |
+| Detectors unchanged            | ADR-064 surfaces intact; this extends ADR-064's naming convention with a routing convention rather than superseding it.                                                                                                   |
+| Not yet wired into scaffolders | The per-brand scaffolders still call their detector directly; routing them through the dispatch — and reusing it for the next brand that shares a style — is a follow-up, deliberately out of this output-neutral change. |

--- a/tools/mtfdigitizer/README.md
+++ b/tools/mtfdigitizer/README.md
@@ -126,11 +126,16 @@ Other combinations raise `NotImplementedError` (fail loud, per B1).
 
 ### Known limits, deferred
 
-- **Plot box is caller-supplied.** Auto-detection across the chart-style
-  zoo (multi-panel stacks, mixed backgrounds, transparency) is genuinely
-  hard and out of scope for #935. Test fixtures hardcode the reference
-  charts' boxes; production callers will need a detector or per-chart
-  hand entry until that task lands.
+- **Plot box resolution.** `extract_chart()` still takes the plot box as
+  an argument. Resolving it is handled by per-family detectors
+  (`pipeline.plotbox.detect_sigma_plot_box` for Sigma;
+  `samyang_plotbox` / `ttartisan_plotbox` / `fuji_plotbox` for the rest,
+  ADR-064) behind one dispatch, `plotbox_detect.detect_plot_box(chart)`
+  (ADR-084): it routes on `style_family`, falls back to the chart's
+  hand-measured box when no detector covers the family, and raises
+  rather than guess when neither is available. Residual limit: the
+  Tokina, Viltrox, Zeiss, and 7Artisans families still rely on the
+  hand-measured box — the fallback path, not a detector.
 - **Plot-box convention is data-edge, not axis-line.** Corners are the
   first/last column with skeleton pixels, not the printed y-axis or
   legend lines. On many charts these coincide (Samyang); on others the

--- a/tools/mtfdigitizer/plotbox_detect.py
+++ b/tools/mtfdigitizer/plotbox_detect.py
@@ -1,0 +1,231 @@
+"""Unified plot-box detection dispatch (ADR-084; extends ADR-064).
+
+The digitizer ships one plot-box detector per chart family that warrants
+auto-detection:
+
+    style_family                     detector
+    ------------------------------   ------------------------------------
+    mainstream-2color-solid-dashed   pipeline.plotbox.detect_sigma_plot_box
+    mainstream-4color-all-solid      samyang_plotbox.detect_samyang_plotbox
+    ttartisan-4color-dual-aperture   ttartisan_plotbox.detect_ttartisan_plotbox
+    fujifilm-permfreq                fuji_plotbox.detect_fuji_plotbox
+
+ADR-064 formalized how each detector is *named*; it deliberately left
+them per-brand, with divergent signatures (a BGR array for Sigma vs a
+path for the rest), return types (a bare `PlotBox` vs a `<Brand>BoxResult`),
+and failure modes (`ValueError` vs a `<Brand>PlotBoxError` vs a
+None / sentinel result). Every caller that wanted a box therefore had to
+know which brand it was holding and adapt by hand — the per-brand
+scaffolders each hard-code their own detector.
+
+This module adds the missing routing layer: `detect_plot_box(chart)`
+keys on `chart.style_family`, calls the right detector, and normalizes
+the primary box into a `DetectedPlotBox`. When no detector covers the
+family (Tokina, Viltrox, Zeiss, 7Artisans today) or detection fails, it
+falls back to the chart's hand-measured `plot_box`. When neither a
+detector nor a hand-measured box can supply one, it raises
+`PlotBoxUnavailable` rather than guess (ADR-081 §4, ADR-038 §4 B1: a
+silent wrong box is visible in the rendered table and forfeits the
+reproduction's credibility).
+
+The dispatch is read-only over the reference set — it does not rewrite
+any committed box, so routing a caller through it changes zero output.
+The four detectors keep their ADR-064 surfaces untouched; this is a thin
+adapter on top, not a rewrite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+from .fuji_plotbox import detect_fuji_plotbox
+from .loader import load_chart_bgr
+from .pipeline import PlotBox
+from .pipeline.plotbox import detect_sigma_plot_box
+from .samyang_plotbox import SamyangPlotBoxError, detect_samyang_plotbox
+from .ttartisan_plotbox import TTartisanPlotBoxError, detect_ttartisan_plotbox
+
+if TYPE_CHECKING:
+    from .referenceset.charts import PlotBoxCoords, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class PlotBoxUnavailable(RuntimeError):
+    """No detector covers the chart's family and it carries no hand-
+    measured box, so the dispatch cannot supply a plot box without
+    guessing."""
+
+
+class _DetectorFailed(RuntimeError):
+    """Internal: normalizes a detector's non-exception failure (Fuji's
+    None / sentinel result) into a raised error, so the dispatch handles
+    every detector's failure through one code path."""
+
+
+# Detection failures worth catching and turning into a hand-measured
+# fallback. Sigma raises bare `ValueError` (#950, predates ADR-064);
+# Samyang / TTartisan raise their ADR-064 `<Brand>PlotBoxError`; Fuji
+# returns None / a sentinel box, normalized to `_DetectorFailed` in its
+# adapter below.
+_DETECTION_ERRORS = (
+    ValueError,
+    SamyangPlotBoxError,
+    TTartisanPlotBoxError,
+    _DetectorFailed,
+)
+
+
+@dataclass(frozen=True)
+class DetectedPlotBox:
+    """A plot box resolved for one chart, plus how it was obtained.
+
+    `plot_box` is always the primary plot rectangle. `source` is
+    ``"detected"`` when a family detector produced it and ``"fallback"``
+    when the detector was absent or failed and the chart's hand-measured
+    box was used instead. `detector` names the family key that ran
+    (``"sigma"``, ``"samyang"``, ...) or ``"hand-measured"`` on fallback.
+
+    `secondary_box` carries a second panel when the family packs one into
+    the same PNG (Samyang's stopped-aperture panel); it is None for
+    single-panel families. `image_height_mm` is filled by detectors that
+    calibrate it from the chart (TTartisan, Fuji) and None otherwise.
+    `notes` records the fallback reason, so a silent-looking fallback
+    stays traceable.
+    """
+
+    plot_box: PlotBox
+    source: str
+    detector: str
+    secondary_box: PlotBox | None = None
+    image_height_mm: float | None = None
+    notes: tuple[str, ...] = ()
+
+
+def _coords_to_box(coords: "PlotBoxCoords") -> PlotBox:
+    return PlotBox(
+        x_left=coords.x_left,
+        x_right=coords.x_right,
+        y_top=coords.y_top,
+        y_bottom=coords.y_bottom,
+    )
+
+
+def _tuple_to_box(coords: tuple[int, int, int, int]) -> PlotBox:
+    x_left, x_right, y_top, y_bottom = coords
+    return PlotBox(
+        x_left=x_left, x_right=x_right, y_top=y_top, y_bottom=y_bottom
+    )
+
+
+def _chart_image(chart: "ReferenceChart") -> Path:
+    return REPO_ROOT / chart.chart_path
+
+
+def _detect_sigma(chart: "ReferenceChart") -> DetectedPlotBox:
+    image = load_chart_bgr(_chart_image(chart))
+    box = detect_sigma_plot_box(image)
+    return DetectedPlotBox(plot_box=box, source="detected", detector="sigma")
+
+
+def _detect_samyang(chart: "ReferenceChart") -> DetectedPlotBox:
+    result = detect_samyang_plotbox(_chart_image(chart))
+    return DetectedPlotBox(
+        plot_box=_tuple_to_box(result.plot_box),
+        source="detected",
+        detector="samyang",
+        secondary_box=_tuple_to_box(result.stopped_box),
+    )
+
+
+def _detect_ttartisan(chart: "ReferenceChart") -> DetectedPlotBox:
+    result = detect_ttartisan_plotbox(_chart_image(chart))
+    return DetectedPlotBox(
+        plot_box=_tuple_to_box(result.plot_box),
+        source="detected",
+        detector="ttartisan",
+        image_height_mm=result.image_height_mm,
+    )
+
+
+def _detect_fuji(chart: "ReferenceChart") -> DetectedPlotBox:
+    # Fuji signals failure by returning None (unreadable image) or a
+    # (0, 0, 0, 0) sentinel box with the reason in `notes`, rather than
+    # raising. Normalize both to `_DetectorFailed` so the dispatch's
+    # single except clause handles it like every other detector.
+    result = detect_fuji_plotbox(_chart_image(chart))
+    if result is None:
+        raise _DetectorFailed("image could not be read")
+    if result.plot_box == (0, 0, 0, 0):
+        raise _DetectorFailed("; ".join(result.notes) or "detection failed")
+    return DetectedPlotBox(
+        plot_box=_tuple_to_box(result.plot_box),
+        source="detected",
+        detector="fuji",
+        image_height_mm=result.image_height_mm,
+    )
+
+
+# Single source of truth for style_family -> detector, mirroring
+# `family_profile.PROFILE_BY_STYLE`. A family absent here has no detector
+# yet; `detect_plot_box` falls back to its hand-measured box. Only
+# validated detectors are listed — an unproven mapping would let a
+# wrong-but-non-raising box silently override the hand-measured one,
+# exactly the failure ADR-081 §4 forbids.
+_DETECTOR_BY_STYLE: dict[
+    str, Callable[["ReferenceChart"], DetectedPlotBox]
+] = {
+    "mainstream-2color-solid-dashed": _detect_sigma,
+    "mainstream-4color-all-solid": _detect_samyang,
+    # `idealized-flat` is the Samyang 4-color template under a distinct
+    # family name (the flat ~1.0 reflex chart); `family_profile` already
+    # maps it to the Samyang profile, and the Samyang detector reproduces
+    # its committed box exactly. Route it to the same detector so a
+    # shared-template chart still gets detection (ADR-081 §5).
+    "idealized-flat": _detect_samyang,
+    "ttartisan-4color-dual-aperture": _detect_ttartisan,
+    "fujifilm-permfreq": _detect_fuji,
+}
+
+
+def has_detector(style_family: str) -> bool:
+    """Whether a plot-box detector covers `style_family`."""
+    return style_family in _DETECTOR_BY_STYLE
+
+
+def _fallback(chart: "ReferenceChart", reason: str) -> DetectedPlotBox:
+    if chart.plot_box is None:
+        raise PlotBoxUnavailable(
+            f"{chart.slug}: {reason}, and the chart carries no hand-"
+            f"measured plot_box — cannot supply a plot box without guessing"
+        )
+    return DetectedPlotBox(
+        plot_box=_coords_to_box(chart.plot_box),
+        source="fallback",
+        detector="hand-measured",
+        notes=(reason,),
+    )
+
+
+def detect_plot_box(chart: "ReferenceChart") -> DetectedPlotBox:
+    """Resolve the plot box for one reference chart.
+
+    Routes on `chart.style_family` to the family's detector and returns a
+    ``source="detected"`` box on success. When no detector covers the
+    family, or detection fails, falls back to the chart's hand-measured
+    `plot_box` (``source="fallback"``, with the reason in `notes`).
+    Raises `PlotBoxUnavailable` when neither is available — never returns
+    a silently guessed box (ADR-081 §4).
+    """
+    detector = _DETECTOR_BY_STYLE.get(chart.style_family)
+    if detector is None:
+        return _fallback(
+            chart, f"no detector for style_family={chart.style_family!r}"
+        )
+    try:
+        return detector(chart)
+    except _DETECTION_ERRORS as exc:
+        return _fallback(chart, f"{type(exc).__name__}: {exc}")

--- a/tools/mtfdigitizer/tests/test_plotbox_dispatch.py
+++ b/tools/mtfdigitizer/tests/test_plotbox_dispatch.py
@@ -1,0 +1,226 @@
+"""Tests for the unified plot-box dispatch (`plotbox_detect.py`, ADR-084).
+
+The four brand detectors each own their own precision regression
+(`test_plotbox_detect.py`, `test_samyang_plotbox.py`,
+`test_ttartisan_plotbox.py`, `test_fuji_plotbox.py`). This suite does not
+re-test detector accuracy; it pins the *routing* layer:
+
+- `test_detected_families_route_to_their_detector` — each family with a
+  detector routes to it and returns a ``source="detected"`` box that
+  matches the committed reference box, confirming the dispatch table maps
+  the style family to the right detector and normalizes its result.
+- `test_samyang_dispatch_carries_secondary_box` — the two-panel family
+  surfaces its stopped panel through `secondary_box`.
+- `test_no_detector_families_fall_back` — a family with no detector but a
+  hand-measured box falls back loudly (``source="fallback"``, reason in
+  `notes`), never silently drops it.
+- `test_missing_box_and_no_detector_raises` — the out-of-band
+  fail-loud shape (no detector, no box) raises rather than guessing.
+- `test_detector_failure_falls_back_*` — when a detector raises, the
+  dispatch falls back to the hand-measured box, or raises when there is
+  none. Uses a monkeypatched detector so the failure is deterministic
+  and image-independent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mtfdigitizer import plotbox_detect
+from mtfdigitizer.plotbox_detect import (
+    PlotBoxUnavailable,
+    detect_plot_box,
+    has_detector,
+)
+from mtfdigitizer.referenceset import REFERENCE_CHARTS
+from mtfdigitizer.referenceset.charts import PlotBoxCoords, ReferenceChart
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TOLERANCE_PX = 2
+
+# style_family -> the `detector` label the dispatch must report.
+# `idealized-flat` shares the Samyang 4-color template (see
+# `plotbox_detect._DETECTOR_BY_STYLE`).
+_EXPECTED_DETECTOR = {
+    "mainstream-2color-solid-dashed": "sigma",
+    "mainstream-4color-all-solid": "samyang",
+    "idealized-flat": "samyang",
+    "ttartisan-4color-dual-aperture": "ttartisan",
+    "fujifilm-permfreq": "fuji",
+}
+
+
+def _coords(pb: PlotBoxCoords) -> tuple[int, int, int, int]:
+    return (pb.x_left, pb.x_right, pb.y_top, pb.y_bottom)
+
+
+def _box(pb) -> tuple[int, int, int, int]:
+    return (pb.x_left, pb.x_right, pb.y_top, pb.y_bottom)
+
+
+def _first_chart_per_detected_family() -> list:
+    """One representative chart per family that has a detector."""
+    seen: dict[str, ReferenceChart] = {}
+    for chart in REFERENCE_CHARTS:
+        if (
+            chart.style_family in _EXPECTED_DETECTOR
+            and chart.plot_box is not None
+            and chart.style_family not in seen
+        ):
+            seen[chart.style_family] = chart
+    return list(seen.values())
+
+
+def _charts_without_detector() -> list:
+    return [
+        c
+        for c in REFERENCE_CHARTS
+        if not has_detector(c.style_family) and c.plot_box is not None
+    ]
+
+
+@pytest.mark.parametrize(
+    "chart",
+    _first_chart_per_detected_family(),
+    ids=lambda c: c.style_family,
+)
+def test_detected_families_route_to_their_detector(chart) -> None:
+    """A family with a detector routes to it and matches its committed box.
+
+    Pins the dispatch table (right style_family -> right detector) and the
+    result normalization, not detector precision — hence a 2px tolerance,
+    the same the Sigma detector's own suite allows for hand-measured
+    anchors.
+    """
+    if not (REPO_ROOT / chart.chart_path).exists():
+        pytest.skip(f"chart image missing: {chart.chart_path}")
+
+    result = detect_plot_box(chart)
+
+    assert result.source == "detected"
+    assert result.detector == _EXPECTED_DETECTOR[chart.style_family]
+
+    detected = _box(result.plot_box)
+    committed = _coords(chart.plot_box)
+    for got, want, corner in zip(detected, committed, "x_left x_right y_top y_bottom".split()):
+        assert abs(got - want) <= TOLERANCE_PX, (
+            f"{chart.slug} {corner}: dispatch box {detected} vs committed "
+            f"{committed} exceeds {TOLERANCE_PX}px"
+        )
+
+
+def test_samyang_dispatch_carries_secondary_box() -> None:
+    """The Samyang two-panel family surfaces its stopped panel."""
+    samyang = next(
+        (
+            c
+            for c in REFERENCE_CHARTS
+            if c.style_family == "mainstream-4color-all-solid"
+            and c.plot_box is not None
+        ),
+        None,
+    )
+    assert samyang is not None, "no Samyang reference chart with a plot box"
+    if not (REPO_ROOT / samyang.chart_path).exists():
+        pytest.skip(f"chart image missing: {samyang.chart_path}")
+
+    result = detect_plot_box(samyang)
+
+    assert result.secondary_box is not None, (
+        "Samyang dispatch must carry the stopped panel as secondary_box"
+    )
+    stopped_views = [
+        v for v in samyang.additional_views if v.aperture == "stopped"
+    ]
+    assert stopped_views, f"{samyang.slug} has no stopped panel view"
+    assert _box(result.secondary_box) == _coords(stopped_views[0].plot_box)
+
+
+@pytest.mark.parametrize(
+    "chart",
+    _charts_without_detector(),
+    ids=lambda c: c.slug,
+)
+def test_no_detector_families_fall_back(chart) -> None:
+    """A family with no detector falls back to its hand-measured box.
+
+    The fallback is loud: `source` marks it and `notes` records why, so a
+    box that came from the hand-measured record is never mistaken for a
+    detected one.
+    """
+    result = detect_plot_box(chart)
+
+    assert result.source == "fallback"
+    assert result.detector == "hand-measured"
+    assert _box(result.plot_box) == _coords(chart.plot_box)
+    assert result.notes, "fallback must record the reason in notes"
+    assert "no detector" in result.notes[0]
+
+
+def test_missing_box_and_no_detector_raises() -> None:
+    """The out-of-band fail-loud shape has no detector and no box."""
+    orphan = next(
+        (
+            c
+            for c in REFERENCE_CHARTS
+            if not has_detector(c.style_family) and c.plot_box is None
+        ),
+        None,
+    )
+    assert orphan is not None, (
+        "expected at least one reference chart with no detector and no box "
+        "(the deliberate fail-loud anchor)"
+    )
+    with pytest.raises(PlotBoxUnavailable, match="cannot supply a plot box"):
+        detect_plot_box(orphan)
+
+
+def _synthetic_chart(plot_box: PlotBoxCoords | None) -> ReferenceChart:
+    """A minimal chart in a detector-backed family for failure tests."""
+    return ReferenceChart(
+        slug="synthetic-dispatch-test",
+        chart_path="does/not/exist.png",
+        style_family="mainstream-2color-solid-dashed",
+        apertures=(),
+        frequencies_lpmm=(),
+        image_height_mm=0.0,
+        notes="synthetic",
+        plot_box=plot_box,
+    )
+
+
+def _raise_value_error(_chart) -> plotbox_detect.DetectedPlotBox:
+    raise ValueError("simulated detector failure")
+
+
+def test_detector_failure_falls_back_to_hand_measured(monkeypatch) -> None:
+    """When a detector raises, the dispatch uses the hand-measured box."""
+    monkeypatch.setitem(
+        plotbox_detect._DETECTOR_BY_STYLE,
+        "mainstream-2color-solid-dashed",
+        _raise_value_error,
+    )
+    chart = _synthetic_chart(PlotBoxCoords(10, 20, 30, 40))
+
+    result = detect_plot_box(chart)
+
+    assert result.source == "fallback"
+    assert result.detector == "hand-measured"
+    assert _box(result.plot_box) == (10, 20, 30, 40)
+    assert "simulated detector failure" in result.notes[0]
+
+
+def test_detector_failure_without_hand_box_raises(monkeypatch) -> None:
+    """A detector failure with no hand-measured box fails loud."""
+    monkeypatch.setitem(
+        plotbox_detect._DETECTOR_BY_STYLE,
+        "mainstream-2color-solid-dashed",
+        _raise_value_error,
+    )
+    chart = _synthetic_chart(None)
+
+    with pytest.raises(PlotBoxUnavailable, match="without guessing"):
+        detect_plot_box(chart)


### PR DESCRIPTION
Closes #1413.

## What

Adds `plotbox_detect.detect_plot_box(chart)` — a thin routing layer over the four existing per-family plot-box detectors (Sigma, Samyang, TTartisan, Fuji). It:

- keys on `chart.style_family` (mirroring `family_profile.PROFILE_BY_STYLE`);
- normalizes each detector's divergent result (bare `PlotBox` vs `<Brand>BoxResult`, `ValueError` vs `<Brand>PlotBoxError` vs None/sentinel) into a frozen `DetectedPlotBox` (primary box + `source` + `detector` + optional `secondary_box`/`image_height_mm` + `notes`);
- **falls back** to the chart's hand-measured `plot_box` when no detector covers the family, recording the reason in `notes`;
- **fails loud** (`PlotBoxUnavailable`) when neither a detector nor a hand-measured box is available — never a silent guessed box (ADR-081 §4, ADR-038 §4 B1).

`idealized-flat` maps to the Samyang detector, mirroring `PROFILE_BY_STYLE` — it is the Samyang 4-color template under a distinct family name, and the detector reproduces its committed box exactly.

## Why the scope differs from the issue text

#1413 framed detection as "today Sigma-only." It isn't — four ADR-064 detectors already exist, and **AC1 (detected == committed) and AC3 (output-neutral) were already satisfied** by the per-detector regression suites added in #950. The genuine gap was **AC2**: no unified entry point that tries detection and falls back. This PR delivers AC2 plus a routing regression test.

Coverage across the 11 reference families: 5 route to a detector, 5 fall back to a hand-measured box (Tokina ×2, Viltrox, Zeiss, 7Artisans), 1 (`soft-multicurve-promo`) fails loud.

## Tests

New `test_plotbox_dispatch.py` (19 tests) pins routing / secondary-box / fallback / fail-loud / monkeypatched-detector-failure. It does **not** re-test detector precision — the four `*_plotbox` suites own that.

Full `tools/` suite: **530 passed** (was 511; +19). Output-neutral — no committed box changed; the four detector modules and their ADR-064 surfaces are untouched.

## Decision record

ADR-084 — extends ADR-064's naming convention with a routing convention. Not yet wired into the per-brand scaffolders (deliberate follow-up, keeps this change output-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)