### PR TITLE
docs(pagefetch): point the copy at its standalone upstream (#1447)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 coverage/
 __pycache__/
 .pytest_cache/
+.mypy_cache/
 .cache/
 reports/
 .lighthouseci/

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,9 @@ docs/optical-specs/**/eye-read.md
 # Python tooling — own pytest suites, not part of the front-end gate
 tools/
 
-# Python caches — generated, never committed
+# Python caches — generated, never committed. mypy writes a self-ignoring
+# .gitignore inside its cache, so git skips the directory while Prettier,
+# which does not read nested ignore files, walks every entry in it.
 **/.pytest_cache/
 **/__pycache__/
+**/.mypy_cache/

--- a/tools/pagefetch/README.md
+++ b/tools/pagefetch/README.md
@@ -9,6 +9,12 @@ sites — and caches responses on disk.
 extracted into a standalone repository or git submodule and reused
 anywhere.
 
+> **This directory is a copy.** The package is published standalone at
+> [braboj/page-fetcher](https://github.com/braboj/page-fetcher), which
+> carries the same history. Whether wuseria switches to consuming it as a
+> submodule is open — see #1456. Until that is decided, a fix made here
+> MUST be carried upstream (and vice versa), or the two copies diverge.
+
 ## Quick start
 
 ```python


### PR DESCRIPTION
Follow-up to the pagefetch extraction (#1447). No behaviour change.

## What

`pagefetch` is now published at
[braboj/page-fetcher](https://github.com/braboj/page-fetcher), split out
with its history preserved across `tools/pagefetch/`,
`tools/fetch-page.py` and `tools/FETCH-PAGE.md`. wuseria deliberately
keeps its own copy for now — #1456 tracks whether that becomes a
submodule.

That leaves two copies of the same package, so this adds a note at the
top of `tools/pagefetch/README.md` saying so, and that a fix made in
either copy has to be carried to the other. Without it the first
divergence is silent, and there is already one waiting:
braboj/page-fetcher#1 (the urllib tier does not decode gzip and caches
the garbage) exists in both.

## Also: ignore `.mypy_cache/`

`npm run validate` failed locally with 451 Prettier errors, every one of
them inside `.mypy_cache/`. mypy writes a `.gitignore` containing `*`
into its own cache directory, so git skips it and `git status` looks
clean — but Prettier does not read nested ignore files and walks the
whole tree. CI never sees this because it runs on a clean checkout.

`.prettierignore` already had a "Python caches" section listing
`.pytest_cache` and `__pycache__`; `.mypy_cache` was simply missing from
it. Added there and to `.gitignore`.

This is the "green CI does not prove environment independence" case in
`base/workflow/quality-gates.md` — the gate depends on developer-machine
state that CI cannot reproduce.

## Verification

- `npm run validate` — full gate passes (lint, format, check, 462 pages
  built, trailing-slash check clean)
- Confirmed the only Prettier failures were under `.mypy_cache/`: zero
  non-cache warnings before the fix
- Confirmed lint-staged did not reformat the README — `tools/` stays
  ignored, and the committed diff is the six intended lines

Closes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)