### PR TITLE
fix(ci): mirror deploy test gate with always-run vitest job (#1443)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,28 @@ jobs:
       - run: npm ci
       - run: npm run format
 
+  # The vitest data-integrity suite reads the docs/optical-specs/**
+  # filesystem (dirsWithLog, directory-name and same-product invariants),
+  # which the `code` path-filter does NOT cover. The deploy runs these
+  # tests unconditionally inside `validate`; the path-filtered `build` job
+  # below skips them on a PR that only adds docs/optical-specs files, so
+  # such a PR can go green while breaking the main deploy (#1441 -> #1442).
+  # This always-run job mirrors the deploy's test step without an
+  # enumeration-fragile path filter, exactly as `format` does for Prettier.
+  # See ADR-086 (and ADR-076 for the format precedent).
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run test
+
   build:
     runs-on: ubuntu-latest
     needs: changes
@@ -167,12 +189,12 @@ jobs:
 
   gate:
     runs-on: ubuntu-latest
-    needs: [format, build, lighthouse, pytest, staleness]
+    needs: [format, test, build, lighthouse, pytest, staleness]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.format.result }}" == "failure" || "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" || "${{ needs.pytest.result }}" == "failure" || "${{ needs.staleness.result }}" == "failure" ]]; then
+          if [[ "${{ needs.format.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.build.result }}" == "failure" || "${{ needs.lighthouse.result }}" == "failure" || "${{ needs.pytest.result }}" == "failure" || "${{ needs.staleness.result }}" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi

--- a/docs/decisions/086-pr-gate-mirrors-deploy-test.md
+++ b/docs/decisions/086-pr-gate-mirrors-deploy-test.md
@@ -1,0 +1,142 @@
+# ADR-086: PR CI mirrors the deploy test gate via an always-run job
+
+**Status:** Accepted
+**Date:** 2026-07-19
+
+## Context
+
+`deploy.yml` runs `npm run validate` unconditionally on every push to
+`main`. `validate` chains `lint -> format -> check -> test -> build ->
+check:links`, and the `test` step is `vitest run --coverage`. The vitest
+data-integrity suite in `src/data/mtf-readings.test.ts` reads the
+`docs/optical-specs/**` filesystem directly: it walks the directory for
+`dirsWithLog` (dirs containing a `digitization-log.md`), enforces the
+directory-name invariant against `toDataSlug`, and hashes primary MTF
+charts for the same-product invariant.
+
+The PR workflow `ci.yml` runs the same `validate` inside its `build`
+job, but `build` is gated on the `code` paths-filter:
+
+```
+code: src/** public/** astro.config.mjs tsconfig.json
+      package.json package-lock.json lighthouserc.json .github/workflows/**
+```
+
+That filter omits `docs/optical-specs/**`. A PR that only adds files
+under `tools/**` plus a `docs/optical-specs/<slug>/digitization-log.md`
+therefore skips `build` entirely, so the vitest suite never runs on the
+PR. The `gate` aggregator only fails on a sub-job `failure`, and a
+skipped `build` reports `skipped`, not `failure` — so the PR goes green.
+The deploy is then the FIRST place the data-integrity check runs
+post-merge, on `main`, blocking the site deploy.
+
+This happened for real. PR #1441 added the Mitakon GFX profile
+(`tools/**`) plus a `digitization-log.md` for the 65mm f/1.4 Tier-1
+anchor, whose readings were intentionally not yet emitted to
+`mtfReadings`. The `every accepted-extraction directory has a
+mtfReadings entry` test flagged it only on the `main` deploy, which
+failed; #1442 hotfixed it by adding the slug to `KNOWN_PENDING_EMIT`.
+The upstream quality-gates template names this exact failure: "PR gate
+MUST mirror the deploy gate" and "Skipped is not passed"
+(`quality-gates-scope-agreement`).
+
+ADR-076 established the same-shaped fix for the `format` step, but its
+Neutral section asserted that "the other steps only read paths the
+`code`/`tools` filters already cover." That was incomplete: the `test`
+step reads `docs/optical-specs/**`, which neither filter covers. #1443
+is the second cross-cutting exposure ADR-076's Open section anticipated
+("If a future `validate` step gains a cross-cutting input beyond
+Prettier ... re-evaluate the mirror rule when that lands"). ADR-076's
+decision — the `format` always-run job — remains valid and in force;
+only that side-observation was wrong, and this ADR records the
+correction.
+
+## Decision
+
+Add a dedicated `test` job to `ci.yml` that runs `npm run test` on every
+PR with no path filter, and wire it into the `gate` aggregator. `build`,
+`lighthouse`, `pytest`, and `staleness` keep their (correct) path
+filters.
+
+```
+                 +-----------+
+                 |  changes  |  (paths-filter: code/lighthouse/tools/staleness)
+                 +-----------+
+                   |   |   |  \
+   always-run      |   |   |   +--> pytest    (if tools)
+  +---------+      |   |   +------> staleness (if tools|optical-specs)
+  | format  |      |   +----------> build     (if code) --> lighthouse (if lighthouse)
+  | prettier|      |
+  +----+----+      |
+  +---------+      |
+  |  test   |      |
+  | vitest  |      |
+  +----+----+      |
+       |           |
+       v           v
+     +--------------------------------------+
+     |  gate  needs:[format,test,build,      |
+     |        lighthouse,pytest,staleness]   |
+     |  fail if ANY == 'failure'             |
+     +--------------------------------------+
+```
+
+The `test` job does not check out the submodule — the vitest suite reads
+`src/**` and `docs/optical-specs/**`, both in the main repo, never
+`docs/solid-ai-templates/`. It reuses the npm cache. `build` still runs
+`validate` (which re-runs `test`) on code-touching PRs; the redundant
+vitest pass there is negligible and keeps the `test` job's trigger
+enumeration-free — the same tradeoff ADR-076 accepted for `format`.
+
+Branch protection already requires `gate`; because `gate` now depends on
+`test` and fails when `test` fails, no branch-protection setting change
+is needed.
+
+## Alternatives considered
+
+| Alternative                                                                    | Rejected because                                                                                                                                                          |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add `docs/optical-specs/**` (or `**/digitization-log.md`) to the `code` filter | A filter must enumerate every path the vitest suite reads; the next test that reads a new tracked directory reopens the exact gap that broke `main`. Enumeration-fragile. |
+| Make `build` run unconditionally on all PRs                                    | A docs- or tools-only PR would then run the full 462-page build, coverage suite, and link check needlessly. The test step is the exposure — mirror only it, per ADR-076.  |
+| Rely on the existing `staleness` job (`extract --check`)                       | Different check: `extract --check` re-renders committed logs and fails on drift; it does not enforce the `mtfReadings`-entry / directory-name / same-product invariants.  |
+| Status quo (deploy catches it)                                                 | A gate that runs only post-merge is a failure notification, not a gate — by the time it fires, `main` is already broken.                                                  |
+
+## Consequences
+
+### Positive
+
+- A `docs/optical-specs/**` change that violates a data invariant fails
+  the PR, before merge — the deploy is no longer the first line of
+  defense for the vitest suite.
+- Enumeration-free: no path list to keep in sync as new tests read new
+  tracked directories. The safety net covers paths nobody thought to add
+  to a filter.
+- After this ADR, every `validate` step is mirrored on PRs: `format` and
+  `test` run always; `lint`, `check`, `build`, and `check:links` read
+  only paths the `code` filter already covers.
+
+### Negative
+
+- Every PR pays an extra `npm ci` + `vitest run --coverage`, including
+  PRs a filter would have skipped. Deterministic and bounded; acceptable
+  against a recurring `main`-red foot-gun.
+- vitest runs twice on code-touching PRs (once in `test`, once inside
+  `build`'s `validate`). Negligible cost, kept for simplicity — the same
+  tradeoff ADR-076 accepted for `format`.
+
+### Neutral
+
+- `build`, `lighthouse`, `pytest`, and `staleness` retain their path
+  filters; this ADR narrows the mirror rule to the second cross-cutting
+  step (test), not a change to the others.
+- Corrects, but does not supersede, ADR-076: that ADR's `format` job is
+  unchanged and remains Accepted. Only its Neutral-section claim that the
+  remaining `validate` steps read covered paths was incomplete, which
+  #1443 exposed.
+
+### Open
+
+- All `validate` steps are now accounted for. If a future step gains a
+  cross-cutting input beyond `src/**` and the covered manifest/config
+  paths, it needs the same always-run treatment — re-evaluate the mirror
+  rule when that lands.


### PR DESCRIPTION
Closes #1443

## Problem

`deploy.yml` runs `npm run validate` unconditionally on every push to `main`. Its `test` step (`vitest run --coverage`) reads `docs/optical-specs/**` for the data-integrity invariants in `src/data/mtf-readings.test.ts` (`dirsWithLog`, directory-name, same-product).

The PR `build` job runs the same `validate` but is gated on the `code` path-filter, which **omits `docs/optical-specs/**`**. PR #1441 added only `tools/**` + a `digitization-log.md`, so `build` was skipped, the vitest suite never ran on the PR, it merged green, and the `main` deploy then failed on that exact test — a failure notification instead of a gate (incident hotfixed by #1442).

## Fix

Add a dedicated always-run `test` job (no path filter) that runs `npm run test`, and wire it into the `gate` aggregator. This mirrors the deploy's test step exactly as the `format` job (ADR-076) mirrors Prettier — enumeration-free, so no path list to keep in sync as tests read new tracked dirs.

`build`, `lighthouse`, `pytest`, and `staleness` keep their (correct) path filters. Follows `quality-gates.md` "PR gate MUST mirror the deploy gate" and "Mirror cross-cutting checks with an always-run job".

## Verification

Ran the always-run job's command locally:

- Baseline `npx vitest run src/data/mtf-readings.test.ts` → **18 passed**.
- Repro of the #1441 shape (a stray `docs/optical-specs/<slug>/` with a `digitization-log.md` but no `mtfReadings` entry) → **2 failed** (`every accepted-extraction directory has a mtfReadings entry`, `every optical-specs directory matches a lens via toDataSlug`). Repro dir removed.

So the job now runs on the PRs that previously skipped it, and catches the exact scenario that broke `main`.

## Notes

- ADR-086 documents the decision. It also records that ADR-076's Neutral-section claim ("other validate steps read only covered paths") was incomplete — the `test` step reads `docs/optical-specs/**`. This is a correction, **not** a supersession: ADR-076's `format` job is unchanged and stays Accepted.
- vitest runs twice on code-touching PRs (once in `test`, once inside `build`'s `validate`) — negligible, same tradeoff ADR-076 accepted for `format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)