### PR TITLE
fix(mtf): mark mitakon-65mm frontend emit pending to unblock main deploy

### DIFF
--- a/src/data/mtf-readings.test.ts
+++ b/src/data/mtf-readings.test.ts
@@ -290,6 +290,10 @@ describe("docs/optical-specs ↔ mtf-readings coverage", () => {
     "7artisans-50mm-f1-2-mark-ii",
     "sigma-30mm-f1-4-dc-dn-c",
     "tokina-atx-m-23mm-f1-4-x",
+    // Tier-1 calibration anchor (#810). Frontend emit deferred until the
+    // GEODESIC_DP corner-crossing fix lands (#1440) so the imperfect corner
+    // is not shipped to the site.
+    "mitakon-speedmaster-65mm-f1-4-gfx",
   ]);
 
   it("every accepted-extraction directory has a mtfReadings entry", () => {


### PR DESCRIPTION
## Incident
Post-merge main deploy (#1441) failed: `npm run validate` → vitest `every accepted-extraction directory has a mtfReadings entry`. The Mitakon 65mm Tier-1 anchor got a committed `digitization-log.md` but no frontend `mtfReadings` entry (emit deferred pending the #1440 corner fix).

## Fix
Add `mitakon-speedmaster-65mm-f1-4-gfx` to `KNOWN_PENDING_EMIT` — the established escape hatch for anchors whose frontend emit is intentionally deferred (already holds Tokina 23mm, 7artisans, sigma-30mm). Verified locally: mtf-readings.test.ts 18/18 pass.

## Gate gap (follow-up)
The PR for #1441 skipped this test because the path-filter treated a `docs/optical-specs/**/digitization-log.md` change as tools-only, but the test reads that directory. Filing a follow-up to close the PR-gate-vs-deploy-gate mismatch.

Refs #810, #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)